### PR TITLE
Multi-component diffusion

### DIFF
--- a/Source/DiffusionOp.H
+++ b/Source/DiffusionOp.H
@@ -20,7 +20,7 @@ class DiffusionOp
 
    // Methods
 
-   DiffusionOp (PeleLM* a_pelelm);
+   DiffusionOp (PeleLM* a_pelelm, int ncomp = 1);
 
    void diffuse_scalar (amrex::Vector<amrex::MultiFab*> const& a_phi,
                         int phi_comp,
@@ -92,6 +92,7 @@ class DiffusionOp
 #endif
 
    int m_verbose = 0;
+   int m_ncomp = 1;
 
    // Options to control MLMG behavior
    int m_mg_verbose = 0;

--- a/Source/DiffusionOp.cpp
+++ b/Source/DiffusionOp.cpp
@@ -13,8 +13,8 @@ using namespace amrex;
 //---------------------------------------------------------------------------------------
 // Diffusion Operator
 
-DiffusionOp::DiffusionOp (PeleLM* a_pelelm)
-                        : m_pelelm(a_pelelm)
+DiffusionOp::DiffusionOp (PeleLM* a_pelelm, int ncomp)
+                        : m_pelelm(a_pelelm), m_ncomp(ncomp)
 {
    readParameters();
 
@@ -42,12 +42,12 @@ DiffusionOp::DiffusionOp (PeleLM* a_pelelm)
    m_scal_apply_op.reset(new MLEBABecLap(m_pelelm->Geom(0,m_pelelm->finestLevel()),
                                          m_pelelm->boxArray(0,m_pelelm->finestLevel()),
                                          m_pelelm->DistributionMap(0,m_pelelm->finestLevel()),
-                                         info_apply, ebfactVec));
+                                         info_apply, ebfactVec, m_ncomp));
 #else
    m_scal_apply_op.reset(new MLABecLaplacian(m_pelelm->Geom(0,m_pelelm->finestLevel()),
                                              m_pelelm->boxArray(0,m_pelelm->finestLevel()),
                                              m_pelelm->DistributionMap(0,m_pelelm->finestLevel()),
-                                             info_apply));
+                                             info_apply, {}, m_ncomp));
 #endif
    m_scal_apply_op->setMaxOrder(m_mg_maxorder);
 
@@ -56,12 +56,12 @@ DiffusionOp::DiffusionOp (PeleLM* a_pelelm)
    m_scal_solve_op.reset(new MLEBABecLap(m_pelelm->Geom(0,m_pelelm->finestLevel()),
                                          m_pelelm->boxArray(0,m_pelelm->finestLevel()),
                                          m_pelelm->DistributionMap(0,m_pelelm->finestLevel()),
-                                         info_solve, ebfactVec));
+                                         info_solve, ebfactVec, m_ncomp));
 #else
    m_scal_solve_op.reset(new MLABecLaplacian(m_pelelm->Geom(0,m_pelelm->finestLevel()),
                                              m_pelelm->boxArray(0,m_pelelm->finestLevel()),
                                              m_pelelm->DistributionMap(0,m_pelelm->finestLevel()),
-                                             info_solve));
+                                             info_solve, {}, m_ncomp));
 #endif
    m_scal_solve_op->setMaxOrder(m_mg_maxorder);
 
@@ -70,12 +70,12 @@ DiffusionOp::DiffusionOp (PeleLM* a_pelelm)
    m_gradient_op.reset(new MLEBABecLap(m_pelelm->Geom(0,m_pelelm->finestLevel()),
                                        m_pelelm->boxArray(0,m_pelelm->finestLevel()),
                                        m_pelelm->DistributionMap(0,m_pelelm->finestLevel()),
-                                       info_apply, ebfactVec));
+                                       info_apply, ebfactVec, m_ncomp));
 #else
    m_gradient_op.reset(new MLABecLaplacian(m_pelelm->Geom(0,m_pelelm->finestLevel()),
                                            m_pelelm->boxArray(0,m_pelelm->finestLevel()),
                                            m_pelelm->DistributionMap(0,m_pelelm->finestLevel()),
-                                           info_apply));
+                                           info_apply, {}, m_ncomp));
 #endif
    m_gradient_op->setMaxOrder(m_mg_maxorder);
    m_gradient_op->setScalars(0.0,1.0);

