### PR TITLE
A series a small fixes and changes

### DIFF
--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -1038,6 +1038,8 @@ class PeleLM : public amrex::AmrCore {
    int m_do_temporals = 0;
    int m_temp_int = 5;
    int m_do_massBalance = 0;
+   int m_do_energyBalance = 0;
+   int m_do_speciesBalance = 0;
    amrex::Real m_massOld;
    amrex::Real m_massNew;
    amrex::Real m_RhoHOld;

--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -620,6 +620,8 @@ class PeleLM : public amrex::AmrCore {
    // Typical values
    void setTypicalValues(const PeleLM::TimeStamp &a_time, int is_init = 0);
    void updateTypicalValuesChem();
+    
+   void checkMemory(const std::string &a_message);
    //-----------------------------------------------------------------------------
 
 #ifdef AMREX_USE_EB
@@ -1008,6 +1010,7 @@ class PeleLM : public amrex::AmrCore {
 
    // Misc.
    int m_floor_species = 0;
+   int m_checkMem = 0;
 
    // SDC
    int m_nSDCmax = 1;

--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -664,6 +664,9 @@ class PeleLM : public amrex::AmrCore {
    EBFactory (int lev) const noexcept { 
       return static_cast<amrex::EBFArrayBoxFactory const&>(*m_factory[lev]);
    }
+
+   void correct_vel_small_cells(amrex::Vector<amrex::MultiFab*> const &a_vel,
+                                amrex::Vector<amrex::Array<amrex::MultiFab const*,AMREX_SPACEDIM> > const &a_umac);
 #endif
 
 

--- a/Source/PeleLMAdvance.cpp
+++ b/Source/PeleLMAdvance.cpp
@@ -1,10 +1,16 @@
 #include <PeleLM.H>
 #include <PeleLMUtils.H>
+#include <AMReX_MemProfiler.H>
 
 using namespace amrex;
 
 void PeleLM::Advance(int is_initIter) {
    BL_PROFILE("PeleLM::Advance()");
+
+#ifdef AMREX_MEM_PROFILING
+   // Memory profiler if compiled
+   MemProfiler::report("STEP ["+std::to_string(m_nstep)+"]");
+#endif
 
    // Start timing current time step
    Real strt_time = ParallelDescriptor::second();
@@ -46,6 +52,8 @@ void PeleLM::Advance(int is_initIter) {
    if ( m_verbose ) {
       amrex::Print() << " STEP [" << m_nstep << "] - Time: " << m_cur_time << ", dt " << m_dt << "\n";
    }
+
+   checkMemory("Adv. start");
 
    //----------------------------------------------------------------
    // Data for the advance, only live for the duration of the advance
@@ -138,6 +146,7 @@ void PeleLM::Advance(int is_initIter) {
          ParallelDescriptor::ReduceRealMax(MACEnd, ParallelDescriptor::IOProcessorNumber());
          amrex::Print() << "   - Advance()::MACProjection()  --> Time: " << MACEnd << "\n";
       }
+      checkMemory("MAC-Proj");
 
    } else {
 
@@ -189,6 +198,7 @@ void PeleLM::Advance(int is_initIter) {
       ParallelDescriptor::ReduceRealMax(VelAdvEnd, ParallelDescriptor::IOProcessorNumber());
       amrex::Print() << "   - Advance()::VelocityAdvance  --> Time: " << VelAdvEnd << "\n";
    }
+   checkMemory("Nodal-Proj");
    BL_PROFILE_VAR_STOP(PLM_VEL);
    //----------------------------------------------------------------
 
@@ -279,6 +289,7 @@ void PeleLM::oneSDC(int sdcIter,
       ParallelDescriptor::ReduceRealMax(MACEnd, ParallelDescriptor::IOProcessorNumber());
       amrex::Print() << "   - oneSDC()::MACProjection()   --> Time: " << MACEnd << "\n";
    }
+   checkMemory("MAC-Proj");
    BL_PROFILE_VAR_STOP(PLM_MAC);
    //----------------------------------------------------------------
 
@@ -305,6 +316,7 @@ void PeleLM::oneSDC(int sdcIter,
       ParallelDescriptor::ReduceRealMax(ScalAdvEnd, ParallelDescriptor::IOProcessorNumber());
       amrex::Print() << "   - oneSDC()::ScalarAdvection() --> Time: " << ScalAdvEnd << "\n";
    }
+   checkMemory("ScalAdv");
    BL_PROFILE_VAR_STOP(PLM_SADV);
    //----------------------------------------------------------------
 
@@ -326,6 +338,7 @@ void PeleLM::oneSDC(int sdcIter,
       ParallelDescriptor::ReduceRealMax(ScalDiffEnd, ParallelDescriptor::IOProcessorNumber());
       amrex::Print() << "   - oneSDC()::ScalarDiffusion() --> Time: " << ScalDiffEnd << "\n";
    }
+   checkMemory("ScalDiff");
    BL_PROFILE_VAR_STOP(PLM_DIFF);
    //----------------------------------------------------------------
 
@@ -354,6 +367,7 @@ void PeleLM::oneSDC(int sdcIter,
       ParallelDescriptor::ReduceRealMax(ScalReacEnd, ParallelDescriptor::IOProcessorNumber());
       amrex::Print() << "   - oneSDC()::ScalarReaction()  --> Time: " << ScalReacEnd << "\n";
    }
+   checkMemory("ScalReact");
    BL_PROFILE_VAR_STOP(PLM_REAC);
    //----------------------------------------------------------------
 

--- a/Source/PeleLMEos.cpp
+++ b/Source/PeleLMEos.cpp
@@ -217,8 +217,8 @@ void PeleLM::calc_dPdt(const TimeStamp &a_time,
 
    for (int lev = 0; lev <= finest_level; ++lev) {
       calc_dPdt(lev, a_time, a_dPdt[lev]);
-#ifdef AMRE_USE_EB
-      EB_set_covered(a_dPdt[lev],0.0);
+#ifdef AMREX_USE_EB
+      EB_set_covered(*a_dPdt[lev],0.0);
 #endif
    }
 

--- a/Source/PeleLMInit.cpp
+++ b/Source/PeleLMInit.cpp
@@ -183,9 +183,7 @@ void PeleLM::initData() {
       // TODO : this estimate is probably useless
       Real dtInit = computeDt(is_init,AmrNewTime);
       Print() << " Initial dt: " << dtInit << "\n";
-      //WriteDebugPlotFile(GetVecOfConstPtrs(getDensityVect(AmrNewTime)),"RhoPostDist");
-      //WriteDebugPlotFile(GetVecOfConstPtrs(getSpeciesVect(AmrNewTime)),"RhoYsPostDist");
-      //WriteDebugPlotFile(GetVecOfConstPtrs(getTempVect(AmrNewTime)),"TempPostDist");
+      //WriteDebugPlotFile(GetVecOfConstPtrs(getStateVect(AmrNewTime)),"InitSol");
 
       // Subcycling IAMR/PeleLM first does a projection with no reaction divU
       // which can make the dt for evaluating I_R better

--- a/Source/PeleLMSetup.cpp
+++ b/Source/PeleLMSetup.cpp
@@ -138,7 +138,6 @@ void PeleLM::readParameters() {
          lo_bc[dir] = 0;
       } else if (lo_bc_char[dir] == "Inflow") {
          lo_bc[dir] = 1;
-         isOpenDomain = 1;
       } else if (lo_bc_char[dir] == "Outflow") {
          lo_bc[dir] = 2;
          isOpenDomain = 1;
@@ -161,7 +160,6 @@ void PeleLM::readParameters() {
          hi_bc[dir] = 0;
       } else if (hi_bc_char[dir] == "Inflow") {
          hi_bc[dir] = 1;
-         isOpenDomain = 1;
       } else if (hi_bc_char[dir] == "Outflow") {
          hi_bc[dir] = 2;
          isOpenDomain = 1;

--- a/Source/PeleLMSetup.cpp
+++ b/Source/PeleLMSetup.cpp
@@ -295,6 +295,7 @@ void PeleLM::readParameters() {
    // -----------------------------------------
    pp.query("sdc_iterMax",m_nSDCmax);
    pp.query("floor_species",m_floor_species);
+   pp.query("memory_checks",m_checkMem);
 
    // -----------------------------------------
    // Reaction

--- a/Source/PeleLMTemporals.cpp
+++ b/Source/PeleLMTemporals.cpp
@@ -15,17 +15,21 @@ void PeleLM::initTemporals(const PeleLM::TimeStamp &a_time)
          m_domainMassFlux[2*idim+1] = 0.0;
       }
    }
-   m_RhoHOld = MFSum(GetVecOfConstPtrs(getRhoHVect(a_time)),0);
-   for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
-      m_domainRhoHFlux[2*idim] = 0.0;
-      m_domainRhoHFlux[2*idim+1] = 0.0;
+   if (m_do_energyBalance && !m_incompressible) {
+      m_RhoHOld = MFSum(GetVecOfConstPtrs(getRhoHVect(a_time)),0);
+      for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+         m_domainRhoHFlux[2*idim] = 0.0;
+         m_domainRhoHFlux[2*idim+1] = 0.0;
+      }
    }
 
-   for (int n = 0; n < NUM_SPECIES; n++){
-      m_RhoYOld[n] = MFSum(GetVecOfConstPtrs(getSpeciesVect(a_time)),n);
-      for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
-         m_domainRhoYFlux[2*n*AMREX_SPACEDIM+2*idim] = 0.0;
-         m_domainRhoYFlux[1+2*n*AMREX_SPACEDIM+2*idim] = 0.0;
+   if (m_do_speciesBalance && !m_incompressible) {
+      for (int n = 0; n < NUM_SPECIES; n++){
+         m_RhoYOld[n] = MFSum(GetVecOfConstPtrs(getSpeciesVect(a_time)),n);
+         for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+            m_domainRhoYFlux[2*n*AMREX_SPACEDIM+2*idim] = 0.0;
+            m_domainRhoYFlux[1+2*n*AMREX_SPACEDIM+2*idim] = 0.0;
+         }
       }
    }
 

--- a/Source/PeleLMUtils.cpp
+++ b/Source/PeleLMUtils.cpp
@@ -777,19 +777,13 @@ void PeleLM::setTypicalValues(const TimeStamp &a_time, int is_init)
     }
     
     if (!m_incompressible) {
-        // First get the difference between max/min, if too small use average
-        typical_values[DENSITY] = stateMax[DENSITY] - stateMin[DENSITY];
-        if (typical_values[DENSITY] < 0.1 * stateMin[DENSITY]) typical_values[DENSITY] = 0.5 * (stateMax[DENSITY] + stateMin[DENSITY]);
+        // Average between max/min
+        typical_values[DENSITY] = 0.5 * (stateMax[DENSITY] + stateMin[DENSITY]);
         for (int n = 0; n < NUM_SPECIES; n++) {
-            typical_values[FIRSTSPEC+n] = stateMax[FIRSTSPEC+n] - stateMin[FIRSTSPEC+n];
-            if (typical_values[FIRSTSPEC+n] < 0.1 * stateMin[FIRSTSPEC+n]) {
-                typical_values[FIRSTSPEC+n] = 0.5 * (stateMax[FIRSTSPEC+n] + stateMin[FIRSTSPEC+n]);
-            }
+            typical_values[FIRSTSPEC+n] = 0.5 * (stateMax[FIRSTSPEC+n] + stateMin[FIRSTSPEC+n]) / typical_values[DENSITY];
         }
-        typical_values[RHOH] = stateMax[RHOH] - stateMin[RHOH];
-        if (typical_values[RHOH] < 0.1 * stateMin[RHOH]) typical_values[RHOH] = 0.5 * (stateMax[RHOH] + stateMin[RHOH]);
-        typical_values[TEMP] = stateMax[TEMP] - stateMin[TEMP];
-        if (typical_values[TEMP] < 0.1 * stateMin[TEMP]) typical_values[TEMP] = 0.5 * (stateMax[TEMP] + stateMin[TEMP]);
+        typical_values[RHOH] = 0.5 * (stateMax[RHOH] + stateMin[RHOH]) / typical_values[DENSITY];
+        typical_values[TEMP] = 0.5 * (stateMax[TEMP] + stateMin[TEMP]);
         typical_values[RHORT] = m_pOld;
 
         // Pass into chemsitry if requested
@@ -808,7 +802,7 @@ void PeleLM::setTypicalValues(const TimeStamp &a_time, int is_init)
         if (!m_incompressible) {
             Print() << "\tDensity: " << typical_values[DENSITY] << '\n';
             Print() << "\tTemp:    " << typical_values[TEMP]    << '\n';
-            Print() << "\tRhoH:    " << typical_values[RHOH]    << '\n';
+            Print() << "\tH:       " << typical_values[RHOH]    << '\n';
             Vector<std::string> spec_names;
             pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(spec_names);
             for (int n = 0; n < NUM_SPECIES; n++) {


### PR DESCRIPTION
 - add a function to fix the velocity in small cells (unused at this point)
 - add lightweight memory checks throughout the algorithm (`peleLM.memory_checks = 1`) and add a call to AMReX profiler
 - fix detection of closed chamber -> can have inflow
 - fix error when using `peleLM.incompressible = 1`
 - use typical values for the covered cells and switch to using min/max average to define those
 - fix typo on setCovered in Eos