### PR TITLE
Enable initializing data from pltfile

### DIFF
--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -419,6 +419,7 @@ class PeleLM : public amrex::AmrCore {
    void WriteHeader(const std::string &name, bool is_checkpoint) const;
    void WriteDebugPlotFile(const amrex::Vector<const amrex::MultiFab*> &a_MF,
                            const std::string &pltname);
+   void initLevelDataFromPlt(int a_lev, const std::string &a_pltFile);
    //-----------------------------------------------------------------------------
 
    //-----------------------------------------------------------------------------
@@ -890,7 +891,8 @@ class PeleLM : public amrex::AmrCore {
    int m_verbose = 0;
 
    // IO options
-   std::string m_restart_file{""};
+   std::string m_restart_chkfile{""};
+   std::string m_restart_pltfile{""};
    std::string m_plot_file{"plt"};
    std::string m_check_file{"chk"};
    int m_derivePlotVarCount = 0;

--- a/Source/PeleLMInit.cpp
+++ b/Source/PeleLMInit.cpp
@@ -69,8 +69,12 @@ void PeleLM::MakeNewLevelFromScratch( int lev,
 #endif
 
    // Fill the initial solution (if not restarting)
-   if (m_restart_file.empty()) {
-      initLevelData(lev);
+   if (m_restart_chkfile.empty()) {
+      if (m_restart_pltfile.empty()) {
+          initLevelData(lev);
+      } else {
+          initLevelDataFromPlt(lev, m_restart_pltfile);
+      }
    }
 
    // Times
@@ -92,7 +96,7 @@ void PeleLM::MakeNewLevelFromScratch( int lev,
 void PeleLM::initData() {
    BL_PROFILE_VAR("PeleLM::initData()", initData);
 
-   if (m_restart_file.empty()) {
+   if (m_restart_chkfile.empty()) {
 
       //----------------------------------------------------------------
       // This is an AmrCore member function which recursively makes new levels

--- a/Source/PeleLMPlot.cpp
+++ b/Source/PeleLMPlot.cpp
@@ -3,6 +3,8 @@
 #include <AMReX_buildInfo.H>
 #include "PelePhysics.H"
 #include <AMReX_ParmParse.H>
+#include <AMReX_DataServices.H>
+#include <AMReX_AmrData.H>
 
 using namespace amrex;
 
@@ -348,7 +350,7 @@ void PeleLM::ReadCheckPointFile()
 {
    BL_PROFILE("PeleLM::ReadCheckPointFile()");
 
-   amrex::Print() << "Restarting from checkpoint " << m_restart_file << "\n";
+   amrex::Print() << "Restarting from checkpoint " << m_restart_chkfile << "\n";
 
    Real prob_lo[AMREX_SPACEDIM];
    Real prob_hi[AMREX_SPACEDIM];
@@ -359,7 +361,7 @@ void PeleLM::ReadCheckPointFile()
    **              (by calling MakeNewLevelFromScratch)                       *
    ****************************************************************************/
 
-   std::string File(m_restart_file + "/Header");
+   std::string File(m_restart_chkfile + "/Header");
 
    VisMF::IO_Buffer io_buffer(VisMF::GetIOBufferSize());
 
@@ -456,52 +458,52 @@ void PeleLM::ReadCheckPointFile()
    for(int lev = 0; lev <= finest_level; ++lev)
    {
       VisMF::Read(m_leveldata_new[lev]->velocity,
-                  amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "velocity"));
+                  amrex::MultiFabFileFullPrefix(lev, m_restart_chkfile, level_prefix, "velocity"));
 
       VisMF::Read(m_leveldata_new[lev]->gp,
-                  amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "gradp"));
+                  amrex::MultiFabFileFullPrefix(lev, m_restart_chkfile, level_prefix, "gradp"));
 
       VisMF::Read(m_leveldata_new[lev]->press,
-                  amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "p"));
+                  amrex::MultiFabFileFullPrefix(lev, m_restart_chkfile, level_prefix, "p"));
 
       if (!m_incompressible) {
          VisMF::Read(m_leveldata_new[lev]->density,
-                     amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "density"));
+                     amrex::MultiFabFileFullPrefix(lev, m_restart_chkfile, level_prefix, "density"));
 
          VisMF::Read(m_leveldata_new[lev]->species,
-                     amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "species"));
+                     amrex::MultiFabFileFullPrefix(lev, m_restart_chkfile, level_prefix, "species"));
 
          VisMF::Read(m_leveldata_new[lev]->rhoh,
-                     amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "rhoH"));
+                     amrex::MultiFabFileFullPrefix(lev, m_restart_chkfile, level_prefix, "rhoH"));
 
          VisMF::Read(m_leveldata_new[lev]->temp,
-                     amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "temp"));
+                     amrex::MultiFabFileFullPrefix(lev, m_restart_chkfile, level_prefix, "temp"));
 
          VisMF::Read(m_leveldata_new[lev]->rhoRT,
-                     amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "rhoRT"));
+                     amrex::MultiFabFileFullPrefix(lev, m_restart_chkfile, level_prefix, "rhoRT"));
 
          if (m_has_divu) {
             VisMF::Read(m_leveldata_new[lev]->divu,
-                        amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "divU"));
+                        amrex::MultiFabFileFullPrefix(lev, m_restart_chkfile, level_prefix, "divU"));
          }
 
 #ifdef PELE_USE_EFIELD
          if (!m_restart_nonEF) {
             VisMF::Read(m_leveldata_new[lev]->phiV,
-                        amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "phiV"));
+                        amrex::MultiFabFileFullPrefix(lev, m_restart_chkfile, level_prefix, "phiV"));
 
             VisMF::Read(m_leveldata_new[lev]->nE,
-                        amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "nE"));
+                        amrex::MultiFabFileFullPrefix(lev, m_restart_chkfile, level_prefix, "nE"));
 
             if (m_do_react) {
                VisMF::Read(m_leveldatareact[lev]->I_R,
-                           amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "I_R"));
+                           amrex::MultiFabFileFullPrefix(lev, m_restart_chkfile, level_prefix, "I_R"));
             }
          } else {
             // I_R for non-EF simulation is one component shorted, need to account for that.
             if (m_do_react) {
                MultiFab I_Rtemp(grids[lev],dmap[lev],NUM_SPECIES,0);
-               VisMF::Read(I_Rtemp,amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "I_R"));
+               VisMF::Read(I_Rtemp,amrex::MultiFabFileFullPrefix(lev, m_restart_chkfile, level_prefix, "I_R"));
                MultiFab::Copy(m_leveldatareact[lev]->I_R,I_Rtemp,0,0,NUM_SPECIES,0);
             }
 