--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -1024,7 +1024,7 @@ class PeleLM : public amrex::AmrCore {
    int m_refine_cutcells = 1;
    amrex::Vector<amrex::Real> coveredState_h;
    amrex::Gpu::DeviceVector<amrex::Real> coveredState_d;
-   std::string m_adv_redist_type = "NewStateRedist";
+   std::string m_adv_redist_type = "StateRedist";
    std::string m_diff_redist_type = "FluxRedist";
 #endif
    //-----------------------------------------------------------------------------

--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -818,6 +818,7 @@ class PeleLM : public amrex::AmrCore {
    amrex::Vector<int>          fetchAdvTypeArray(int scomp, int ncomp);
    amrex::Vector<int>          fetchDiffTypeArray(int scomp, int ncomp);
    DiffusionOp* getDiffusionOp ();
+   DiffusionOp* getMCDiffusionOp (int ncomp = 1);
    DiffusionTensorOp* getDiffusionTensorOp ();
    //-----------------------------------------------------------------------------
 
@@ -885,6 +886,7 @@ class PeleLM : public amrex::AmrCore {
 
    // Linear solvers
    std::unique_ptr<DiffusionOp> m_diffusion_op;
+   std::unique_ptr<DiffusionOp> m_mcdiffusion_op;
    std::unique_ptr<DiffusionTensorOp> m_diffusionTensor_op;
    std::unique_ptr<Hydro::MacProjector> macproj;
    int m_macProjNeedReset = 0;

--- a/Source/PeleLMDiffusion.cpp
+++ b/Source/PeleLMDiffusion.cpp
@@ -172,11 +172,11 @@ void PeleLM::computeDifferentialDiffusionFluxes(const TimeStamp &a_time,
    // Get the species diffusion fluxes from the DiffusionOp
    // Don't average down just yet
    int do_avgDown = 0;
-   getDiffusionOp()->computeDiffFluxes(a_fluxes, 0,
-                                       GetVecOfConstPtrs(getSpeciesVect(a_time)), 0,
-                                       GetVecOfConstPtrs(getDensityVect(a_time)),
-                                       GetVecOfConstPtrs(getDiffusivityVect(a_time)), 0, bcRecSpec,
-                                       NUM_SPECIES, -1.0, do_avgDown);
+   getMCDiffusionOp(NUM_SPECIES)->computeDiffFluxes(a_fluxes, 0,
+                                                    GetVecOfConstPtrs(getSpeciesVect(a_time)), 0,
+                                                    GetVecOfConstPtrs(getDensityVect(a_time)),
+                                                    GetVecOfConstPtrs(getDiffusivityVect(a_time)), 0, bcRecSpec,
+                                                    NUM_SPECIES, -1.0, do_avgDown);
 
    // Add the wbar term
    // TODO: might need to do an average_down of the wbar fluxes
@@ -610,13 +610,13 @@ void PeleLM::differentialDiffusionUpdate(std::unique_ptr<AdvanceAdvData> &advDat
    // Solve for \widetilda{rhoY^{np1,kp1}}
    // -> return the uncorrected fluxes^{np1,kp1}
    // -> and the partially updated species (not including wbar or flux correction)
-   getDiffusionOp()->diffuse_scalar(getSpeciesVect(AmrNewTime), 0,
-                                    GetVecOfConstPtrs(advData->Forcing), 0,
-                                    GetVecOfArrOfPtrs(fluxes), 0,
-                                    GetVecOfConstPtrs(getDensityVect(AmrNewTime)),        // this is the acoeff of LinOp
-                                    GetVecOfConstPtrs(getDensityVect(AmrNewTime)),        // this triggers proper scaling by density
-                                    GetVecOfConstPtrs(getDiffusivityVect(AmrNewTime)), 0, bcRecSpec,
-                                    NUM_SPECIES, 0, m_dt);
+   getMCDiffusionOp(NUM_SPECIES)->diffuse_scalar(getSpeciesVect(AmrNewTime), 0,
+                                                 GetVecOfConstPtrs(advData->Forcing), 0,
+                                                 GetVecOfArrOfPtrs(fluxes), 0,
+                                                 GetVecOfConstPtrs(getDensityVect(AmrNewTime)),        // this is the acoeff of LinOp
+                                                 GetVecOfConstPtrs(getDensityVect(AmrNewTime)),        // this triggers proper scaling by density
+                                                 GetVecOfConstPtrs(getDiffusivityVect(AmrNewTime)), 0, bcRecSpec,
+                                                 NUM_SPECIES, 0, m_dt);
 
    // Add lagged Wbar term
    // Computed in computeDifferentialDiffusionTerms at t^{n} if first SDC iteration, t^{np1,k} otherwise

--- a/Source/PeleLMDiffusion.cpp
+++ b/Source/PeleLMDiffusion.cpp
@@ -18,6 +18,13 @@ PeleLM::getDiffusionOp()
    return m_diffusion_op.get();
 }
 
+DiffusionOp*
+PeleLM::getMCDiffusionOp(int ncomp)
+{
+   if (!m_mcdiffusion_op || m_mcdiffusion_op->m_ncomp != ncomp) m_mcdiffusion_op.reset(new DiffusionOp(this,ncomp));
+   return m_mcdiffusion_op.get();
+}
+
 DiffusionTensorOp*
 PeleLM::getDiffusionTensorOp ()
 {

--- a/Source/PeleLMEB.cpp
+++ b/Source/PeleLMEB.cpp
@@ -71,8 +71,7 @@ void PeleLM::redistributeAofS(int a_lev,
                 // FluxRedistribute
                 Box gbx = bx;
 
-                if (m_adv_redist_type == "StateRedist" || 
-                    m_adv_redist_type == "NewStateRedist")
+                if (m_adv_redist_type == "StateRedist")
                   gbx.grow(3);
                 else if (m_adv_redist_type == "FluxRedist")
                   gbx.grow(2);
@@ -144,8 +143,7 @@ void PeleLM::redistributeDiff(int a_lev,
                 // FluxRedistribute
                 Box gbx = bx;
 
-                if (m_diff_redist_type == "StateRedist" || 
-                    m_diff_redist_type == "NewStateRedist")
+                if (m_diff_redist_type == "StateRedist")
                   gbx.grow(3);
                 else if (m_diff_redist_type == "FluxRedist")
                   gbx.grow(2);
@@ -236,9 +234,7 @@ void PeleLM::initialRedistribution()
 {
     // Redistribute the initial solution if adv/diff scheme uses State or NewState
     if (m_adv_redist_type == "StateRedist" || 
-        m_adv_redist_type == "NewStateRedist" ||
-        m_diff_redist_type == "StateRedist" ||
-        m_diff_redist_type == "NewStateRedist") { 
+        m_diff_redist_type == "StateRedist") { 
 
         for (int lev = 0; lev <= finest_level; ++lev) {
 

--- a/Source/PeleLMRegrid.cpp
+++ b/Source/PeleLMRegrid.cpp
@@ -87,6 +87,7 @@ void PeleLM::MakeNewLevelFromCoarse( int lev,
 
    // DiffusionOp will be recreated
    m_diffusion_op.reset();
+   m_mcdiffusion_op.reset();
    m_diffusionTensor_op.reset();
 
    // Trigger MacProj reset
@@ -178,6 +179,7 @@ void PeleLM::RemakeLevel( int lev,
 
    // DiffusionOp will be recreated
    m_diffusion_op.reset();
+   m_mcdiffusion_op.reset();
    m_diffusionTensor_op.reset();
 
    // Trigger MacProj reset
@@ -195,6 +197,7 @@ void PeleLM::ClearLevel(int lev) {
    m_dmapChem[lev].reset();
    m_factory[lev].reset();
    m_diffusion_op.reset();
+   m_mcdiffusion_op.reset();
    m_diffusionTensor_op.reset();
    macproj.reset();
 #ifdef PELE_USE_EFIELD


### PR DESCRIPTION
PeleLM class now have two diffusionOp: a single component one (use `getDiffusionOp()`) and a multi-component one (use `getMCDiffusionOp(ncomp)`). If `ncomp` is different from the number of components used to create the operator, the `unique_ptr` will reset.