### PR TITLE
The issue with non-C2 thermo leading to deltaT iter failure still there.

### DIFF
--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -1150,6 +1150,7 @@ class PeleLM : public amrex::AmrCore {
    int m_deltaT_verbose = 0;
    int m_deltaTIterMax = 10;
    amrex::Real m_deltaT_norm_max = 1.0e-10;
+   int m_crashOnDeltaTFail = 1;
 
    // Pressure
    amrex::Real m_dpdtFactor = 1.0;

--- a/Source/PeleLMDiffusion.cpp
+++ b/Source/PeleLMDiffusion.cpp
@@ -767,7 +767,11 @@ void PeleLM::differentialDiffusionUpdate(std::unique_ptr<AdvanceAdvData> &advDat
 
       // Check for convergence failure
       if ( (dTiter == m_deltaTIterMax-1) && ( deltaT_norm > m_deltaT_norm_max ) ) {
-         Abort("deltaT_iters not converged !");
+         if ( m_crashOnDeltaTFail ) {
+            Abort("deltaT_iters not converged !");
+         } else {
+            Print() << "deltaT_iters not converged !\n";
+         }
       }
    }
    //------------------------------------------------------------------------

--- a/Source/PeleLMSetup.cpp
+++ b/Source/PeleLMSetup.cpp
@@ -306,6 +306,8 @@ void PeleLM::readParameters() {
    pp.query("deltaT_verbose",m_deltaT_verbose);
    pp.query("deltaT_iterMax",m_deltaTIterMax);
    pp.query("deltaT_tol",m_deltaT_norm_max);
+   pp.query("deltaT_crashIfFailing",m_crashOnDeltaTFail);
+  
 
    // -----------------------------------------
    // initialization


### PR DESCRIPTION
Add the option to only warn and not crash if deltaT iterations fails.
Use `peleLM.deltaT_crashIfFailing = 0` to warn and not crash. This should be used only if deltaT failure
has been clearly identified as coming from the thermodynamic.