### PR TITLE
Change level data layout

### DIFF
--- a/Source/Efield/PeleLMEFNLSolve.cpp
+++ b/Source/Efield/PeleLMEFNLSolve.cpp
@@ -343,7 +343,7 @@ void PeleLM::computeBGcharge(const Real &a_time,
       for (MFIter mfi(ldataNLs_p->backgroundCharge,TilingIfNotGPU()); mfi.isValid(); ++mfi)
       {
          const Box& bx = mfi.tilebox();
-         auto const& rhoYold  = ldata_p->species.const_array(mfi);
+         auto const& rhoYold  = ldata_p->state.const_array(mfi,FIRSTSPEC);
          auto const& adv_arr  = advData->AofS[lev].const_array(mfi,FIRSTSPEC);
          auto const& dn_arr   = diffData->Dn[lev].const_array(mfi);
          auto const& dnp1_arr = diffData->Dnp1[lev].const_array(mfi);

--- a/Source/Efield/PeleLMEFPoisson.cpp
+++ b/Source/Efield/PeleLMEFPoisson.cpp
@@ -28,7 +28,7 @@ void PeleLM::poissonSolveEF(const TimeStamp &a_time)
       for (MFIter mfi(*rhsPoisson[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
       {
          const Box& bx = mfi.tilebox();
-         auto const& rhoY = ldata_p->species.const_array(mfi);
+         auto const& rhoY = ldata_p->state.const_array(mfi,FIRSTSPEC);
          auto const& nE   = ldata_p->nE.const_array(mfi);
          auto const& rhs  = rhsPoisson[lev]->array(mfi);
          Real      factor = -1.0;// / ( eps0  * epsr);

--- a/Source/Efield/PeleLMEFReactions.cpp
+++ b/Source/Efield/PeleLMEFReactions.cpp
@@ -12,13 +12,13 @@ void PeleLM::computeInstantaneousReactionRateEF(int lev,
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-   for (MFIter mfi(ldata_p->species,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+   for (MFIter mfi(ldata_p->state,TilingIfNotGPU()); mfi.isValid(); ++mfi)
    {
       const Box& bx = mfi.tilebox();
-      auto const& rhoY    = ldata_p->species.const_array(mfi);
-      auto const& rhoH    = ldata_p->rhoh.const_array(mfi);
+      auto const& rhoY    = ldata_p->state.const_array(mfi,FIRSTSPEC);
+      auto const& rhoH    = ldata_p->state.const_array(mfi,RHOH);
       auto const& nE      = ldata_p->nE.const_array(mfi);
-      auto const& T       = ldata_p->temp.const_array(mfi);
+      auto const& T       = ldata_p->state.const_array(mfi,TEMP);
       auto const& rhoYdot = a_I_R->array(mfi);
       auto const& nEdot   = a_I_R->array(mfi,NUM_SPECIES);
 

--- a/Source/Efield/PeleLMEFTimeStep.cpp
+++ b/Source/Efield/PeleLMEFTimeStep.cpp
@@ -86,10 +86,10 @@ PeleLM::estEFIonsDt(const TimeStamp &a_time)
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-      for (MFIter mfi(ldata_p->velocity,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      for (MFIter mfi(ldata_p->state,TilingIfNotGPU()); mfi.isValid(); ++mfi)
       {
          const Box& bx = mfi.tilebox();
-         auto const& vel     = ldata_p->velocity.const_array(mfi);
+         auto const& vel     = ldata_p->state.const_array(mfi,VELX);
          auto const& efield  = efield_cc.const_array(mfi);
          auto const& mob_cc  = ldata_p->mob_cc.const_array(mfi);
          auto const& uDrMax  = driftVelMax_cc.array(mfi);
@@ -107,9 +107,9 @@ PeleLM::estEFIonsDt(const TimeStamp &a_time)
          });
       }
 
-		const auto dx = Geom(lev).CellSizeArray();
-   	amrex::Real cfl_lcl = m_cfl;
-   	estdt_lev = amrex::ReduceMin(driftVelMax_cc, 0, [dx,cfl_lcl]
+      const auto dx = Geom(lev).CellSizeArray();
+      amrex::Real cfl_lcl = m_cfl;
+      estdt_lev = amrex::ReduceMin(driftVelMax_cc, 0, [dx,cfl_lcl]
       AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& ueffm) noexcept -> Real
       {
          using namespace amrex::literals;

--- a/Source/Efield/PeleLMEFTransport.cpp
+++ b/Source/Efield/PeleLMEFTransport.cpp
@@ -18,7 +18,7 @@ void PeleLM::calcEFTransport(const TimeStamp &a_time) {
          const Box& gbx     = mfi.growntilebox();
          auto const& mobE   = ldata_p->mobE_cc.array(mfi);
          auto const& diffE  = ldata_p->diffE_cc.array(mfi);
-         auto const& T      = ldata_p->temp.const_array(mfi);
+         auto const& T      = ldata_p->state.const_array(mfi,TEMP);
          Real factor = PP_RU_MKS / ( Na * elemCharge );
          amrex::ParallelFor(gbx, [mobE, diffE, T, factor]
          AMREX_GPU_DEVICE (int i, int j, int k) noexcept

--- a/Source/Efield/PeleLMEFUtils.cpp
+++ b/Source/Efield/PeleLMEFUtils.cpp
@@ -188,13 +188,13 @@ void PeleLM::initializeElectronNeutral()
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-      for (MFIter mfi(ldata_p->species, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      for (MFIter mfi(ldata_p->state, TilingIfNotGPU()); mfi.isValid(); ++mfi)
       {
          const Box& bx = mfi.tilebox();
-         auto const& rho      = ldata_p->density.array(mfi);
-         auto const& rhoY     = ldata_p->species.array(mfi);
-         auto const& rhoH     = ldata_p->rhoh.array(mfi);
-         auto const& temp     = ldata_p->temp.array(mfi);
+         auto const& rho      = ldata_p->state.array(mfi,DENSITY);
+         auto const& rhoY     = ldata_p->state.array(mfi,FIRSTSPEC);
+         auto const& rhoH     = ldata_p->state.array(mfi,RHOH);
+         auto const& temp     = ldata_p->state.array(mfi,TEMP);
          auto const& nE       = ldata_p->nE.array(mfi);
          amrex::ParallelFor(bx, [rho, rhoY, rhoH, temp, nE, lprobparm]
          AMREX_GPU_DEVICE (int i, int j, int k) noexcept

--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -110,12 +110,7 @@ class PeleLM : public amrex::AmrCore {
                  int a_nAux, int a_nGrowState, int a_nGrowMAC);
 
       // cell-centered state multifabs
-      amrex::MultiFab velocity;        // Velocity (dim:AMREX_SPACEDIM)
-      amrex::MultiFab density;         // Density (dim:1)
-      amrex::MultiFab species;         // Species mass fraction (dim:NUM_SPECIES)
-      amrex::MultiFab rhoh;            // Rho * enthalpy (dim:1)
-      amrex::MultiFab rhoRT;           // Thermodynamic pressure (dim:1)
-      amrex::MultiFab temp;            // Temperature (dim:1)
+      amrex::MultiFab state;           // Stqte data: velocity, density, rhoYs, rhoH, Temp, RhoRT
       amrex::MultiFab auxiliaries;     // Auxiliary variables (passive scalars and others) (dim:m_nAux)
       amrex::MultiFab gp;              // pressure gradient (dim:AMREX_SPACEDIM)
       amrex::MultiFab divu;            // Velocity divergence constraint
@@ -137,6 +132,7 @@ class PeleLM : public amrex::AmrCore {
       amrex::MultiFab mob_cc;          // Species mobility (dim:NUM_IONS)
 #endif
    };
+
    struct LevelDataReact {
       LevelDataReact () = default;
       LevelDataReact (const amrex::BoxArray &ba,
@@ -213,7 +209,7 @@ class PeleLM : public amrex::AmrCore {
                            const amrex::Real &a_dt);
 
    // Actual projection function
-   void doNodalProject(amrex::Vector<amrex::MultiFab*> &a_vel,
+   void doNodalProject(const amrex::Vector<amrex::MultiFab*> &a_vel,
                        const amrex::Vector<amrex::MultiFab*> &a_sigma,
                        const amrex::Vector<amrex::MultiFab*> &rhs_cc,
                        const amrex::Vector<const amrex::MultiFab*> &rhs_nd,
@@ -457,11 +453,11 @@ class PeleLM : public amrex::AmrCore {
    fillPatchState(int lev, amrex::Real a_time, int nGrow);
 
    // FillPatch state components
-   void fillpatch_velocity(int lev, amrex::Real a_time, amrex::MultiFab& a_vel, int nGhost);
-   void fillpatch_density(int lev, amrex::Real a_time, amrex::MultiFab& a_rho, int nGhost);
-   void fillpatch_species(int lev, amrex::Real a_time, amrex::MultiFab& a_rhoY, int nGhost);
-   void fillpatch_energy(int lev, amrex::Real a_time, amrex::MultiFab& a_rhoh, amrex::MultiFab& a_temp, int nGhost);
-   void fillpatch_thermoPress(int lev, amrex::Real a_time, amrex::MultiFab& a_rhoRT, int nGhost);
+   void fillpatch_state(int lev, amrex::Real a_time, amrex::MultiFab& a_state, int nGhost);
+   void fillpatch_density(int lev, amrex::Real a_time, amrex::MultiFab& a_rhoY, int rho_comp, int nGhost);
+   void fillpatch_species(int lev, amrex::Real a_time, amrex::MultiFab& a_rhoY, int rhoY_comp, int nGhost);
+   void fillpatch_temp(int lev, amrex::Real a_time,
+                       amrex::MultiFab& a_temp, int temp_comp, int nGhost);
    void fillpatch_divu(int lev, amrex::Real a_time, amrex::MultiFab& a_divu, int nGhost);
    void fillpatch_gradp(int lev, amrex::Real a_time, amrex::MultiFab& a_gp, int nGhost);
    void fillpatch_reaction(int lev, amrex::Real a_time, amrex::MultiFab& a_I_R, int nGhost);
@@ -475,9 +471,7 @@ class PeleLM : public amrex::AmrCore {
 #endif
 
    // FillCoarsePatch state components
-   void fillcoarsepatch_velocity(int lev, amrex::Real a_time, amrex::MultiFab& a_vel, int nGhost);
-   void fillcoarsepatch_mass(int lev, amrex::Real a_time, amrex::MultiFab& a_rho, amrex::MultiFab& a_rhoY, int nGhost);
-   void fillcoarsepatch_energy(int lev, amrex::Real a_time, amrex::MultiFab& a_rhoh, amrex::MultiFab& a_temp, int nGhost);
+   void fillcoarsepatch_state(int lev, amrex::Real a_time, amrex::MultiFab& a_state, int nGhost);
    void fillcoarsepatch_divu(int lev, amrex::Real a_time, amrex::MultiFab& a_divu, int nGhost);
    void fillcoarsepatch_gradp(int lev, amrex::Real a_time, amrex::MultiFab& a_gp, int nGhost);
    void fillcoarsepatch_reaction(int lev, amrex::Real a_time, amrex::MultiFab& a_I_R, int nGhost);
@@ -495,11 +489,9 @@ class PeleLM : public amrex::AmrCore {
 
    // Average down operations
    void averageDownState(const PeleLM::TimeStamp &a_time);
+   void averageDownScalars(const PeleLM::TimeStamp &a_time);
    void averageDownVelocity(const PeleLM::TimeStamp &a_time);
    void averageDownDensity(const PeleLM::TimeStamp &a_time);
-   void averageDownSpecies(const PeleLM::TimeStamp &a_time);
-   void averageDownEnthalpy(const PeleLM::TimeStamp &a_time);
-   void averageDownTemp(const PeleLM::TimeStamp &a_time);
    void averageDownRhoRT(const PeleLM::TimeStamp &a_time);
 #ifdef PELE_USE_EFIELD
    void averageDownnE(const PeleLM::TimeStamp &a_time);
@@ -800,11 +792,11 @@ class PeleLM : public amrex::AmrCore {
       }
    }
 
-   amrex::Vector<amrex::MultiFab* > getVelocityVect(const PeleLM::TimeStamp &a_time);
-   amrex::Vector<amrex::MultiFab* > getDensityVect(const PeleLM::TimeStamp &a_time);
-   amrex::Vector<amrex::MultiFab* > getSpeciesVect(const PeleLM::TimeStamp &a_time);
-   amrex::Vector<amrex::MultiFab* > getTempVect(const PeleLM::TimeStamp &a_time);
-   amrex::Vector<amrex::MultiFab* > getRhoHVect(const PeleLM::TimeStamp &a_time);
+   amrex::Vector<std::unique_ptr<amrex::MultiFab> > getVelocityVect(const PeleLM::TimeStamp &a_time);
+   amrex::Vector<std::unique_ptr<amrex::MultiFab> > getDensityVect(const PeleLM::TimeStamp &a_time);
+   amrex::Vector<std::unique_ptr<amrex::MultiFab> > getSpeciesVect(const PeleLM::TimeStamp &a_time);
+   amrex::Vector<std::unique_ptr<amrex::MultiFab> > getRhoHVect(const PeleLM::TimeStamp &a_time);
+   amrex::Vector<std::unique_ptr<amrex::MultiFab> > getTempVect(const PeleLM::TimeStamp &a_time);
    amrex::Vector<amrex::MultiFab* > getDivUVect(const PeleLM::TimeStamp &a_time);
    amrex::Vector<amrex::MultiFab* > getDiffusivityVect(const PeleLM::TimeStamp &a_time);
    amrex::Vector<amrex::MultiFab* > getViscosityVect(const PeleLM::TimeStamp &a_time);

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -32,23 +32,19 @@ PeleLM::getLevelDataPtr(int lev, const PeleLM::TimeStamp &a_time, int useUMac)
                                   m_incompressible, m_has_divu,
                                   m_nAux, m_nGrowState, m_nGrowMAC));
       Real time = getTime(lev,a_time);
-      if (useUMac) {
-         // TODO: find a way to get U^{n+1/2} from Umac
-         // For now get old time
-         Real oldtime = getTime(lev,AmrOldTime);
-         fillpatch_velocity(lev, oldtime, m_leveldata_floating->velocity, m_nGrowState);
-      } else {
-         fillpatch_velocity(lev, time, m_leveldata_floating->velocity, m_nGrowState);
-      }
-      if (!m_incompressible) {
-         fillpatch_density(lev, time, m_leveldata_floating->density, m_nGrowState);
-         fillpatch_species(lev, time, m_leveldata_floating->species, m_nGrowState);
-         fillpatch_energy(lev, time, m_leveldata_floating->rhoh, m_leveldata_floating->temp, m_nGrowState);
+      fillpatch_state(lev, time, m_leveldata_floating->state, m_nGrowState);
+      //if (useUMac) {
+      //   // TODO: find a way to get U^{n+1/2} from Umac
+      //   // For now get old time
+      //   Real oldtime = getTime(lev,AmrOldTime);
+      //   fillpatch_velocity(lev, oldtime, m_leveldata_floating->state, VELX, m_nGrowState);
+      //}
 #ifdef PELE_USE_EFIELD
+      if (!m_incompressible) {
          fillpatch_phiV(lev, time, m_leveldata_floating->phiV, m_nGrowState);
          fillpatch_nE(lev, time, m_leveldata_floating->nE, m_nGrowState);
-#endif
       }
+#endif
       return m_leveldata_floating.get();
    }
 }
@@ -63,92 +59,91 @@ PeleLM::getLevelDataReactPtr(int lev)
    }
 }
 
-Vector<MultiFab *>
+Vector<std::unique_ptr<MultiFab> >
 PeleLM::getVelocityVect(const TimeStamp &a_time) {
-   Vector<MultiFab*> r;
+   Vector<std::unique_ptr<MultiFab> > r;
    r.reserve(finest_level+1);
    if ( a_time == AmrOldTime ) {
       for (int lev = 0; lev <= finest_level; ++lev) {
-         r.push_back(&(m_leveldata_old[lev]->velocity));
+         r.push_back(std::make_unique<MultiFab> (m_leveldata_old[lev]->state,amrex::make_alias,VELX,AMREX_SPACEDIM));
       }
    } else {
       for (int lev = 0; lev <= finest_level; ++lev) {
-         r.push_back(&(m_leveldata_new[lev]->velocity));
+         r.push_back(std::make_unique<MultiFab> (m_leveldata_new[lev]->state,amrex::make_alias,VELX,AMREX_SPACEDIM));
       }
    }
    return r;
 }
 
-Vector<MultiFab *>
+Vector<std::unique_ptr<MultiFab> >
 PeleLM::getSpeciesVect(const TimeStamp &a_time) {
    AMREX_ASSERT(!m_incompressible);
-   Vector<MultiFab*> r;
+   Vector<std::unique_ptr<MultiFab> > r;
    r.reserve(finest_level+1);
    if ( a_time == AmrOldTime ) {
       for (int lev = 0; lev <= finest_level; ++lev) {
-         r.push_back(&(m_leveldata_old[lev]->species));
+         r.push_back(std::make_unique<MultiFab> (m_leveldata_old[lev]->state,amrex::make_alias,FIRSTSPEC,NUM_SPECIES));
       }
    } else {
       for (int lev = 0; lev <= finest_level; ++lev) {
-         r.push_back(&(m_leveldata_new[lev]->species));
+         r.push_back(std::make_unique<MultiFab> (m_leveldata_new[lev]->state,amrex::make_alias,FIRSTSPEC,NUM_SPECIES));
       }
    }
    return r;
 }
 
-Vector<MultiFab *>
+Vector<std::unique_ptr<MultiFab> >
 PeleLM::getDensityVect(const TimeStamp &a_time) {
    AMREX_ASSERT(!m_incompressible);
-   Vector<MultiFab*> r;
+   Vector<std::unique_ptr<MultiFab> > r;
    r.reserve(finest_level+1);
    if ( a_time == AmrOldTime ) {
       for (int lev = 0; lev <= finest_level; ++lev) {
-         r.push_back(&(m_leveldata_old[lev]->density));
+         r.push_back(std::make_unique<MultiFab> (m_leveldata_old[lev]->state,amrex::make_alias,DENSITY,1));
       }
    } else if ( a_time == AmrNewTime ) {
       for (int lev = 0; lev <= finest_level; ++lev) {
-         r.push_back(&(m_leveldata_new[lev]->density));
+         r.push_back(std::make_unique<MultiFab> (m_leveldata_new[lev]->state,amrex::make_alias,DENSITY,1));
       }
    } else {
       for (int lev = 0; lev <= finest_level; ++lev) {
          Real time = getTime(lev,a_time);
-         m_halfTimeDensity[lev].reset( new MultiFab(grids[lev], dmap[lev], 1, m_nGrowState) );
-         fillpatch_density(lev,time,*(m_halfTimeDensity[lev].get()),m_nGrowState);
-         r.push_back(m_halfTimeDensity[lev].get());
+         r.push_back(std::make_unique<MultiFab> (grids[lev], dmap[lev], 1, m_nGrowState) );
+         fillpatch_density(lev,time,*(r[lev].get()),0,m_nGrowState);
       }
    }
    return r;
 }
 
-Vector<MultiFab *>
+Vector<std::unique_ptr<MultiFab> >
 PeleLM::getTempVect(const TimeStamp &a_time) {
    AMREX_ASSERT(!m_incompressible);
-   Vector<MultiFab*> r;
+   Vector<std::unique_ptr<MultiFab> > r;
    r.reserve(finest_level+1);
    if ( a_time == AmrOldTime ) {
       for (int lev = 0; lev <= finest_level; ++lev) {
-         r.push_back(&(m_leveldata_old[lev]->temp));
+         r.push_back(std::make_unique<MultiFab> (m_leveldata_old[lev]->state,amrex::make_alias,TEMP,1));
       }
    } else {
       for (int lev = 0; lev <= finest_level; ++lev) {
-         r.push_back(&(m_leveldata_new[lev]->temp));
+         r.push_back(std::make_unique<MultiFab> (m_leveldata_new[lev]->state,amrex::make_alias,TEMP,1));
       }
    }
    return r;
 }
 
-Vector<MultiFab *>
+Vector<std::unique_ptr<MultiFab> >
 PeleLM::getRhoHVect(const TimeStamp &a_time) {
    AMREX_ASSERT(!m_incompressible);
-   Vector<MultiFab*> r;
+   Vector<std::unique_ptr<MultiFab> > r;
    r.reserve(finest_level+1);
    if ( a_time == AmrOldTime ) {
       for (int lev = 0; lev <= finest_level; ++lev) {
-         r.push_back(&(m_leveldata_old[lev]->rhoh));
+         r.push_back(std::make_unique<MultiFab> (m_leveldata_old[lev]->state,amrex::make_alias,RHOH,1));
       }
    } else {
       for (int lev = 0; lev <= finest_level; ++lev) {
-         r.push_back(&(m_leveldata_new[lev]->rhoh));
+         r.push_back(std::make_unique<MultiFab> (m_leveldata_new[lev]->state,amrex::make_alias,RHOH,1));
       }
    }
    return r;
@@ -208,16 +203,34 @@ void
 PeleLM::averageDownState(const PeleLM::TimeStamp &a_time)
 {
    for (int lev = finest_level; lev > 0; --lev) {
-      std::unique_ptr<MultiFab> stateFine = fillPatchState(lev, getTime(lev,a_time), 0);
-      std::unique_ptr<MultiFab> stateCrse = fillPatchState(lev-1, getTime(lev,a_time), 0);
+      auto ldataFine_p = getLevelDataPtr(lev,a_time);
+      auto ldataCrse_p = getLevelDataPtr(lev-1,a_time);
 #ifdef AMREX_USE_EB
-      EB_average_down(*stateFine,
-                      *stateCrse,
+      EB_average_down(ldataFine_p->state,
+                      ldataCrse_p->state,
                       0,NVAR,refRatio(lev-1));
 #else
-      average_down(*stateFine,
-                   *stateCrse,
+      average_down(ldataFine_p->state,
+                   ldataCrse_p->state,
                    0,NVAR,refRatio(lev-1));
+#endif
+   }
+}
+
+void
+PeleLM::averageDownScalars(const PeleLM::TimeStamp &a_time)
+{
+   for (int lev = finest_level; lev > 0; --lev) {
+      auto ldataFine_p = getLevelDataPtr(lev,a_time);
+      auto ldataCrse_p = getLevelDataPtr(lev-1,a_time);
+#ifdef AMREX_USE_EB
+      EB_average_down(ldataFine_p->state,
+                      ldataCrse_p->state,
+                      DENSITY,NUM_SPECIES+3,refRatio(lev-1));
+#else
+      average_down(ldataFine_p->state,
+                   ldataCrse_p->state,
+                   DENSITY,NUM_SPECIES+3,refRatio(lev-1));
 #endif
    }
 }
@@ -229,31 +242,13 @@ PeleLM::averageDownDensity(const PeleLM::TimeStamp &a_time)
       auto ldataFine_p = getLevelDataPtr(lev,a_time);
       auto ldataCrse_p = getLevelDataPtr(lev-1,a_time);
 #ifdef AMREX_USE_EB
-      EB_average_down(ldataFine_p->density,
-                      ldataCrse_p->density,
-                      0,1,refRatio(lev-1));
+      EB_average_down(ldataFine_p->state,
+                      ldataCrse_p->state,
+                      DENSITY,1,refRatio(lev-1));
 #else
-      average_down(ldataFine_p->density,
-                   ldataCrse_p->density,
-                   0,1,refRatio(lev-1));
-#endif
-   }
-}
-
-void
-PeleLM::averageDownSpecies(const PeleLM::TimeStamp &a_time)
-{
-   for (int lev = finest_level; lev > 0; --lev) {
-      auto ldataFine_p = getLevelDataPtr(lev,a_time);
-      auto ldataCrse_p = getLevelDataPtr(lev-1,a_time);
-#ifdef AMREX_USE_EB
-      EB_average_down(ldataFine_p->species,
-                      ldataCrse_p->species,
-                      0,NUM_SPECIES,refRatio(lev-1));
-#else
-      average_down(ldataFine_p->species,
-                   ldataCrse_p->species,
-                   0,NUM_SPECIES,refRatio(lev-1));
+      average_down(ldataFine_p->state,
+                   ldataCrse_p->state,
+                   DENSITY,1,refRatio(lev-1));
 #endif
    }
 }
@@ -265,49 +260,13 @@ PeleLM::averageDownVelocity(const PeleLM::TimeStamp &a_time)
       auto ldataFine_p = getLevelDataPtr(lev,a_time);
       auto ldataCrse_p = getLevelDataPtr(lev-1,a_time);
 #ifdef AMREX_USE_EB
-      EB_average_down(ldataFine_p->velocity,
-                      ldataCrse_p->velocity,
-                      0,AMREX_SPACEDIM,refRatio(lev-1));
+      EB_average_down(ldataFine_p->state,
+                      ldataCrse_p->state,
+                      VELX,AMREX_SPACEDIM,refRatio(lev-1));
 #else
-      average_down(ldataFine_p->velocity,
-                   ldataCrse_p->velocity,
-                   0,AMREX_SPACEDIM,refRatio(lev-1));
-#endif
-   }
-}
-
-void
-PeleLM::averageDownTemp(const PeleLM::TimeStamp &a_time)
-{
-   for (int lev = finest_level; lev > 0; --lev) {
-      auto ldataFine_p = getLevelDataPtr(lev,a_time);
-      auto ldataCrse_p = getLevelDataPtr(lev-1,a_time);
-#ifdef AMREX_USE_EB
-      EB_average_down(ldataFine_p->temp,
-                      ldataCrse_p->temp,
-                      0,1,refRatio(lev-1));
-#else
-      average_down(ldataFine_p->temp,
-                   ldataCrse_p->temp,
-                   0,1,refRatio(lev-1));
-#endif
-   }
-}
-
-void
-PeleLM::averageDownEnthalpy(const PeleLM::TimeStamp &a_time)
-{
-   for (int lev = finest_level; lev > 0; --lev) {
-      auto ldataFine_p = getLevelDataPtr(lev,a_time);
-      auto ldataCrse_p = getLevelDataPtr(lev-1,a_time);
-#ifdef AMREX_USE_EB
-      EB_average_down(ldataFine_p->rhoh,
-                      ldataCrse_p->rhoh,
-                      0,1,refRatio(lev-1));
-#else
-      average_down(ldataFine_p->rhoh,
-                   ldataCrse_p->rhoh,
-                   0,1,refRatio(lev-1));
+      average_down(ldataFine_p->state,
+                   ldataCrse_p->state,
+                   VELX,AMREX_SPACEDIM,refRatio(lev-1));
 #endif
    }
 }
@@ -319,13 +278,13 @@ PeleLM::averageDownRhoRT(const PeleLM::TimeStamp &a_time)
       auto ldataFine_p = getLevelDataPtr(lev,a_time);
       auto ldataCrse_p = getLevelDataPtr(lev-1,a_time);
 #ifdef AMREX_USE_EB
-      EB_average_down(ldataFine_p->rhoRT,
-                      ldataCrse_p->rhoRT,
-                      0,1,refRatio(lev-1));
+      EB_average_down(ldataFine_p->state,
+                      ldataCrse_p->state,
+                      RHORT,1,refRatio(lev-1));
 #else
-      average_down(ldataFine_p->rhoRT,
-                   ldataCrse_p->rhoRT,
-                   0,1,refRatio(lev-1));
+      average_down(ldataFine_p->state,
+                   ldataCrse_p->state,
+                   RHORT,1,refRatio(lev-1));
 #endif
    }
 }

--- a/Source/PeleLMAdvance.cpp
+++ b/Source/PeleLMAdvance.cpp
@@ -129,10 +129,7 @@ void PeleLM::Advance(int is_initIter) {
       }
 
       // Post SDC
-      averageDownDensity(AmrNewTime); // Gather the following if needed TODO
-      averageDownSpecies(AmrNewTime);
-      averageDownEnthalpy(AmrNewTime);
-      averageDownTemp(AmrNewTime);
+      averageDownScalars(AmrNewTime);
 #ifdef PELE_USE_EFIELD
       averageDownnE(AmrNewTime);
 #endif
@@ -215,10 +212,7 @@ void PeleLM::oneSDC(int sdcIter,
          UpdateStart = ParallelDescriptor::second();
       }
       // fillpatch the new state
-      averageDownDensity(AmrNewTime); // Gather the following if needed TODO
-      averageDownSpecies(AmrNewTime);
-      averageDownEnthalpy(AmrNewTime);
-      averageDownTemp(AmrNewTime);
+      averageDownScalars(AmrNewTime);
 #ifdef PELE_USE_EFIELD
       averageDownnE(AmrNewTime);
 #endif

--- a/Source/PeleLMBC.cpp
+++ b/Source/PeleLMBC.cpp
@@ -226,12 +226,8 @@ void PeleLM::fillPatchState(int lev, const TimeStamp &a_time) {
    auto ldata_p = getLevelDataPtr(lev,a_time);
    Real time = getTime(lev, a_time);
 
-   fillpatch_velocity(lev, time, ldata_p->velocity, m_nGrowState);
+   fillpatch_state(lev, time, ldata_p->state, m_nGrowState);
    if (!m_incompressible) {
-      fillpatch_density(lev, time, ldata_p->density, m_nGrowState);
-      fillpatch_species(lev, time, ldata_p->species, m_nGrowState);
-      fillpatch_energy(lev, time, ldata_p->rhoh, ldata_p->temp, m_nGrowState);
-      fillpatch_thermoPress(lev, time, ldata_p->rhoRT, m_nGrowState);
       if (m_has_divu) {
          fillpatch_divu(lev, time, ldata_p->divu, ldata_p->divu.nGrow());
       }
@@ -249,7 +245,7 @@ void PeleLM::fillPatchDensity(const TimeStamp &a_time) {
    for (int lev = 0; lev <= finest_level; lev++) {
       auto ldata_p = getLevelDataPtr(lev,a_time);
       Real time = getTime(lev, a_time);
-      fillpatch_density(lev, time, ldata_p->density, m_nGrowState);
+      fillpatch_density(lev, time, ldata_p->state, DENSITY, m_nGrowState);
    }
 }
 
@@ -258,7 +254,7 @@ void PeleLM::fillPatchSpecies(const TimeStamp &a_time) {
    for (int lev = 0; lev <= finest_level; lev++) {
       auto ldata_p = getLevelDataPtr(lev,a_time);
       Real time = getTime(lev, a_time);
-      fillpatch_species(lev, time, ldata_p->species, m_nGrowState);
+      fillpatch_species(lev, time, ldata_p->state, FIRSTSPEC, m_nGrowState);
    }
 }
 
@@ -267,7 +263,7 @@ void PeleLM::fillPatchTemp(const TimeStamp &a_time) {
    for (int lev = 0; lev <= finest_level; lev++) {
       auto ldata_p = getLevelDataPtr(lev,a_time);
       Real time = getTime(lev, a_time);
-      fillpatch_energy(lev, time, ldata_p->rhoh, ldata_p->temp, m_nGrowState);
+      fillpatch_temp(lev, time, ldata_p->state, TEMP, m_nGrowState);
    }
 }
 
@@ -293,74 +289,66 @@ PeleLM::fillPatchState(int lev, Real a_time, int nGrow) {
    std::unique_ptr<MultiFab> mf;
    mf.reset(new MultiFab(grids[lev], dmap[lev], NVAR, nGrow));
 
-   MultiFab vel(*mf, amrex::make_alias, VELX, AMREX_SPACEDIM);
-   fillpatch_velocity(lev, a_time, vel, nGrow);
-   if (!m_incompressible) {
-      MultiFab rho(*mf, amrex::make_alias, DENSITY, 1);
-      fillpatch_density(lev, a_time, rho, nGrow);
-      MultiFab rhoY(*mf, amrex::make_alias, FIRSTSPEC, NUM_SPECIES);
-      fillpatch_species(lev, a_time, rhoY, nGrow);
-      MultiFab rhoh(*mf, amrex::make_alias, RHOH, 1);
-      MultiFab temp(*mf, amrex::make_alias, TEMP, 1);
-      fillpatch_energy(lev, a_time, rhoh, temp, nGrow);
-      MultiFab rhoRT(*mf, amrex::make_alias, RHORT, 1);
-      fillpatch_thermoPress(lev, a_time, rhoRT, nGrow);
+   fillpatch_state(lev, a_time, *mf, nGrow);
 #ifdef PELE_USE_EFIELD
+   if (!m_incompressible) {
       MultiFab nE(*mf, amrex::make_alias, NE, 1);
       fillpatch_nE(lev, a_time, nE, nGrow);
       MultiFab phiV(*mf, amrex::make_alias, PHIV, 1);
       fillpatch_phiV(lev, a_time, phiV, nGrow);
-#endif
    }
+#endif
    //TODO Aux
 
    return mf;
 }
 //-----------------------------------------------------------------------------
 
-// Fill the velocity
-void PeleLM::fillpatch_velocity(int lev,
-                                const amrex::Real a_time,
-                                amrex::MultiFab &a_vel,
-                                int nGhost) {
+// Fill the state
+void PeleLM::fillpatch_state(int lev,
+                             const amrex::Real a_time,
+                             amrex::MultiFab &a_state,
+                             int nGhost) {
    ProbParm const* lprobparm = prob_parm_d;
    pele::physics::PMF::PmfData::DataContainer const* lpmfdata = pmf_data.getDeviceData();
 
-#ifdef PELE_USE_TURBINFLOW
-   fillTurbInflow(a_vel, lev, a_time);
-#endif
+// TODO restore this
+//#ifdef PELE_USE_TURBINFLOW
+//   fillTurbInflow(a_vel, lev, a_time);
+//#endif
 
    if (lev == 0) {
-      PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirVel>> bndry_func(geom[lev], fetchBCRecArray(VELX,AMREX_SPACEDIM),
-                                                                     PeleLMCCFillExtDirVel{lprobparm, lpmfdata, m_nAux});
-      FillPatchSingleLevel(a_vel, IntVect(nGhost), a_time,
-                           {&(m_leveldata_old[lev]->velocity),&(m_leveldata_new[lev]->velocity)},
-                           {m_t_old[lev], m_t_new[lev]},0,0,AMREX_SPACEDIM,geom[lev], bndry_func, 0);
+      PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState>> bndry_func(geom[lev], fetchBCRecArray(0,NVAR),
+                                                                       PeleLMCCFillExtDirState{lprobparm, lpmfdata, m_nAux});
+      FillPatchSingleLevel(a_state, IntVect(nGhost), a_time,
+                           {&(m_leveldata_old[lev]->state),&(m_leveldata_new[lev]->state)},
+                           {m_t_old[lev], m_t_new[lev]},0,0,NVAR,geom[lev], bndry_func, 0);
    } else {
 
       // Interpolator
       auto* mapper = getInterpolator();
 
-      PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirVel>> crse_bndry_func(geom[lev-1], fetchBCRecArray(VELX,AMREX_SPACEDIM),
-                                                                          PeleLMCCFillExtDirVel{lprobparm, lpmfdata, m_nAux});
-      PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirVel>> fine_bndry_func(geom[lev], fetchBCRecArray(VELX,AMREX_SPACEDIM),
-                                                                          PeleLMCCFillExtDirVel{lprobparm, lpmfdata, m_nAux});
-      FillPatchTwoLevels(a_vel, IntVect(nGhost), a_time,
-                         {&(m_leveldata_old[lev-1]->velocity),&(m_leveldata_new[lev-1]->velocity)},
+      PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState>> crse_bndry_func(geom[lev-1], fetchBCRecArray(0,NVAR),
+                                                                            PeleLMCCFillExtDirState{lprobparm, lpmfdata, m_nAux});
+      PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState>> fine_bndry_func(geom[lev], fetchBCRecArray(0,NVAR),
+                                                                            PeleLMCCFillExtDirState{lprobparm, lpmfdata, m_nAux});
+      FillPatchTwoLevels(a_state, IntVect(nGhost), a_time,
+                         {&(m_leveldata_old[lev-1]->state),&(m_leveldata_new[lev-1]->state)},
                          {m_t_old[lev-1], m_t_new[lev-1]},
-                         {&(m_leveldata_old[lev]->velocity),&(m_leveldata_new[lev]->velocity)},
+                         {&(m_leveldata_old[lev]->state),&(m_leveldata_new[lev]->state)},
                          {m_t_old[lev], m_t_new[lev]},
-                         0, 0, AMREX_SPACEDIM, geom[lev-1], geom[lev],
+                         0, 0, NVAR, geom[lev-1], geom[lev],
                          crse_bndry_func,0,fine_bndry_func,0,
-                         refRatio(lev-1), mapper, fetchBCRecArray(VELX,AMREX_SPACEDIM), 0);
+                         refRatio(lev-1), mapper, fetchBCRecArray(0,NVAR), 0);
    }
-   a_vel.EnforcePeriodicity(geom[lev].periodicity());
+   // TODO: restore a_vel.EnforcePeriodicity(geom[lev].periodicity());
 }
 
 // Fill the density
 void PeleLM::fillpatch_density(int lev,
                                const amrex::Real a_time,
                                amrex::MultiFab &a_density,
+                               int rho_comp,
                                int nGhost) {
    ProbParm const* lprobparm = prob_parm_d;
    pele::physics::PMF::PmfData::DataContainer const* lpmfdata = pmf_data.getDeviceData();
@@ -370,8 +358,8 @@ void PeleLM::fillpatch_density(int lev,
       PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirDens>> bndry_func_rho(geom[lev], fetchBCRecArray(DENSITY,1),
                                                                           PeleLMCCFillExtDirDens{lprobparm, lpmfdata, m_nAux});
       FillPatchSingleLevel(a_density, IntVect(nGhost), a_time,
-                           {&(m_leveldata_old[lev]->density),&(m_leveldata_new[lev]->density)},
-                           {m_t_old[lev], m_t_new[lev]},0,0,1,geom[lev], bndry_func_rho, 0);
+                           {&(m_leveldata_old[lev]->state),&(m_leveldata_new[lev]->state)},
+                           {m_t_old[lev], m_t_new[lev]},DENSITY,rho_comp,1,geom[lev], bndry_func_rho, 0);
 
    } else {
 
@@ -384,11 +372,11 @@ void PeleLM::fillpatch_density(int lev,
       PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirDens>> fine_bndry_func_rho(geom[lev], fetchBCRecArray(DENSITY,1),
                                                                                PeleLMCCFillExtDirDens{lprobparm, lpmfdata, m_nAux});
       FillPatchTwoLevels(a_density, IntVect(nGhost), a_time,
-                         {&(m_leveldata_old[lev-1]->density),&(m_leveldata_new[lev-1]->density)},
+                         {&(m_leveldata_old[lev-1]->state),&(m_leveldata_new[lev-1]->state)},
                          {m_t_old[lev-1], m_t_new[lev-1]},
-                         {&(m_leveldata_old[lev]->density),&(m_leveldata_new[lev]->density)},
+                         {&(m_leveldata_old[lev]->state),&(m_leveldata_new[lev]->state)},
                          {m_t_old[lev], m_t_new[lev]},
-                         0, 0, 1, geom[lev-1], geom[lev],
+                         DENSITY, rho_comp, 1, geom[lev-1], geom[lev],
                          crse_bndry_func_rho,0,fine_bndry_func_rho,0,
                          refRatio(lev-1), mapper, fetchBCRecArray(DENSITY,1), 0);
    }
@@ -398,6 +386,7 @@ void PeleLM::fillpatch_density(int lev,
 void PeleLM::fillpatch_species(int lev,
                                const amrex::Real a_time,
                                amrex::MultiFab &a_species,
+                               int rhoY_comp,
                                int nGhost) {
    ProbParm const* lprobparm = prob_parm_d;
    pele::physics::PMF::PmfData::DataContainer const* lpmfdata = pmf_data.getDeviceData();
@@ -407,8 +396,8 @@ void PeleLM::fillpatch_species(int lev,
       PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirSpec>> bndry_func(geom[lev], fetchBCRecArray(FIRSTSPEC,NUM_SPECIES),
                                                                       PeleLMCCFillExtDirSpec{lprobparm, lpmfdata, m_nAux});
       FillPatchSingleLevel(a_species, IntVect(nGhost), a_time,
-                           {&(m_leveldata_old[lev]->species),&(m_leveldata_new[lev]->species)},
-                           {m_t_old[lev], m_t_new[lev]},0,0,NUM_SPECIES,geom[lev], bndry_func, 0);
+                           {&(m_leveldata_old[lev]->state),&(m_leveldata_new[lev]->state)},
+                           {m_t_old[lev], m_t_new[lev]},FIRSTSPEC,rhoY_comp,NUM_SPECIES,geom[lev], bndry_func, 0);
    } else {
 
       // Interpolator
@@ -420,109 +409,47 @@ void PeleLM::fillpatch_species(int lev,
       PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirSpec>> fine_bndry_func(geom[lev], fetchBCRecArray(FIRSTSPEC,NUM_SPECIES),
                                                                            PeleLMCCFillExtDirSpec{lprobparm, lpmfdata, m_nAux});
       FillPatchTwoLevels(a_species, IntVect(nGhost), a_time,
-                         {&(m_leveldata_old[lev-1]->species),&(m_leveldata_new[lev-1]->species)},
+                         {&(m_leveldata_old[lev-1]->state),&(m_leveldata_new[lev-1]->state)},
                          {m_t_old[lev-1], m_t_new[lev-1]},
-                         {&(m_leveldata_old[lev]->species),&(m_leveldata_new[lev]->species)},
+                         {&(m_leveldata_old[lev]->state),&(m_leveldata_new[lev]->state)},
                          {m_t_old[lev], m_t_new[lev]},
-                         0, 0, NUM_SPECIES, geom[lev-1], geom[lev],
+                         FIRSTSPEC, rhoY_comp, NUM_SPECIES, geom[lev-1], geom[lev],
                          crse_bndry_func,0,fine_bndry_func,0,
                          refRatio(lev-1), mapper, fetchBCRecArray(FIRSTSPEC,NUM_SPECIES), 0);
    }
 }
 
-// Fill rhoH and temperature
-void PeleLM::fillpatch_energy(int lev,
-                              const amrex::Real a_time,
-                              amrex::MultiFab &a_rhoh,
-                              amrex::MultiFab &a_temp,
-                              int nGhost) {
+// Fill temperature
+void PeleLM::fillpatch_temp(int lev,
+                            const amrex::Real a_time,
+                            amrex::MultiFab &a_temp,
+                            int temp_comp,
+                            int nGhost) {
    ProbParm const* lprobparm = prob_parm_d;
    pele::physics::PMF::PmfData::DataContainer const* lpmfdata = pmf_data.getDeviceData();
    if (lev == 0) {
-
-      // rhoH
-      PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirRhoH>> bndry_func_rhoh(geom[lev], fetchBCRecArray(RHOH,1),
-                                                                          PeleLMCCFillExtDirRhoH{lprobparm, lpmfdata, m_nAux});
-      FillPatchSingleLevel(a_rhoh, IntVect(nGhost), a_time,
-                           {&(m_leveldata_old[lev]->rhoh),&(m_leveldata_new[lev]->rhoh)},
-                           {m_t_old[lev], m_t_new[lev]},0,0,1,geom[lev], bndry_func_rhoh, 0);
-
-      // temperature
       PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirTemp>> bndry_func(geom[lev], fetchBCRecArray(TEMP,1),
                                                                       PeleLMCCFillExtDirTemp{lprobparm, lpmfdata, m_nAux});
       FillPatchSingleLevel(a_temp, IntVect(nGhost), a_time,
-                           {&(m_leveldata_old[lev]->temp),&(m_leveldata_new[lev]->temp)},
-                           {m_t_old[lev], m_t_new[lev]},0,0,1,geom[lev], bndry_func, 0);
+                           {&(m_leveldata_old[lev]->state),&(m_leveldata_new[lev]->state)},
+                           {m_t_old[lev], m_t_new[lev]},TEMP,temp_comp,1,geom[lev], bndry_func, 0);
    } else {
 
       // Interpolator
       auto* mapper = getInterpolator();
 
-      // rhoH
-      PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirRhoH>> crse_bndry_func_rhoh(geom[lev-1], fetchBCRecArray(RHOH,1),
-                                                                                PeleLMCCFillExtDirRhoH{lprobparm, lpmfdata, m_nAux});
-      PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirRhoH>> fine_bndry_func_rhoh(geom[lev], fetchBCRecArray(RHOH,1),
-                                                                                PeleLMCCFillExtDirRhoH{lprobparm, lpmfdata, m_nAux});
-      FillPatchTwoLevels(a_rhoh, IntVect(nGhost), a_time,
-                         {&(m_leveldata_old[lev-1]->rhoh),&(m_leveldata_new[lev-1]->rhoh)},
-                         {m_t_old[lev-1], m_t_new[lev-1]},
-                         {&(m_leveldata_old[lev]->rhoh),&(m_leveldata_new[lev]->rhoh)},
-                         {m_t_old[lev], m_t_new[lev]},
-                         0, 0, 1, geom[lev-1], geom[lev],
-                         crse_bndry_func_rhoh,0,fine_bndry_func_rhoh,0,
-                         refRatio(lev-1), mapper, fetchBCRecArray(RHOH,1), 0);
-
-      // temperature
       PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirTemp>> crse_bndry_func(geom[lev-1], fetchBCRecArray(TEMP,1),
                                                                            PeleLMCCFillExtDirTemp{lprobparm, lpmfdata, m_nAux});
       PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirTemp>> fine_bndry_func(geom[lev], fetchBCRecArray(TEMP,1),
                                                                            PeleLMCCFillExtDirTemp{lprobparm, lpmfdata, m_nAux});
       FillPatchTwoLevels(a_temp, IntVect(nGhost), a_time,
-                         {&(m_leveldata_old[lev-1]->temp),&(m_leveldata_new[lev-1]->temp)},
+                         {&(m_leveldata_old[lev-1]->state),&(m_leveldata_new[lev-1]->state)},
                          {m_t_old[lev-1], m_t_new[lev-1]},
-                         {&(m_leveldata_old[lev]->temp),&(m_leveldata_new[lev]->temp)},
+                         {&(m_leveldata_old[lev]->state),&(m_leveldata_new[lev]->state)},
                          {m_t_old[lev], m_t_new[lev]},
-                         0, 0, 1, geom[lev-1], geom[lev],
+                         TEMP, temp_comp, 1, geom[lev-1], geom[lev],
                          crse_bndry_func,0,fine_bndry_func,0,
                          refRatio(lev-1), mapper, fetchBCRecArray(TEMP,1), 0);
-
-   }
-}
-
-// Fill the thermodynamic pressure
-void PeleLM::fillpatch_thermoPress(int lev,
-                                   const amrex::Real a_time,
-                                   amrex::MultiFab &a_rhoRT,
-                                   int nGhost) {
-   ProbParm const* lprobparm = prob_parm_d;
-   pele::physics::PMF::PmfData::DataContainer const* lpmfdata = pmf_data.getDeviceData();
-   if (lev == 0) {
-
-      // Density
-      PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirDummy>> bndry_func_rhoRT(geom[lev], fetchBCRecArray(RHORT,1),
-                                                                             PeleLMCCFillExtDirDummy{lprobparm, m_nAux});
-      FillPatchSingleLevel(a_rhoRT, IntVect(nGhost), a_time,
-                           {&(m_leveldata_old[lev]->rhoRT),&(m_leveldata_new[lev]->rhoRT)},
-                           {m_t_old[lev], m_t_new[lev]},0,0,1,geom[lev], bndry_func_rhoRT, 0);
-
-   } else {
-
-      // Interpolator
-      auto* mapper = getInterpolator();
-
-      // Density
-      PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirDummy>> crse_bndry_func_rhoRT(geom[lev-1], fetchBCRecArray(RHORT,1), 
-                                                                                  PeleLMCCFillExtDirDummy{lprobparm, m_nAux});
-      PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirDummy>> fine_bndry_func_rhoRT(geom[lev], fetchBCRecArray(RHORT,1),
-                                                                                  PeleLMCCFillExtDirDummy{lprobparm, m_nAux});
-      FillPatchTwoLevels(a_rhoRT, IntVect(nGhost), a_time,
-                         {&(m_leveldata_old[lev-1]->rhoRT),&(m_leveldata_new[lev-1]->rhoRT)},
-                         {m_t_old[lev-1], m_t_new[lev-1]},
-                         {&(m_leveldata_old[lev]->rhoRT),&(m_leveldata_new[lev]->rhoRT)},
-                         {m_t_old[lev], m_t_new[lev]},
-                         0, 0, 1, geom[lev-1], geom[lev],
-                         crse_bndry_func_rhoRT,0,fine_bndry_func_rhoRT,0,
-                         refRatio(lev-1), mapper, fetchBCRecArray(DENSITY,1), 0);
    }
 }
 
@@ -732,98 +659,26 @@ void PeleLM::fillpatch_reaction(int lev,
    }
 }
 
-// Fill the velocity
-void PeleLM::fillcoarsepatch_velocity(int lev,
-                                      const amrex::Real a_time,
-                                      amrex::MultiFab &a_vel,
-                                      int nGhost) {
+// Fill the state
+void PeleLM::fillcoarsepatch_state(int lev,
+                                   const amrex::Real a_time,
+                                   amrex::MultiFab &a_state,
+                                   int nGhost) {
    ProbParm const* lprobparm = prob_parm_d;
    pele::physics::PMF::PmfData::DataContainer const* lpmfdata = pmf_data.getDeviceData();
 
    // Interpolator
    auto* mapper = getInterpolator();
 
-   PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirVel>> crse_bndry_func(geom[lev-1], fetchBCRecArray(VELX,AMREX_SPACEDIM),
-                                                                       PeleLMCCFillExtDirVel{lprobparm, lpmfdata, m_nAux});
-   PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirVel>> fine_bndry_func(geom[lev], fetchBCRecArray(VELX,AMREX_SPACEDIM),
-                                                                       PeleLMCCFillExtDirVel{lprobparm, lpmfdata, m_nAux});
-   InterpFromCoarseLevel(a_vel, IntVect(nGhost), a_time,
-                         m_leveldata_new[lev-1]->velocity, 0, 0, AMREX_SPACEDIM,
+   PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState>> crse_bndry_func(geom[lev-1], fetchBCRecArray(0,NVAR),
+                                                                         PeleLMCCFillExtDirState{lprobparm, lpmfdata, m_nAux});
+   PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState>> fine_bndry_func(geom[lev], fetchBCRecArray(0,NVAR),
+                                                                         PeleLMCCFillExtDirState{lprobparm, lpmfdata, m_nAux});
+   InterpFromCoarseLevel(a_state, IntVect(nGhost), a_time,
+                         m_leveldata_new[lev-1]->state, 0, 0, NVAR,
                          geom[lev-1], geom[lev],
                          crse_bndry_func,0,fine_bndry_func,0,
-                         refRatio(lev-1), mapper, fetchBCRecArray(VELX,AMREX_SPACEDIM), 0);
-}
-
-// Fill the mass
-void PeleLM::fillcoarsepatch_mass(int lev,
-                                  const amrex::Real a_time,
-                                  amrex::MultiFab &a_density,
-                                  amrex::MultiFab &a_species,
-                                  int nGhost) {
-   ProbParm const* lprobparm = prob_parm_d;
-   pele::physics::PMF::PmfData::DataContainer const* lpmfdata = pmf_data.getDeviceData();
-
-   // Interpolator
-   auto* mapper = getInterpolator();
-
-   // Density
-   PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirDens>> crse_bndry_func_rho(geom[lev-1], fetchBCRecArray(DENSITY,1),
-                                                                            PeleLMCCFillExtDirDens{lprobparm, lpmfdata, m_nAux});
-   PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirDens>> fine_bndry_func_rho(geom[lev], fetchBCRecArray(DENSITY,1),
-                                                                            PeleLMCCFillExtDirDens{lprobparm, lpmfdata, m_nAux});
-   InterpFromCoarseLevel(a_density, IntVect(nGhost), a_time,
-                         m_leveldata_new[lev-1]->density, 0, 0, 1,
-                         geom[lev-1], geom[lev],
-                         crse_bndry_func_rho,0,fine_bndry_func_rho,0,
-                         refRatio(lev-1), mapper, fetchBCRecArray(DENSITY,1), 0);
-
-   // Species
-   PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirSpec>> crse_bndry_func(geom[lev-1], fetchBCRecArray(FIRSTSPEC,NUM_SPECIES),
-                                                                        PeleLMCCFillExtDirSpec{lprobparm, lpmfdata, m_nAux});
-   PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirSpec>> fine_bndry_func(geom[lev], fetchBCRecArray(FIRSTSPEC,NUM_SPECIES),
-                                                                        PeleLMCCFillExtDirSpec{lprobparm, lpmfdata, m_nAux});
-   InterpFromCoarseLevel(a_species, IntVect(nGhost), a_time,
-                         m_leveldata_new[lev-1]->species, 0, 0, NUM_SPECIES,
-                         geom[lev-1], geom[lev],
-                         crse_bndry_func,0,fine_bndry_func,0,
-                         refRatio(lev-1), mapper, fetchBCRecArray(FIRSTSPEC,NUM_SPECIES), 0);
-
-}
-
-// Fill the mass
-void PeleLM::fillcoarsepatch_energy(int lev,
-                                    const amrex::Real a_time,
-                                    amrex::MultiFab &a_rhoh,
-                                    amrex::MultiFab &a_temp,
-                                    int nGhost) {
-   ProbParm const* lprobparm = prob_parm_d;
-   pele::physics::PMF::PmfData::DataContainer const* lpmfdata = pmf_data.getDeviceData();
-
-   // Interpolator
-   auto* mapper = getInterpolator();
-
-   // rhoH
-   PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirRhoH>> crse_bndry_func_rhoh(geom[lev-1], fetchBCRecArray(RHOH,1),
-                                                                             PeleLMCCFillExtDirRhoH{lprobparm, lpmfdata, m_nAux});
-   PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirRhoH>> fine_bndry_func_rhoh(geom[lev], fetchBCRecArray(RHOH,1),
-                                                                             PeleLMCCFillExtDirRhoH{lprobparm, lpmfdata, m_nAux});
-   InterpFromCoarseLevel(a_rhoh, IntVect(nGhost), a_time,
-                         m_leveldata_new[lev-1]->rhoh, 0, 0, 1,
-                         geom[lev-1], geom[lev],
-                         crse_bndry_func_rhoh,0,fine_bndry_func_rhoh,0,
-                         refRatio(lev-1), mapper, fetchBCRecArray(RHOH,1), 0);
-
-   // temperature
-   PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirTemp>> crse_bndry_func(geom[lev-1], fetchBCRecArray(TEMP,1),
-                                                                        PeleLMCCFillExtDirTemp{lprobparm, lpmfdata, m_nAux});
-   PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirTemp>> fine_bndry_func(geom[lev], fetchBCRecArray(TEMP,1),
-                                                                        PeleLMCCFillExtDirTemp{lprobparm, lpmfdata, m_nAux});
-   InterpFromCoarseLevel(a_temp, IntVect(nGhost), a_time,
-                         m_leveldata_new[lev-1]->temp, 0, 0, 1,
-                         geom[lev-1], geom[lev],
-                         crse_bndry_func,0,fine_bndry_func,0,
-                         refRatio(lev-1), mapper, fetchBCRecArray(TEMP,1), 0);
-
+                         refRatio(lev-1), mapper, fetchBCRecArray(0,NVAR), 0);
 }
 
 // Fill the grad P

--- a/Source/PeleLMBCfill.H
+++ b/Source/PeleLMBCfill.H
@@ -6,6 +6,81 @@
 
 using namespace amrex;
 
+struct PeleLMCCFillExtDirState
+{
+
+   ProbParm const* lprobparm;
+   pele::physics::PMF::PmfData::DataContainer const* lpmfdata;
+   const int m_nAux;
+
+   AMREX_GPU_HOST
+   constexpr PeleLMCCFillExtDirState(ProbParm const* a_prob_parm,
+                                     pele::physics::PMF::PmfData::DataContainer const* a_pmf_data, int a_nAux)
+                                     : lprobparm(a_prob_parm), lpmfdata(a_pmf_data), m_nAux(a_nAux) {}
+
+   AMREX_GPU_DEVICE
+   void operator()(
+      const amrex::IntVect& iv,
+      amrex::Array4<amrex::Real> const& state,
+      const int /*dcomp*/,
+      const int /*numcomp*/,
+      amrex::GeometryData const& geom,
+      const amrex::Real time,
+      const amrex::BCRec* bcr,
+      const int /*bcomp*/,
+      const int /*orig_comp*/) const
+   {
+
+      // Get geometry data
+      const int* domlo = geom.Domain().loVect();
+      const int* domhi = geom.Domain().hiVect();
+      const amrex::Real* prob_lo = geom.ProbLo();
+      const amrex::Real* dx = geom.CellSize();
+      const amrex::Real x[AMREX_SPACEDIM] = {AMREX_D_DECL(prob_lo[0] + (iv[0] + 0.5) * dx[0],
+                                                          prob_lo[1] + (iv[1] + 0.5) * dx[1],
+                                                          prob_lo[2] + (iv[2] + 0.5) * dx[2])};
+
+      for (int idir = 0; idir < AMREX_SPACEDIM; idir++) {
+
+         // Low
+         for (int n = 0; n < NVAR; n++) {
+
+            // bcnormal handles all the state components at once
+            amrex::Real s_ext[NVAR] = {0.0};
+
+            // Get current state component BC
+            const int* bc = bcr[n].data();
+
+            if ((bc[idir] == amrex::BCType::ext_dir) and (iv[idir] < domlo[idir])) {
+
+               // bcnormal() is defined in pelelm_prob.H in problem directory in /Exec
+               bcnormal(x, m_nAux, s_ext, idir, 1, time, geom, *lprobparm, lpmfdata);
+               state(iv,n) = s_ext[n];
+               // TODO handle velocity exceptions
+            }
+         }
+
+         // High
+         for (int n = 0; n < NVAR; n++) {
+
+            // bcnormal handles all the state components at once
+            amrex::Real s_ext[NVAR] = {0.0};
+
+            // Get current state component BC
+            const int* bc = bcr[n].data();
+
+            if ((bc[idir+AMREX_SPACEDIM] == amrex::BCType::ext_dir) and (iv[idir] > domhi[idir])) {
+
+               // bcnormal() is defined in pelelm_prob.H in problem directory in /Exec
+               bcnormal(x, m_nAux, s_ext, idir, -1, time, geom, *lprobparm, lpmfdata);
+               state(iv,n) = s_ext[n];
+               // TODO handle velocity exceptions
+            }
+         }
+      }
+   }
+};
+
 struct PeleLMCCFillExtDirVel
 {
 
@@ -96,7 +171,7 @@ struct PeleLMCCFillExtDirSpec
    void operator()(
       const amrex::IntVect& iv,
       amrex::Array4<amrex::Real> const& rhoY,
-      const int /*dcomp*/,
+      const int dcomp,
       const int /*numcomp*/,
       amrex::GeometryData const& geom,
       const amrex::Real time,
@@ -129,7 +204,7 @@ struct PeleLMCCFillExtDirSpec
                // bcnormal() is defined in pelelm_prob.H in problem directory in /Exec
                bcnormal(x, m_nAux, s_ext, idir, 1, time, geom, *lprobparm, lpmfdata);
 
-               rhoY(iv,n) = s_ext[FIRSTSPEC+n];
+               rhoY(iv,dcomp+n) = s_ext[FIRSTSPEC+n];
 
             // High
             } else if ((bc[idir+AMREX_SPACEDIM] == amrex::BCType::ext_dir) and (iv[idir] > domhi[idir])) {
@@ -137,7 +212,7 @@ struct PeleLMCCFillExtDirSpec
                // bcnormal() is defined in pelelm_prob.H in problem directory in /Exec
                bcnormal(x, m_nAux, s_ext, idir, -1, time, geom, *lprobparm, lpmfdata);
 
-               rhoY(iv,n) = s_ext[FIRSTSPEC+n];
+               rhoY(iv,dcomp+n) = s_ext[FIRSTSPEC+n];
             }
          }
       }
@@ -159,8 +234,8 @@ struct PeleLMCCFillExtDirDens
    AMREX_GPU_DEVICE
    void operator()(
       const amrex::IntVect& iv,
-      amrex::Array4<amrex::Real> const& rho,
-      const int /*dcomp*/,
+      amrex::Array4<amrex::Real> const& state,
+      const int dcomp,
       const int /*numcomp*/,
       amrex::GeometryData const& geom,
       const amrex::Real time,
@@ -191,7 +266,7 @@ struct PeleLMCCFillExtDirDens
             // bcnormal() is defined in pelelm_prob.H in problem directory in /Exec
             bcnormal(x, m_nAux, s_ext, idir, 1, time, geom, *lprobparm, lpmfdata);
 
-            rho(iv) = s_ext[DENSITY];
+            state(iv,dcomp) = s_ext[DENSITY];
 
          // High
          } else if ((bc[idir+AMREX_SPACEDIM] == amrex::BCType::ext_dir) and (iv[idir] > domhi[idir])) {
@@ -199,7 +274,7 @@ struct PeleLMCCFillExtDirDens
             // bcnormal() is defined in pelelm_prob.H in problem directory in /Exec
             bcnormal(x, m_nAux, s_ext, idir, -1, time, geom, *lprobparm, lpmfdata);
 
-            rho(iv) = s_ext[DENSITY];
+            state(iv,dcomp) = s_ext[DENSITY];
 
          }
       }
@@ -283,14 +358,14 @@ struct PeleLMCCFillExtDirTemp
    AMREX_GPU_DEVICE
    void operator()(
       const amrex::IntVect& iv,
-      amrex::Array4<amrex::Real> const& temp,
-      const int /*dcomp*/,
+      amrex::Array4<amrex::Real> const& state,
+      const int dcomp,
       const int /*numcomp*/,
       amrex::GeometryData const& geom,
       const amrex::Real time,
       const amrex::BCRec* bcr,
-      const int /*bcomp*/,
-      const int /*orig_comp*/) const
+      const int bcomp,
+      const int orig_comp) const
    {
 
       // Get geometry data
@@ -315,7 +390,7 @@ struct PeleLMCCFillExtDirTemp
             // bcnormal() is defined in pelelm_prob.H in problem directory in /Exec
             bcnormal(x, m_nAux, s_ext, idir, 1, time, geom, *lprobparm, lpmfdata);
 
-            temp(iv) = s_ext[TEMP];
+            state(iv,dcomp) = s_ext[TEMP];
 
          // High
          } else if ((bc[idir+AMREX_SPACEDIM] == amrex::BCType::ext_dir) and (iv[idir] > domhi[idir])) {
@@ -323,7 +398,7 @@ struct PeleLMCCFillExtDirTemp
             // bcnormal() is defined in pelelm_prob.H in problem directory in /Exec
             bcnormal(x, m_nAux, s_ext, idir, -1, time, geom, *lprobparm, lpmfdata);
 
-            temp(iv) = s_ext[TEMP];
+            state(iv,dcomp) = s_ext[TEMP];
 
          }
       }

--- a/Source/PeleLMBCfill.H
+++ b/Source/PeleLMBCfill.H
@@ -53,10 +53,17 @@ struct PeleLMCCFillExtDirState
 
             if ((bc[idir] == amrex::BCType::ext_dir) and (iv[idir] < domlo[idir])) {
 
+#ifdef PELE_USE_TURBINFLOW
+               // If using TurbInflow, pass in the turbulent data. User can overwrite if needed
+               if ( n >= VELX && n < DENSITY ) {
+                  for (int n = 0; n < AMREX_SPACEDIM; n++) {
+                     s_ext[VELX+n] = vel(iv,n);
+                  }
+               }
+#endif
                // bcnormal() is defined in pelelm_prob.H in problem directory in /Exec
                bcnormal(x, m_nAux, s_ext, idir, 1, time, geom, *lprobparm, lpmfdata);
                state(iv,n) = s_ext[n];
-               // TODO handle velocity exceptions
             }
          }
 
@@ -71,10 +78,17 @@ struct PeleLMCCFillExtDirState
 
             if ((bc[idir+AMREX_SPACEDIM] == amrex::BCType::ext_dir) and (iv[idir] > domhi[idir])) {
 
+#ifdef PELE_USE_TURBINFLOW
+               // If using TurbInflow, pass in the turbulent data. User can overwrite if needed
+               if ( n >= VELX && n < DENSITY ) {
+                  for (int n = 0; n < AMREX_SPACEDIM; n++) {
+                     s_ext[VELX+n] = vel(iv,n);
+                  }
+               }
+#endif
                // bcnormal() is defined in pelelm_prob.H in problem directory in /Exec
                bcnormal(x, m_nAux, s_ext, idir, -1, time, geom, *lprobparm, lpmfdata);
                state(iv,n) = s_ext[n];
-               // TODO handle velocity exceptions
             }
          }
       }

--- a/Source/PeleLMData.cpp
+++ b/Source/PeleLMData.cpp
@@ -8,17 +8,12 @@ PeleLM::LevelData::LevelData(amrex::BoxArray const& ba,
                              int a_incompressible, int a_has_divu, 
                              int a_nAux, int a_nGrowState, int a_nGrowMAC)
 {
-   velocity.define(ba, dm, AMREX_SPACEDIM, a_nGrowState, MFInfo(), factory);
+   state.define(   ba, dm, NVAR          , a_nGrowState, MFInfo(), factory);
    gp.define(      ba, dm, AMREX_SPACEDIM, 0           , MFInfo(), factory);
    press.define(   amrex::convert(ba,IntVect::TheNodeVector()),
                        dm, 1             , 1           , MFInfo(), factory);
    visc_cc.define( ba, dm, 1             , 1           , MFInfo(), factory);
    if (! a_incompressible ) {
-      density.define (ba, dm, 1             , a_nGrowState, MFInfo(), factory);
-      species.define (ba, dm, NUM_SPECIES   , a_nGrowState, MFInfo(), factory);
-      rhoh.define    (ba, dm, 1             , a_nGrowState, MFInfo(), factory);
-      rhoRT.define   (ba, dm, 1             , a_nGrowState, MFInfo(), factory);
-      temp.define    (ba, dm, 1             , a_nGrowState, MFInfo(), factory);
       if (a_has_divu) {   
          divu.define (ba, dm, 1             , 1           , MFInfo(), factory);
       }
@@ -156,13 +151,8 @@ void
 PeleLM::copyStateNewToOld(int nGhost) {
    AMREX_ASSERT(nGhost<=m_nGrowState);
    for (int lev = 0; lev <= finest_level; lev++ ) {
-      MultiFab::Copy(m_leveldata_old[lev]->velocity,m_leveldata_new[lev]->velocity,0,0,AMREX_SPACEDIM,nGhost);
+      MultiFab::Copy(m_leveldata_old[lev]->state,m_leveldata_new[lev]->state,0,0,NVAR,nGhost);
       if ( !m_incompressible ) {
-         MultiFab::Copy(m_leveldata_old[lev]->density,m_leveldata_new[lev]->density,0,0,1,nGhost);
-         MultiFab::Copy(m_leveldata_old[lev]->species,m_leveldata_new[lev]->species,0,0,NUM_SPECIES,nGhost);
-         MultiFab::Copy(m_leveldata_old[lev]->rhoh,m_leveldata_new[lev]->rhoh,0,0,1,nGhost);
-         MultiFab::Copy(m_leveldata_old[lev]->temp,m_leveldata_new[lev]->temp,0,0,1,nGhost);
-         MultiFab::Copy(m_leveldata_old[lev]->rhoRT,m_leveldata_new[lev]->rhoRT,0,0,1,nGhost);
          if ( m_has_divu ) {
             MultiFab::Copy(m_leveldata_old[lev]->divu,m_leveldata_new[lev]->divu,0,0,1,std::min(nGhost,1));
          }
@@ -186,13 +176,8 @@ void
 PeleLM::copyStateOldToNew(int nGhost) {
    AMREX_ASSERT(nGhost<=m_nGrowState);
    for (int lev = 0; lev <= finest_level; lev++ ) {
-      MultiFab::Copy(m_leveldata_new[lev]->velocity,m_leveldata_old[lev]->velocity,0,0,AMREX_SPACEDIM,nGhost);
+      MultiFab::Copy(m_leveldata_new[lev]->state,m_leveldata_old[lev]->state,0,0,NVAR,nGhost);
       if ( !m_incompressible ) {
-         MultiFab::Copy(m_leveldata_new[lev]->density,m_leveldata_old[lev]->density,0,0,1,nGhost);
-         MultiFab::Copy(m_leveldata_new[lev]->species,m_leveldata_old[lev]->species,0,0,NUM_SPECIES,nGhost);
-         MultiFab::Copy(m_leveldata_new[lev]->rhoh,m_leveldata_old[lev]->rhoh,0,0,1,nGhost);
-         MultiFab::Copy(m_leveldata_new[lev]->temp,m_leveldata_old[lev]->temp,0,0,1,nGhost);
-         MultiFab::Copy(m_leveldata_new[lev]->rhoRT,m_leveldata_old[lev]->rhoRT,0,0,1,nGhost);
          if ( m_has_divu ) {
             MultiFab::Copy(m_leveldata_new[lev]->divu,m_leveldata_old[lev]->divu,0,0,1,std::min(nGhost,1));
          }

--- a/Source/PeleLMEB.cpp
+++ b/Source/PeleLMEB.cpp
@@ -217,17 +217,7 @@ void PeleLM::setCoveredState(int lev, const TimeStamp &a_time)
 
     auto ldata_p = getLevelDataPtr(lev,a_time);
 
-    // TODO: do a single kernel launch there
-    EB_set_covered(ldata_p->velocity,coveredState_h[0]);
-    EB_set_covered(ldata_p->density,coveredState_h[DENSITY]);
-    Vector<Real> covSpec(NUM_SPECIES);
-    for (int n = 0; n<NUM_SPECIES; n++) {
-        covSpec[n] = coveredState_h[FIRSTSPEC+n];
-    }
-    EB_set_covered(ldata_p->species,0,NUM_SPECIES,covSpec);
-    EB_set_covered(ldata_p->rhoh,coveredState_h[RHOH]);
-    EB_set_covered(ldata_p->temp,coveredState_h[TEMP]);
-    EB_set_covered(ldata_p->rhoRT,coveredState_h[RHORT]);
+    EB_set_covered(ldata_p->state,0,NVAR,coveredState_h);
 }
 
 void PeleLM::initialRedistribution()
@@ -241,43 +231,21 @@ void PeleLM::initialRedistribution()
             // New time
             Real timeNew = getTime(lev, AmrNewTime);
 
-            // Jugle with Old/New states: fillPatch old and redistribute
+            // Jungle with Old/New states: fillPatch old and redistribute
             // from Old->New to end up with proper New state
             auto ldataOld_p = getLevelDataPtr(lev,AmrOldTime);
             auto ldataNew_p = getLevelDataPtr(lev,AmrNewTime);
 
             auto const& fact = EBFactory(lev);
 
-            // Velocities
-            EB_set_covered(ldataNew_p->velocity,0.0);
-            ldataNew_p->velocity.FillBoundary(geom[lev].periodicity());
-            MultiFab::Copy(ldataOld_p->velocity, ldataNew_p->velocity, 0, 0, AMREX_SPACEDIM, m_nGrowState);
-            fillpatch_velocity(lev, timeNew, ldataOld_p->velocity, m_nGrowState);
+            // State
+            Vector<Real> stateCovered(NVAR,0.0);
+            EB_set_covered(ldataNew_p->state,0,NVAR,stateCovered);
+            ldataNew_p->state.FillBoundary(geom[lev].periodicity());
+            MultiFab::Copy(ldataOld_p->state, ldataNew_p->state, 0, 0, NVAR, m_nGrowState);
+            fillpatch_state(lev, timeNew, ldataOld_p->state, m_nGrowState);
 
-            if (!m_incompressible) {
-
-                // Mass
-                EB_set_covered(ldataNew_p->density,0.0);
-                ldataNew_p->density.FillBoundary(geom[lev].periodicity());
-                MultiFab::Copy(ldataOld_p->density, ldataNew_p->density, 0, 0, 1, m_nGrowState);
-                fillpatch_density(lev, timeNew, ldataOld_p->density, m_nGrowState);
-
-                EB_set_covered(ldataNew_p->species,0.0);
-                ldataNew_p->species.FillBoundary(geom[lev].periodicity());
-                MultiFab::Copy(ldataOld_p->species, ldataNew_p->species, 0, 0, NUM_SPECIES, m_nGrowState);
-                fillpatch_species(lev, timeNew, ldataOld_p->species, m_nGrowState);
-
-                // Energy
-                EB_set_covered(ldataNew_p->rhoh,0.0);
-                ldataNew_p->rhoh.FillBoundary(geom[lev].periodicity());
-                MultiFab::Copy(ldataOld_p->rhoh, ldataNew_p->rhoh, 0, 0, 1, m_nGrowState);
-                EB_set_covered(ldataNew_p->temp,0.0);
-                ldataNew_p->temp.FillBoundary(geom[lev].periodicity());
-                MultiFab::Copy(ldataOld_p->temp, ldataNew_p->temp, 0, 0, 1, m_nGrowState);
-                fillpatch_energy(lev, timeNew, ldataOld_p->rhoh, ldataOld_p->temp, m_nGrowState);
-            }
-
-            for (MFIter mfi(ldataNew_p->velocity,TilingIfNotGPU()); mfi.isValid(); ++mfi) {   
+            for (MFIter mfi(ldataNew_p->state,TilingIfNotGPU()); mfi.isValid(); ++mfi) {   
 
                 const Box& bx = mfi.validbox();
 
@@ -297,41 +265,13 @@ void PeleLM::initialRedistribution()
                                  apz = fact.getAreaFrac()[2]->const_array(mfi););
                     vfrac = fact.getVolFrac().const_array(mfi);
 
-                    auto bcRecVel = fetchBCRecArray(VELX,AMREX_SPACEDIM); 
-                    auto bcRecVel_d = convertToDeviceVector(bcRecVel);
-                    Redistribution::ApplyToInitialData( bx, AMREX_SPACEDIM,
-                                                        ldataNew_p->velocity.array(mfi), ldataOld_p->velocity.array(mfi),
+                    auto bcRec = fetchBCRecArray(0,NVAR); 
+                    auto bcRec_d = convertToDeviceVector(bcRec);
+                    Redistribution::ApplyToInitialData( bx, NVAR,
+                                                        ldataNew_p->state.array(mfi,0), ldataOld_p->state.array(mfi,0),
                                                         flag, AMREX_D_DECL(apx, apy, apz), vfrac,
                                                         AMREX_D_DECL(fcx, fcy, fcz), ccc,
-                                                        bcRecVel_d.dataPtr(), geom[lev], m_adv_redist_type);
-                    if (!m_incompressible) {
-                        auto bcRec = fetchBCRecArray(FIRSTSPEC,NUM_SPECIES); 
-                        auto bcRec_d = convertToDeviceVector(bcRec);
-                        Redistribution::ApplyToInitialData( bx, 1,
-                                                            ldataNew_p->density.array(mfi), ldataOld_p->density.array(mfi),
-                                                            flag, AMREX_D_DECL(apx, apy, apz), vfrac,
-                                                            AMREX_D_DECL(fcx, fcy, fcz), ccc,
-                                                            bcRec_d.dataPtr(), geom[lev], m_adv_redist_type);
-                        Redistribution::ApplyToInitialData( bx, NUM_SPECIES,
-                                                            ldataNew_p->species.array(mfi), ldataOld_p->species.array(mfi),
-                                                            flag, AMREX_D_DECL(apx, apy, apz), vfrac,
-                                                            AMREX_D_DECL(fcx, fcy, fcz), ccc,
-                                                            bcRec_d.dataPtr(), geom[lev], m_adv_redist_type);
-                        auto bcRecRhoH = fetchBCRecArray(RHOH,1); 
-                        auto bcRecRhoH_d = convertToDeviceVector(bcRecRhoH);
-                        Redistribution::ApplyToInitialData( bx, 1,
-                                                            ldataNew_p->rhoh.array(mfi), ldataOld_p->rhoh.array(mfi),
-                                                            flag, AMREX_D_DECL(apx, apy, apz), vfrac,
-                                                            AMREX_D_DECL(fcx, fcy, fcz), ccc,
-                                                            bcRecRhoH_d.dataPtr(), geom[lev], m_adv_redist_type);
-                        auto bcRecTemp = fetchBCRecArray(TEMP,1); 
-                        auto bcRecTemp_d = convertToDeviceVector(bcRecTemp);
-                        Redistribution::ApplyToInitialData( bx, 1,
-                                                            ldataNew_p->temp.array(mfi), ldataOld_p->temp.array(mfi),
-                                                            flag, AMREX_D_DECL(apx, apy, apz), vfrac,
-                                                            AMREX_D_DECL(fcx, fcy, fcz), ccc,
-                                                            bcRecTemp_d.dataPtr(), geom[lev], m_adv_redist_type);
-                    }
+                                                        bcRec_d.dataPtr(), geom[lev], m_adv_redist_type);
                 }
             }
         }

--- a/Source/PeleLMEos.cpp
+++ b/Source/PeleLMEos.cpp
@@ -25,13 +25,13 @@ void PeleLM::setThermoPress(int lev, const TimeStamp &a_time) {
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
    {
-      for (MFIter mfi(ldata_p->rhoRT,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      for (MFIter mfi(ldata_p->state,TilingIfNotGPU()); mfi.isValid(); ++mfi)
       {
          const Box& bx = mfi.tilebox();
-         auto const& rho     = ldata_p->density.const_array(mfi);
-         auto const& rhoY    = ldata_p->species.const_array(mfi);
-         auto const& T       = ldata_p->temp.const_array(mfi);
-         auto const& P       = ldata_p->rhoRT.array(mfi);
+         auto const& rho     = ldata_p->state.const_array(mfi,DENSITY);
+         auto const& rhoY    = ldata_p->state.const_array(mfi,FIRSTSPEC);
+         auto const& T       = ldata_p->state.const_array(mfi,TEMP);
+         auto const& P       = ldata_p->state.array(mfi,RHORT);
 
          amrex::ParallelFor(bx, [rho, rhoY, T, P]
          AMREX_GPU_DEVICE (int i, int j, int k) noexcept
@@ -103,8 +103,8 @@ void PeleLM::calcDivU(int is_init,
          auto const& flag    = flagfab.const_array();
 #endif
 
-         auto const& rhoY     = ldata_p->species.const_array(mfi);
-         auto const& T        = ldata_p->temp.const_array(mfi);
+         auto const& rhoY     = ldata_p->state.const_array(mfi,FIRSTSPEC);
+         auto const& T        = ldata_p->state.const_array(mfi,TEMP);
          auto const& SpecD    = ( a_time == AmrOldTime ) ? diffData->Dn[lev].const_array(mfi,0)
                                                          : diffData->Dnp1[lev].const_array(mfi,0);
          auto const& Fourier  = ( a_time == AmrOldTime ) ? diffData->Dn[lev].const_array(mfi,NUM_SPECIES)
@@ -112,7 +112,7 @@ void PeleLM::calcDivU(int is_init,
          auto const& DiffDiff = ( a_time == AmrOldTime ) ? diffData->Dn[lev].const_array(mfi,NUM_SPECIES+1)
                                                          : diffData->Dnp1[lev].const_array(mfi,NUM_SPECIES+1);
          auto const& r        = (m_do_react && !m_skipInstantRR) ? RhoYdot.const_array(mfi)
-                                             : ldata_p->species.const_array(mfi);   // Dummy unused Array4
+                                             : ldata_p->state.const_array(mfi,FIRSTSPEC);   // Dummy unused Array4
          auto const& divu     = ldata_p->divu.array(mfi);
          int use_react        = (m_do_react && !m_skipInstantRR) ? 1 : 0;
 
@@ -191,13 +191,13 @@ void PeleLM::setTemperature(int lev, const TimeStamp &a_time) {
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
    {
-      for (MFIter mfi(ldata_p->temp,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      for (MFIter mfi(ldata_p->state,TilingIfNotGPU()); mfi.isValid(); ++mfi)
       {
          const Box& bx = mfi.tilebox();
-         auto const& rho     = ldata_p->density.const_array(mfi);
-         auto const& rhoY    = ldata_p->species.const_array(mfi);
-         auto const& rhoh    = ldata_p->rhoh.const_array(mfi);
-         auto const& T       = ldata_p->temp.array(mfi);
+         auto const& rho     = ldata_p->state.const_array(mfi,DENSITY);
+         auto const& rhoY    = ldata_p->state.const_array(mfi,FIRSTSPEC);
+         auto const& rhoh    = ldata_p->state.const_array(mfi,RHOH);
+         auto const& T       = ldata_p->state.array(mfi,TEMP);
 
          amrex::ParallelFor(bx, [rho, rhoY, rhoh, T]
          AMREX_GPU_DEVICE (int i, int j, int k) noexcept
@@ -245,7 +245,7 @@ void PeleLM::calc_dPdt(int lev,
    {
       const Box& bx = mfi.tilebox();
       auto const& dPdt  = a_dPdt->array(mfi);
-      auto const& P     = ldata_p->rhoRT.const_array(mfi);
+      auto const& P     = ldata_p->state.const_array(mfi,RHORT);
       amrex::ParallelFor(bx, [dPdt, P, p_amb, dt=m_dt, dpdt_fac=m_dpdtFactor]
       AMREX_GPU_DEVICE (int i, int j, int k) noexcept
       {
@@ -275,10 +275,10 @@ PeleLM::adjustPandDivU(std::unique_ptr<AdvanceAdvData> &advData)
         for (MFIter mfi(*ThetaHalft[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
             const Box& bx = mfi.tilebox();
-            auto const& rhoYo  = ldataOld_p->species.const_array(mfi);
-            auto const& rhoYn  = ldataNew_p->species.const_array(mfi);
-            auto const& T_o    = ldataOld_p->temp.const_array(mfi);
-            auto const& T_n    = ldataNew_p->temp.const_array(mfi);
+            auto const& rhoYo  = ldataOld_p->state.const_array(mfi,FIRSTSPEC);
+            auto const& rhoYn  = ldataNew_p->state.const_array(mfi,FIRSTSPEC);
+            auto const& T_o    = ldataOld_p->state.const_array(mfi,TEMP);
+            auto const& T_n    = ldataNew_p->state.const_array(mfi,TEMP);
             auto const& theta  = ThetaHalft[lev]->array(mfi);
             amrex::ParallelFor(bx, [=,pOld=m_pOld,pNew=m_pNew]
             AMREX_GPU_DEVICE (int i, int j, int k) noexcept

--- a/Source/PeleLMForces.cpp
+++ b/Source/PeleLMForces.cpp
@@ -54,11 +54,11 @@ void PeleLM::getVelForces(const TimeStamp &a_time,
    {    
       const auto& bx          = mfi.tilebox();
       FArrayBox DummyFab(bx,1);
-      const auto& vel_arr     = ldata_p->velocity.const_array(mfi);
-      const auto& rho_arr     = (m_incompressible) ? DummyFab.array() : ldata_p->density.const_array(mfi);
-      const auto& rhoY_arr    = (m_incompressible) ? DummyFab.array() : ldata_p->species.const_array(mfi);
-      const auto& rhoh_arr    = (m_incompressible) ? DummyFab.array() : ldata_p->rhoh.const_array(mfi);
-      const auto& temp_arr    = (m_incompressible) ? DummyFab.array() : ldata_p->temp.const_array(mfi);
+      const auto& vel_arr     = ldata_p->state.const_array(mfi,VELX);
+      const auto& rho_arr     = (m_incompressible) ? DummyFab.array() : ldata_p->state.const_array(mfi,DENSITY);
+      const auto& rhoY_arr    = (m_incompressible) ? DummyFab.array() : ldata_p->state.const_array(mfi,FIRSTSPEC);
+      const auto& rhoh_arr    = (m_incompressible) ? DummyFab.array() : ldata_p->state.const_array(mfi,RHOH);
+      const auto& temp_arr    = (m_incompressible) ? DummyFab.array() : ldata_p->state.const_array(mfi,TEMP);
       const auto& force_arr   = a_velForce->array(mfi);
 
       // Get other forces (gravity, ...)

--- a/Source/PeleLMInit.cpp
+++ b/Source/PeleLMInit.cpp
@@ -286,15 +286,15 @@ void PeleLM::initLevelData(int lev) {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-   for (MFIter mfi(ldata_p->velocity,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+   for (MFIter mfi(ldata_p->state,TilingIfNotGPU()); mfi.isValid(); ++mfi)
    {
       const Box& bx = mfi.tilebox();
       FArrayBox DummyFab(bx,1);
-      auto  const &vel_arr   = ldata_p->velocity.array(mfi);
-      auto  const &rho_arr   = (m_incompressible) ? DummyFab.array() : ldata_p->density.array(mfi);
-      auto  const &rhoY_arr  = (m_incompressible) ? DummyFab.array() : ldata_p->species.array(mfi);
-      auto  const &rhoH_arr  = (m_incompressible) ? DummyFab.array() : ldata_p->rhoh.array(mfi);
-      auto  const &temp_arr  = (m_incompressible) ? DummyFab.array() : ldata_p->temp.array(mfi);
+      auto  const &vel_arr   = ldata_p->state.array(mfi,VELX);
+      auto  const &rho_arr   = (m_incompressible) ? DummyFab.array() : ldata_p->state.array(mfi,DENSITY);
+      auto  const &rhoY_arr  = (m_incompressible) ? DummyFab.array() : ldata_p->state.array(mfi,FIRSTSPEC);
+      auto  const &rhoH_arr  = (m_incompressible) ? DummyFab.array() : ldata_p->state.array(mfi,RHOH);
+      auto  const &temp_arr  = (m_incompressible) ? DummyFab.array() : ldata_p->state.array(mfi,TEMP);
       auto  const &aux_arr   = (m_nAux > 0) ? ldata_p->auxiliaries.array(mfi) : DummyFab.array();
 #ifdef PELE_USE_EFIELD
       auto  const &ne_arr    = ldata_p->nE.array(mfi);

--- a/Source/PeleLMInit.cpp
+++ b/Source/PeleLMInit.cpp
@@ -207,6 +207,12 @@ void PeleLM::initData() {
 
             initialProjection();
          }
+         if ( m_numDivuIter == 0 ) {
+            for (int lev = 0; lev <= finest_level; ++lev) {
+               auto ldataR_p   = getLevelDataReactPtr(lev);
+               ldataR_p->I_R.setVal(0.0);
+            }
+         }
       }
 
       //----------------------------------------------------------------

--- a/Source/PeleLMProjection.cpp
+++ b/Source/PeleLMProjection.cpp
@@ -33,9 +33,9 @@ void PeleLM::initialProjection()
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-         for (MFIter mfi(ldata_p->density,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+         for (MFIter mfi(ldata_p->state,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
             Box const& bx = mfi.tilebox();
-            auto const& rho_arr = ldata_p->density.const_array(mfi);
+            auto const& rho_arr = ldata_p->state.const_array(mfi,DENSITY);
             auto const& sig_arr = sigma[lev]->array(mfi);
             amrex::ParallelFor(bx, [rho_arr,sig_arr,dummy_dt]
             AMREX_GPU_DEVICE (int i, int j, int k) noexcept
@@ -47,9 +47,9 @@ void PeleLM::initialProjection()
    }
 
    // Get velocity
-   Vector<MultiFab*> vel;
+   Vector<std::unique_ptr<MultiFab> > vel;
    for (int lev = 0; lev <= finest_level; ++lev) {
-      vel.push_back(&(m_leveldata_new[lev]->velocity));
+      vel.push_back(std::make_unique<MultiFab> (m_leveldata_new[lev]->state, amrex::make_alias,VELX,AMREX_SPACEDIM));
       vel[lev]->setBndry(0.0);
       setInflowBoundaryVel(*vel[lev],lev,AmrNewTime);
    }
@@ -72,7 +72,7 @@ void PeleLM::initialProjection()
       }
    }
 
-   doNodalProject(vel, amrex::GetVecOfPtrs(sigma), rhs_cc, {}, incremental, dummy_dt);
+   doNodalProject(GetVecOfPtrs(vel), GetVecOfPtrs(sigma), rhs_cc, {}, incremental, dummy_dt);
 
    // Set back press and gpress to zero and restore divu
    for (int lev = 0; lev <= finest_level; lev++) {
@@ -112,9 +112,9 @@ void PeleLM::velocityProjection(int is_initIter,
    int incremental = (is_initIter) ? 1 : 0;
 
    // Get sigma : scaled density inv. if not incompressible
-   Vector<std::unique_ptr<MultiFab>> sigma(finest_level+1);
+   Vector<std::unique_ptr<MultiFab> > sigma(finest_level+1);
    if (! m_incompressible ) {
-      Vector<MultiFab*> rhoHalf(finest_level+1);
+      Vector<std::unique_ptr<MultiFab> > rhoHalf(finest_level+1);
       rhoHalf = getDensityVect(a_rhoTime);
       for (int lev = 0; lev <= finest_level; ++lev ) {
 
@@ -140,7 +140,7 @@ void PeleLM::velocityProjection(int is_initIter,
    }
 
    if (!incremental) {
-      Vector<MultiFab*> rhoHalf(finest_level+1);
+      Vector<std::unique_ptr<MultiFab> > rhoHalf(finest_level+1);
       if (!m_incompressible) rhoHalf = getDensityVect(a_rhoTime);
       for (int lev = 0; lev <= finest_level; ++lev ) {
 
@@ -150,9 +150,9 @@ void PeleLM::velocityProjection(int is_initIter,
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-         for (MFIter mfi(ldataNew_p->velocity,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+         for (MFIter mfi(ldataNew_p->state,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
             Box const& bx = mfi.tilebox();
-            auto const& vel_arr = ldataNew_p->velocity.array(mfi);
+            auto const& vel_arr = ldataNew_p->state.array(mfi,VELX);
             auto const& gp_arr  = ldataOld_p->gp.const_array(mfi);
             auto const& rho_arr = (m_incompressible) ? Array4<Real const>() : rhoHalf[lev]->const_array(mfi);
             amrex::ParallelFor(bx, [vel_arr,gp_arr,rho_arr,a_dt,
@@ -175,19 +175,18 @@ void PeleLM::velocityProjection(int is_initIter,
       for (int lev = 0; lev <= finest_level; ++lev) {
          auto ldataOld_p = getLevelDataPtr(lev,AmrOldTime);
          auto ldataNew_p = getLevelDataPtr(lev,AmrNewTime);
-         MultiFab::Subtract(ldataNew_p->velocity,
-                            ldataOld_p->velocity,
-                            0,0,AMREX_SPACEDIM,0);
+         MultiFab::Subtract(ldataNew_p->state,
+                            ldataOld_p->state,
+                            VELX,VELX,AMREX_SPACEDIM,0);
       }
    }
 
    // Get velocity
-   Vector<MultiFab*> vel;
+   Vector<std::unique_ptr<MultiFab> > vel;
    for (int lev = 0; lev <= finest_level; ++lev) {
-      auto ldata_p = getLevelDataPtr(lev,AmrNewTime);
-      vel.push_back(&(ldata_p->velocity));
+      vel.push_back(std::make_unique<MultiFab> (m_leveldata_new[lev]->state,amrex::make_alias,VELX,AMREX_SPACEDIM));
 #ifdef AMREX_USE_EB
-       EB_set_covered(*vel[lev],0.0);
+      EB_set_covered(*vel[lev],0.0);
 #endif
       vel[lev]->setBndry(0.0);
       if (!incremental) setInflowBoundaryVel(*vel[lev],lev,AmrNewTime);
@@ -247,7 +246,7 @@ void PeleLM::velocityProjection(int is_initIter,
       }
    }
 
-   doNodalProject(vel, GetVecOfPtrs(sigma), GetVecOfPtrs(rhs_cc), {}, incremental, a_dt);
+   doNodalProject(GetVecOfPtrs(vel), GetVecOfPtrs(sigma), GetVecOfPtrs(rhs_cc), {}, incremental, a_dt);
 
    // If incremental
    // define back to be U^{np1} by adding U^{n}
@@ -255,15 +254,15 @@ void PeleLM::velocityProjection(int is_initIter,
       for (int lev = 0; lev <= finest_level; ++lev) {
          auto ldataOld_p = getLevelDataPtr(lev,AmrOldTime);
          auto ldataNew_p = getLevelDataPtr(lev,AmrNewTime);
-         MultiFab::Add(ldataNew_p->velocity,
-                       ldataOld_p->velocity,
-                       0,0,AMREX_SPACEDIM,0);
+         MultiFab::Add(ldataNew_p->state,
+                       ldataOld_p->state,
+                       VELX,VELX,AMREX_SPACEDIM,0);
       }
    }
 
 }
 
-void PeleLM::doNodalProject(Vector<MultiFab*> &a_vel,
+void PeleLM::doNodalProject(const Vector<MultiFab*> &a_vel,
                             const Vector<MultiFab*> &a_sigma,
                             const Vector<MultiFab*> &rhs_cc,
                             const Vector<const MultiFab*> &rhs_nd,

--- a/Source/PeleLMReactions.cpp
+++ b/Source/PeleLMReactions.cpp
@@ -54,15 +54,15 @@ void PeleLM::advanceChemistry(int lev,
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-   for (MFIter mfi(ldataNew_p->density,amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+   for (MFIter mfi(ldataNew_p->state,amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
    {
       const Box& bx          = mfi.tilebox();
-      auto const& rhoY_o     = ldataOld_p->species.const_array(mfi);
-      auto const& rhoH_o     = ldataOld_p->rhoh.const_array(mfi);
-      auto const& temp_o     = ldataOld_p->temp.const_array(mfi);
-      auto const& rhoY_n     = ldataNew_p->species.array(mfi);
-      auto const& rhoH_n     = ldataNew_p->rhoh.array(mfi);
-      auto const& temp_n     = ldataNew_p->temp.array(mfi);
+      auto const& rhoY_o     = ldataOld_p->state.const_array(mfi,FIRSTSPEC);
+      auto const& rhoH_o     = ldataOld_p->state.const_array(mfi,RHOH);
+      auto const& temp_o     = ldataOld_p->state.const_array(mfi,TEMP);
+      auto const& rhoY_n     = ldataNew_p->state.array(mfi,FIRSTSPEC);
+      auto const& rhoH_n     = ldataNew_p->state.array(mfi,RHOH);
+      auto const& temp_n     = ldataNew_p->state.array(mfi,TEMP);
       auto const& extF_rhoY  = a_extForcing.array(mfi,0);
       auto const& extF_rhoH  = a_extForcing.array(mfi,NUM_SPECIES);
       auto const& fcl        = ldataR_p->functC.array(mfi);
@@ -85,7 +85,7 @@ void PeleLM::advanceChemistry(int lev,
       // Pass nE -> rhoY_e & FnE -> FrhoY_e
       auto const& nE_o    = ldataOld_p->nE.const_array(mfi);
       auto const& FnE     = a_extForcing.array(mfi,NUM_SPECIES+1);
-      auto const& rhoYe_n = ldataNew_p->species.array(mfi,E_ID);
+      auto const& rhoYe_n = ldataNew_p->state.array(mfi,FIRSTSPEC+E_ID);
       auto const& FrhoYe  = a_extForcing.array(mfi,E_ID);
       auto eos = pele::physics::PhysicsType::eos();
       Real mwt[NUM_SPECIES] = {0.0};
@@ -147,11 +147,11 @@ void PeleLM::advanceChemistry(int lev,
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-   for (MFIter mfi(ldataNew_p->density,amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+   for (MFIter mfi(ldataNew_p->state,amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
    {
       const Box& bx          = mfi.tilebox();
-      auto const& rhoY_o     = ldataOld_p->species.const_array(mfi);
-      auto const& rhoY_n     = ldataNew_p->species.const_array(mfi);
+      auto const& rhoY_o     = ldataOld_p->state.const_array(mfi,FIRSTSPEC);
+      auto const& rhoY_n     = ldataNew_p->state.const_array(mfi,FIRSTSPEC);
       auto const& extF_rhoY  = a_extForcing.const_array(mfi,0);
       auto const& rhoYdot    = ldataR_p->I_R.array(mfi,0);
       Real dt_inv = 1.0/a_dt;
@@ -328,14 +328,14 @@ void PeleLM::advanceChemistry(int lev,
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-   for (MFIter mfi(ldataNew_p->density,amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+   for (MFIter mfi(ldataNew_p->state,amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
    {
       const Box& bx          = mfi.tilebox();
       auto const& state_arr  = StateTemp.const_array(mfi);
-      auto const& rhoY_o     = ldataOld_p->species.const_array(mfi);
-      auto const& rhoY_n     = ldataNew_p->species.array(mfi);
-      auto const& rhoH_n     = ldataNew_p->rhoh.array(mfi);
-      auto const& temp_n     = ldataNew_p->temp.array(mfi);
+      auto const& rhoY_o     = ldataOld_p->state.const_array(mfi,FIRSTSPEC);
+      auto const& rhoY_n     = ldataNew_p->state.array(mfi,FIRSTSPEC);
+      auto const& rhoH_n     = ldataNew_p->state.array(mfi,RHOH);
+      auto const& temp_n     = ldataNew_p->state.array(mfi,TEMP);
       auto const& extF_rhoY  = a_extForcing.const_array(mfi,0);
       auto const& rhoYdot    = ldataR_p->I_R.array(mfi,0);
       Real dt_inv = 1.0/a_dt;
@@ -398,12 +398,12 @@ void PeleLM::computeInstantaneousReactionRate(int lev,
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-   for (MFIter mfi(ldata_p->species,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+   for (MFIter mfi(ldata_p->state,TilingIfNotGPU()); mfi.isValid(); ++mfi)
    {
       const Box& bx = mfi.tilebox();
-      auto const& rhoY    = ldata_p->species.const_array(mfi);
-      auto const& rhoH    = ldata_p->rhoh.const_array(mfi);
-      auto const& T       = ldata_p->temp.const_array(mfi);
+      auto const& rhoY    = ldata_p->state.const_array(mfi,FIRSTSPEC);
+      auto const& rhoH    = ldata_p->state.const_array(mfi,RHOH);
+      auto const& T       = ldata_p->state.const_array(mfi,TEMP);
       auto const& rhoYdot = a_I_R->array(mfi);
 
 #ifdef AMREX_USE_EB
@@ -456,10 +456,10 @@ void PeleLM::getScalarReactForce(std::unique_ptr<AdvanceAdvData> &advData)
       for (MFIter mfi(advData->Forcing[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
       {
          const Box& bx = mfi.tilebox();
-         auto const& rhoY_o     = ldataOld_p->species.const_array(mfi);
-         auto const& rhoH_o     = ldataOld_p->rhoh.const_array(mfi);
-         auto const& rhoY_n     = ldataNew_p->species.const_array(mfi);
-         auto const& rhoH_n     = ldataNew_p->rhoh.const_array(mfi);
+         auto const& rhoY_o     = ldataOld_p->state.const_array(mfi,FIRSTSPEC);
+         auto const& rhoH_o     = ldataOld_p->state.const_array(mfi,RHOH);
+         auto const& rhoY_n     = ldataNew_p->state.const_array(mfi,FIRSTSPEC);
+         auto const& rhoH_n     = ldataNew_p->state.const_array(mfi,RHOH);
          auto const& react      = ldataR_p->I_R.const_array(mfi,0);
          auto const& extF_rhoY  = advData->Forcing[lev].array(mfi,0);
          auto const& extF_rhoH  = advData->Forcing[lev].array(mfi,NUM_SPECIES);
@@ -494,7 +494,7 @@ void PeleLM::getHeatRelease(int a_lev,
            EnthFab.resize(bx,NUM_SPECIES);
            Elixir  Enthi   = EnthFab.elixir();
            auto const& react = ldataR_p->I_R.const_array(mfi,0);
-           auto const& T     = ldataNew_p->temp.const_array(mfi);
+           auto const& T     = ldataNew_p->state.const_array(mfi,TEMP);
            auto const& Hi    = EnthFab.array();
            auto const& HRR   = a_HR->array(mfi);
            amrex::ParallelFor(bx, [T, Hi, HRR, react]

--- a/Source/PeleLMRegrid.cpp
+++ b/Source/PeleLMRegrid.cpp
@@ -40,15 +40,11 @@ void PeleLM::MakeNewLevelFromCoarse( int lev,
                                                    m_nAux, m_nGrowState, m_nGrowMAC));
 
    // Fill the leveldata_new
-   fillcoarsepatch_velocity(lev, time, n_leveldata_new->velocity, 0);
+   fillcoarsepatch_state(lev, time, n_leveldata_new->state, 0);
    fillcoarsepatch_gradp(lev, time, n_leveldata_new->gp, 0);
    n_leveldata_new->press.setVal(0.0);
 
    if (!m_incompressible) {
-      fillcoarsepatch_mass(lev, time, n_leveldata_new->density,
-                           n_leveldata_new->species, 1);
-      fillcoarsepatch_energy(lev, time, n_leveldata_new->rhoh,
-                             n_leveldata_new->temp, 1);
       if (m_has_divu) {
          fillcoarsepatch_divu(lev, time, n_leveldata_new->divu,0);
       }
@@ -132,15 +128,11 @@ void PeleLM::RemakeLevel( int lev,
                                                    m_nAux, m_nGrowState, m_nGrowMAC));
 
    // Fill the leveldata_new
-   fillpatch_velocity(lev, time, n_leveldata_new->velocity, m_nGrowState);
+   fillpatch_state(lev, time, n_leveldata_new->state, m_nGrowState);
    fillpatch_gradp(lev, time, n_leveldata_new->gp, 0);
    n_leveldata_new->press.setVal(0.0);
 
    if (!m_incompressible) {
-      fillpatch_density(lev, time, n_leveldata_new->density, m_nGrowState);
-      fillpatch_species(lev, time, n_leveldata_new->species, m_nGrowState);
-      fillpatch_energy(lev, time, n_leveldata_new->rhoh,
-                       n_leveldata_new->temp, m_nGrowState);
       if (m_has_divu) {
          fillpatch_divu(lev, time, n_leveldata_new->divu, 1);
       }

--- a/Source/PeleLMTagging.cpp
+++ b/Source/PeleLMTagging.cpp
@@ -16,8 +16,8 @@ PeleLM::ErrorEst( int lev,
 
 #ifdef AMREX_USE_EB
    if (m_refine_cutcells) {
-      const MultiFab& rho = (getLevelDataPtr(lev,AmrNewTime))->density;
-      TagCutCells(tags, rho);
+      const MultiFab& state = (getLevelDataPtr(lev,AmrNewTime))->state;
+      TagCutCells(tags, state);
    }
 #endif
 

--- a/Source/PeleLMTimestep.cpp
+++ b/Source/PeleLMTimestep.cpp
@@ -91,7 +91,7 @@ PeleLM::estConvectiveDt(const TimeStamp &a_time) {
 
       // Get max velocity
       Vector<Real> u_max(AMREX_SPACEDIM);
-      u_max = ldata_p->velocity.norm0({AMREX_D_DECL(0,1,2)},0,true,true);
+      u_max = ldata_p->state.norm0({AMREX_D_DECL(VELX,VELY,VELZ)},0,true,true);
 
       //----------------------------------------------------------------
       // Est. min time step on lev
@@ -125,10 +125,11 @@ PeleLM::estDivUDt(const TimeStamp &a_time) {
    for (int lev = 0; lev <= finest_level; ++lev) {
 
       auto ldata_p = getLevelDataPtr(lev, a_time);
+      std::unique_ptr<MultiFab> density = std::make_unique <MultiFab>(ldata_p->state, amrex::make_alias, DENSITY, 1);
 
       auto dtfac = m_divu_dtFactor;
       auto rhoMin = m_divu_rhoMin;
-      Real divu_dt = amrex::ReduceMin(ldata_p->density, ldata_p->divu, 0,
+      Real divu_dt = amrex::ReduceMin(*density, ldata_p->divu, 0,
                                       [dtfac, rhoMin]
       AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& rho,
                                             Array4<Real const> const& divu ) noexcept -> Real

--- a/Source/PeleLMTransportProp.cpp
+++ b/Source/PeleLMTransportProp.cpp
@@ -26,8 +26,8 @@ void PeleLM::calcViscosity(const TimeStamp &a_time) {
          for (MFIter mfi(ldata_p->visc_cc, TilingIfNotGPU()); mfi.isValid(); ++mfi)
          {
             const Box& gbx     = mfi.growntilebox();
-            auto const& rhoY   = ldata_p->species.const_array(mfi);
-            auto const& T      = ldata_p->temp.array(mfi);
+            auto const& rhoY   = ldata_p->state.const_array(mfi,FIRSTSPEC);
+            auto const& T      = ldata_p->state.array(mfi,TEMP);
             auto const& mu     = ldata_p->visc_cc.array(mfi,0);
 
             amrex::ParallelFor(gbx, [rhoY, T, mu, ltransparm]
@@ -56,8 +56,8 @@ void PeleLM::calcDiffusivity(const TimeStamp &a_time) {
       for (MFIter mfi(ldata_p->diff_cc, TilingIfNotGPU()); mfi.isValid(); ++mfi)
       {
          const Box& gbx     = mfi.growntilebox();
-         auto const& rhoY   = ldata_p->species.const_array(mfi);
-         auto const& T      = ldata_p->temp.const_array(mfi);
+         auto const& rhoY   = ldata_p->state.const_array(mfi,FIRSTSPEC);
+         auto const& T      = ldata_p->state.const_array(mfi,TEMP);
          auto const& rhoD   = ldata_p->diff_cc.array(mfi,0);
          auto const& lambda = ldata_p->diff_cc.array(mfi,NUM_SPECIES);
          auto const& mu     = ldata_p->diff_cc.array(mfi,NUM_SPECIES+1);

--- a/Source/PeleLMUMac.cpp
+++ b/Source/PeleLMUMac.cpp
@@ -38,7 +38,7 @@ void PeleLM::predictVelocity(std::unique_ptr<AdvanceAdvData>  &advData,
    getVelForces(AmrOldTime,GetVecOfPtrs(divtau),GetVecOfPtrs(velForces),nGrow_force,add_gradP);
 
    //----------------------------------------------------------------
-   // Predict face velocities with Godunov
+   // Predict face velocities at t^{n+1/2} with Godunov
    auto bcRecVel = fetchBCRecArray(VELX,AMREX_SPACEDIM); 
    auto bcRecVel_d = convertToDeviceVector(bcRecVel);
    for (int lev = 0; lev <= finest_level; ++lev) {
@@ -51,7 +51,7 @@ void PeleLM::predictVelocity(std::unique_ptr<AdvanceAdvData>  &advData,
       const auto& ebfact = EBFactory(lev);
 #endif
 
-      HydroUtils::ExtrapVelToFaces(ldata_p->velocity,
+      HydroUtils::ExtrapVelToFaces(ldata_p->state,
                                    velForces[lev],
                                    AMREX_D_DECL(advData->umac[lev][0],
                                                 advData->umac[lev][1],
@@ -142,7 +142,7 @@ void PeleLM::macProject(const TimeStamp &a_time,
          }
       } else {
          auto ldata_p = getLevelDataPtr(lev,a_time);
-         rho_inv[lev] = getDiffusivity(lev,0,1,{bcRec},ldata_p->density);
+         rho_inv[lev] = getDiffusivity(lev,DENSITY,1,{bcRec},ldata_p->state);
          for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             rho_inv[lev][idim].invert(m_dt/2.0,0);
             rho_inv[lev][idim].FillBoundary(geom[lev].periodicity());

--- a/Source/PeleLMUtils.cpp
+++ b/Source/PeleLMUtils.cpp
@@ -384,10 +384,10 @@ PeleLM::floorSpecies(const TimeStamp &a_time)
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-      for (MFIter mfi(ldata_p->species,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      for (MFIter mfi(ldata_p->state,TilingIfNotGPU()); mfi.isValid(); ++mfi)
       {
          const Box& bx = mfi.tilebox();
-         auto const& rhoY    = ldata_p->species.array(mfi);
+         auto const& rhoY    = ldata_p->state.array(mfi,FIRSTSPEC);
          amrex::ParallelFor(bx, [rhoY]
          AMREX_GPU_DEVICE (int i, int j, int k) noexcept
          {


### PR DESCRIPTION
Moved from a separate velocity, density, species, ... level data MF to a single state MF. Updated fillPatch/averageDown operations to be done all at once.