### PR TITLE
Add control over the number of digits in plt and chk file name

### DIFF
--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -1081,6 +1081,7 @@ class PeleLM : public amrex::AmrCore {
    int m_message_int = 10;
    int m_evaluatePlotVarCount = 0;
    int m_plot_grad_p = 1;
+   int m_ioDigits = 5;
    amrex::Vector<std::string> m_evaluatePlotVars;
 
    //-----------------------------------------------------------------------------

--- a/Source/PeleLMPlot.cpp
+++ b/Source/PeleLMPlot.cpp
@@ -42,7 +42,7 @@ void PeleLM::WriteDebugPlotFile(const Vector<const MultiFab*> &a_MF,
 void PeleLM::WritePlotFile() {
    BL_PROFILE("PeleLM::WritePlotFile()");
 
-   const std::string& plotfilename = amrex::Concatenate(m_plot_file, m_nstep);
+   const std::string& plotfilename = amrex::Concatenate(m_plot_file, m_nstep, m_ioDigits);
 
    if (m_verbose) {
       amrex::Print() << " Dumping plotfile: " << plotfilename << "\n";
@@ -354,7 +354,7 @@ void PeleLM::WriteCheckPointFile()
 {
    BL_PROFILE("PeleLM::WriteCheckPointFile()");
    
-   const std::string& checkpointname = amrex::Concatenate(m_check_file, m_nstep);
+   const std::string& checkpointname = amrex::Concatenate(m_check_file, m_nstep, m_ioDigits);
    
    if (m_verbose) {
       amrex::Print() << "\n Writting checkpoint file: " << checkpointname << "\n";

--- a/Source/PeleLMSetup.cpp
+++ b/Source/PeleLMSetup.cpp
@@ -484,7 +484,7 @@ void PeleLM::readIOParameters() {
    m_regrid_file = "";
    pp.query("initial_grid_file", m_initial_grid_file);
    pp.query("regrid_file", m_regrid_file);
-   pp.query("IOdigits", m_ioDigits);
+   pp.query("file_stepDigits", m_ioDigits);
 
 }
 

--- a/Source/PeleLMSetup.cpp
+++ b/Source/PeleLMSetup.cpp
@@ -484,6 +484,7 @@ void PeleLM::readIOParameters() {
    m_regrid_file = "";
    pp.query("initial_grid_file", m_initial_grid_file);
    pp.query("regrid_file", m_regrid_file);
+   pp.query("IOdigits", m_ioDigits);
 
 }
 


### PR DESCRIPTION
using `amr.file_stepDigits` (default is 5)