@@ -511,13 +513,139 @@ void PeleLM::ReadCheckPointFile()
 #else
          if (m_do_react) {
             VisMF::Read(m_leveldatareact[lev]->I_R,
-                        amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "I_R"));
+                        amrex::MultiFabFileFullPrefix(lev, m_restart_chkfile, level_prefix, "I_R"));
          }
 #endif
       }
    }
    if (m_verbose) {
       amrex::Print() << "Restart complete" << std::endl;
+   }
+}
+
+void PeleLM::initLevelDataFromPlt(int a_lev,
+                                  const std::string &a_dataPltFile)
+{
+   if (m_incompressible) {
+      Abort(" initializing data from a pltfile only available for low-Mach simulations");
+   }
+
+   amrex::Print() << " initData on level " << a_lev << " from pltfile " << a_dataPltFile << "\n";
+
+   // Use DataService to load pltfile and fill level data
+   DataServices::SetBatchMode();
+   Amrvis::FileType fileType(Amrvis::NEWPLT);
+   DataServices dataServices(a_dataPltFile, fileType);
+   if (!dataServices.AmrDataOk()) {
+      DataServices::Dispatch(DataServices::ExitRequest, NULL);
+   }    
+   AmrData& amrData = dataServices.AmrDataRef();
+
+   Vector<std::string> spec_names;
+   pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(spec_names);
+   Vector<std::string> plotnames = amrData.PlotVarNames();
+
+   // Find required data in pltfile
+   int idT = -1, idV = -1, idY = -1, nSpecPlt = 0;
+   for (int i = 0; i < plotnames.size(); ++i) {
+      std::string firstChars = plotnames[i].substr(0, 2);
+      if (plotnames[i] == "temp")            idT = i; 
+      if (plotnames[i] == "x_velocity")      idV = i; 
+      if (firstChars == "Y(" && idY < 0 ) {  // species might not be ordered in the order of the current mech.
+         idY = i;
+      }
+      if (firstChars == "Y(")                nSpecPlt += 1;
+   }
+
+   if ( idY < 0 ) {
+      Abort("Coudn't find species mass fractions in pltfile");
+   }
+   Print() << " " << nSpecPlt << " species found in pltfile, starting with " << plotnames[idY] << "\n";
+
+   // Get level data
+   auto ldata_p = getLevelDataPtr(a_lev,AmrNewTime);
+
+   // Velocity
+   for (int i = 0; i < AMREX_SPACEDIM; i++) {
+      amrData.FillVar(ldata_p->velocity, a_lev, plotnames[idV+i], i);
+      amrData.FlushGrids(idV+i);
+   }
+
+   // Temperature
+   amrData.FillVar(ldata_p->temp, a_lev, plotnames[idT], 0);
+   amrData.FlushGrids(idT);
+
+   // Species
+   // Hold the species in temporary MF before copying to level data
+   MultiFab speciesPlt(grids[a_lev], dmap[a_lev], nSpecPlt, 0);
+   for (int i = 0; i < nSpecPlt; i++) {
+      amrData.FillVar(speciesPlt, a_lev, plotnames[idY+i], i);
+      amrData.FlushGrids(idY+i);
+   }
+   for (int i = 0; i < NUM_SPECIES; i++) {
+      std::string specString = "Y("+spec_names[i]+")";
+      int foundSpec = 0;
+      for (int iplt = 0; iplt < nSpecPlt; iplt++) {
+         if ( specString == plotnames[idY+iplt] ) {
+            MultiFab::Copy(ldata_p->species, speciesPlt, iplt, i, 1, 0);
+            foundSpec = 1;
+         }
+      }
+      if (!foundSpec) ldata_p->species.setVal(0.0,i,1);
+   }
+
+   // Pressure and pressure gradients to zero
+   ldata_p->press.setVal(0.0);
+   ldata_p->gp.setVal(0.0);
+
+   ProbParm const* lprobparm = prob_parm_d;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+   for (MFIter mfi(ldata_p->velocity,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+   {
+      const Box& bx = mfi.tilebox();
+      auto  const &rho_arr   = ldata_p->density.array(mfi);
+      auto  const &rhoY_arr  = ldata_p->species.array(mfi);
+      auto  const &rhoH_arr  = ldata_p->rhoh.array(mfi);
+      auto  const &temp_arr  = ldata_p->temp.array(mfi);
+      amrex::ParallelFor(bx, [=]
+      AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      {
+          auto eos = pele::physics::PhysicsType::eos();
+          Real massfrac[NUM_SPECIES] = {0.0};
+          Real sumYs = 0.0;
+          for (int n = 0; n < NUM_SPECIES; n++){
+             massfrac[n] = rhoY_arr(i,j,k,n);
+             if (n != N2_ID) {
+                sumYs += massfrac[n];
+             }
+          }
+          massfrac[N2_ID] = 1.0 - sumYs; 
+
+          // Get density
+          Real P_cgs = lprobparm->P_mean * 10.0;
+          Real rho_cgs = 0.0;
+          eos.PYT2R(P_cgs, massfrac, temp_arr(i,j,k), rho_cgs);
+          rho_arr(i,j,k) = rho_cgs * 1.0e3;
+
+          // Get enthalpy
+          Real h_cgs = 0.0;
+          eos.TY2H(temp_arr(i,j,k), massfrac, h_cgs);
+          rhoH_arr(i,j,k) = h_cgs * 1.0e-4 * rho_arr(i,j,k);
+            
+          // Fill rhoYs
+          for (int n = 0; n < NUM_SPECIES; n++){
+             rhoY_arr(i,j,k,n) = massfrac[n] * rho_arr(i,j,k);
+          }
+      });
+   }
+
+   // Initialize thermodynamic pressure
+   setThermoPress(a_lev, AmrNewTime);
+   if (m_has_divu) {
+      ldata_p->divu.setVal(0.0);
    }
 }
 

--- a/Source/PeleLMSetup.cpp
+++ b/Source/PeleLMSetup.cpp
@@ -361,7 +361,8 @@ void PeleLM::readIOParameters() {
 
    pp.query("check_file", m_check_file);
    pp.query("check_int" , m_check_int);
-   pp.query("restart" , m_restart_file);
+   pp.query("restart" , m_restart_chkfile);
+   pp.query("initDataPlt" , m_restart_pltfile);
    pp.query("plot_file", m_plot_file);
    pp.query("plot_int" , m_plot_int);
    m_derivePlotVarCount = (pp.countval("derive_plot_vars"));

--- a/Utils/Make.PeleLMeX
+++ b/Utils/Make.PeleLMeX
@@ -89,7 +89,7 @@ Blocs += $(foreach dir, $(Hdirs), $(AMREX_HYDRO_HOME)/$(dir))
 #---------------
 # AMReX sources
 #---------------
-Pdirs := Base Boundary AmrCore LinearSolvers/MLMG
+Pdirs := Base Boundary AmrCore LinearSolvers/MLMG Extern/amrdata
 ifeq ($(USE_EB), TRUE)
     Pdirs += EB
 endif


### PR DESCRIPTION
Simply specify `amr.initDataPlt` when starting a new case.
Default behavior is to read velocities, temperature and matching species (mechanism can be different), ensure sum of Y = 1 by adjusting N2 and recompute rho and rhoH from there.
The provided pltfile need to contain species mass fractions as `Y(<spec_name>)`, and since both LM and LMeX pltfile format are similar, one could use a PeleLM pltfile to initialize a LMeX simulation.