### PR TITLE
Add a couple of features

### DIFF
--- a/Docs/source/LMeXControls.rst
+++ b/Docs/source/LMeXControls.rst
@@ -75,6 +75,7 @@ encountered will lead to termination of the simulation.
     amr.plot_file        = "plt_"          # [OPT, DEF="plt_"] Plot file prefix
     amr.check_int        = 100             # [OPT, DEF=-1] Frequency (as step #) for writting checkpoint file
     amr.check_file       = "chk"           # [OPT, DEF="chk"] Checkpoint file prefix
+    amr.file_stepDigits  = 6               # [OPT, DEF=5] Number of digits when adding nsteps to plt and chk names
     amr.derive_plot_vars = avg_pressure ...# [OPT, DEF=""] List of derived variable included in the plot files
     amr.plot_speciesState = 0              # [OPT, DEF=0] Force adding state rhoYs to the plot files
 

--- a/Docs/source/LMeXControls.rst
+++ b/Docs/source/LMeXControls.rst
@@ -70,6 +70,8 @@ encountered will lead to termination of the simulation.
 
     #--------------------------IO CONTROL--------------------------
     amr.plot_int         = 20              # [OPT, DEF=-1] Frequency (as step #) for writting plot file
+    amr.plot_per         = 002             # [OPT, DEF=-1] Period (time in s) for writting plot file
+    amr.plot_per_exact   = 1               # [OPT, DEF=0] Flag to enforce exactly plt_per by shortening dt 
     amr.plot_file        = "plt_"          # [OPT, DEF="plt_"] Plot file prefix
     amr.check_int        = 100             # [OPT, DEF=-1] Frequency (as step #) for writting checkpoint file
     amr.check_file       = "chk"           # [OPT, DEF="chk"] Checkpoint file prefix
@@ -137,11 +139,11 @@ Linear solvers are a key component of PeleLMeX algorithm, separate controls are 
     mac_proj.atol = 1.0e-12                     # [OPT, DEF=1e-14] Absolute tolerance of the MAC projection
     mac_proj.mg_max_coarsening_level = 5        # [OPT, DEF=100] Maximum number of MG levels (useful when using EB)
 
-    diffusion.verbose                           # [OPT, DEF=0] Verbose of the scalar diffusion solve
+    diffusion.verbose = 1                       # [OPT, DEF=0] Verbose of the scalar diffusion solve
     diffusion.rtol = 1.0e-11                    # [OPT, DEF=1e-11] Relative tolerance of the scalar diffusion solve
     diffusion.atol = 1.0e-12                    # [OPT, DEF=1e-14] Absolute tolerance of the scalar diffusion solve
 
-    tensor_diffusion.verbose                    # [OPT, DEF=0] Verbose of the velocity tensor diffusion solve
+    tensor_diffusion.verbose = 1                # [OPT, DEF=0] Verbose of the velocity tensor diffusion solve
     tensor_diffusion.rtol = 1.0e-11             # [OPT, DEF=1e-11] Relative tolerance of the velocity tensor diffusion solve
     tensor_diffusion.atol = 1.0e-12             # [OPT, DEF=1e-14] Absolute tolerance of the velocity tensor diffusion solve
 

--- a/Docs/source/Model.rst
+++ b/Docs/source/Model.rst
@@ -14,7 +14,7 @@ setup and control of `PeleLMeX` in later sections. `PeleLMeX` is a non-subcyclin
 Overview of `PeleLMeX`
 ----------------------
 
-`PeleLMeX` evolves chemically reacting low Mach number flows with block-structured adaptive mesh refinement (AMR). The code depends upon the `AMReX <https://github.com/AMReX-Codes/amrex>` library to provide the underlying data structures, and tools to manage and operate on them across massively parallel computing architectures. `PeleLMeX` also utilizes the source code and algorithmic infrastructure of `AMReX-Hydro <https://github.com/AMReX-Codes/AMReX-Hydro>`. `PeleLMeX` borrows heavily from `PeleLM <https://github.com/AMReX-Combustion/PeleLM>`.  The core algorithms in `PeleLM`are described in the following papers:
+`PeleLMeX` evolves chemically reacting low Mach number flows with block-structured adaptive mesh refinement (AMR). The code depends upon the `AMReX <https://github.com/AMReX-Codes/amrex>` library to provide the underlying data structures, and tools to manage and operate on them across massively parallel computing architectures. `PeleLMeX` also utilizes the source code and algorithmic infrastructure of `AMReX-Hydro <https://github.com/AMReX-Codes/AMReX-Hydro>`. `PeleLMeX` borrows heavily from `PeleLM <https://github.com/AMReX-Combustion/PeleLM>`.  The core algorithms in `PeleLM` are described in the following papers:
 
 * *A conservative, thermodynamically consistent numerical approach for low Mach number combustion. I. Single-level integration*, A. Nonaka, J. B. Bell, and M. S. Day, *Combust. Theor. Model.*, **22** (1) 156-184 (2018)
 

--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -1076,7 +1076,8 @@ class PeleLM : public amrex::AmrCore {
    int m_plotHeatRelease = 0;
    int m_plotStateSpec = 0;
    int m_plot_int = 0;
-   amrex::Real m_plot_per = -1.;
+   amrex::Real m_plot_per_approx = -1.;
+   amrex::Real m_plot_per_exact = -1.;
    int m_check_int = 0;
    int m_message_int = 10;
    int m_evaluatePlotVarCount = 0;

--- a/Source/PeleLMDeriveFunc.H
+++ b/Source/PeleLMDeriveFunc.H
@@ -16,6 +16,11 @@ void pelelm_dermassfrac (PeleLM* a_pelelm, const amrex::Box& bx, amrex::FArrayBo
                          const amrex::Geometry& geomdata,
                          amrex::Real time, const amrex::Vector<amrex::BCRec> &bcrec, int level);
 
+void pelelm_dermolefrac (PeleLM* a_pelelm, const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int ncomp,
+                         const amrex::FArrayBox& statefab, const amrex::FArrayBox& pressfab,
+                         const amrex::Geometry& geomdata,
+                         amrex::Real time, const amrex::Vector<amrex::BCRec> &bcrec, int level);
+
 void pelelm_dertemp (PeleLM* a_pelelm, const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int ncomp,
                      const amrex::FArrayBox& statefab, const amrex::FArrayBox& pressfab,
                      const amrex::Geometry& geomdata,
@@ -45,4 +50,9 @@ void pelelm_derprogvar (PeleLM* a_pelelm, const amrex::Box& bx, amrex::FArrayBox
                         const amrex::FArrayBox& statefab, const amrex::FArrayBox& pressfab,
                         const amrex::Geometry& geomdata,
                         amrex::Real time, const amrex::Vector<amrex::BCRec> &bcrec, int level);
+
+void pelelm_dervisc (PeleLM* a_pelelm, const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int ncomp,
+                     const amrex::FArrayBox& statefab, const amrex::FArrayBox& pressfab,
+                     const amrex::Geometry& geomdata,
+                     amrex::Real time, const amrex::Vector<amrex::BCRec> &bcrec, int level);
 #endif

--- a/Source/PeleLMEvolve.cpp
+++ b/Source/PeleLMEvolve.cpp
@@ -72,7 +72,7 @@ void PeleLM::Evolve() {
    if (m_verbose > 0) {
       amrex::Print() << "\n >> Final simulation time: " << m_cur_time << "\n";
    }
-   if ( (m_plot_int > 0 || m_plot_per > 0.) && !plt_justDidIt ) {
+   if ( (m_plot_int > 0 || m_plot_per_approx > 0. || m_plot_per_exact > 0.) && !plt_justDidIt ) {
       WritePlotFile();
    }
    if ( m_check_int > 0 && !chk_justDidIt ) {
@@ -87,18 +87,22 @@ PeleLM::writePlotNow()
 
    if ( m_plot_int > 0 && (m_nstep % m_plot_int == 0) ) {
       write_now = true;
-   } else if (m_plot_per > 0.0) {
+   
+   } else if ( m_plot_per_exact > 0.0 && (std::abs(std::remainder(m_cur_time, m_plot_per_exact)) < 1.e-12) ) {
+      write_now = true;
+ 
+   } else if (m_plot_per_approx > 0.0) {
       // Check to see if we've crossed a plot_per interval by comparing
       // the number of intervals that have elapsed for both the current
       // time and the time at the beginning of this timestep.
-      int num_per_old = static_cast<int>((m_cur_time-m_dt) / m_plot_per);
-      int num_per_new = static_cast<int>((m_cur_time     ) / m_plot_per);
+      int num_per_old = static_cast<int>((m_cur_time-m_dt) / m_plot_per_approx);
+      int num_per_new = static_cast<int>((m_cur_time     ) / m_plot_per_approx);
       // Before using these, however, we must test for the case where we're
       // within machine epsilon of the next interval. In that case, increment
       // the counter, because we have indeed reached the next plot_per interval
       // at this point.
       const Real eps = std::numeric_limits<Real>::epsilon() * 10.0_rt * std::abs(m_cur_time);
-      const Real next_plot_time = (num_per_old + 1) * m_plot_per;
+      const Real next_plot_time = (num_per_old + 1) * m_plot_per_approx;
       if ((num_per_new == num_per_old) && std::abs(m_cur_time - next_plot_time) <= eps)
       {
          num_per_new += 1;

--- a/Source/PeleLMInit.cpp
+++ b/Source/PeleLMInit.cpp
@@ -289,7 +289,7 @@ void PeleLM::initData() {
          writeTemporals();
       }
 
-      if (m_plot_int > 0 || m_plot_per > 0.) {
+      if (m_plot_int > 0 || m_plot_per_approx > 0. || m_plot_per_exact > 0.) {
          WritePlotFile();
       }
       if (m_check_int > 0 ) {

--- a/Source/PeleLMSetup.cpp
+++ b/Source/PeleLMSetup.cpp
@@ -470,7 +470,15 @@ void PeleLM::readIOParameters() {
    pp.query("initDataPlt" , m_restart_pltfile);
    pp.query("plot_file", m_plot_file);
    pp.query("plot_int" , m_plot_int);
-   pp.query("plot_per", m_plot_per);
+   if (pp.contains("plot_per")) {
+      int do_exact = 0;
+      pp.query("plot_per_exact",do_exact);
+      if ( do_exact ) {
+        pp.query("plot_per", m_plot_per_exact);
+      } else {
+        pp.query("plot_per", m_plot_per_approx);
+      }
+   }
    pp.query("plot_grad_p", m_plot_grad_p);
    m_derivePlotVarCount = (pp.countval("derive_plot_vars"));
    if (m_derivePlotVarCount != 0) {
@@ -695,22 +703,30 @@ void PeleLM::derivedSetup()
       derive_lst.add("mass_fractions",IndexType::TheCellType(),NUM_SPECIES,
                      var_names_massfrac,pelelm_dermassfrac,the_same_box);
 
+      for (int n = 0 ; n < NUM_SPECIES; n++) {
+         var_names_massfrac[n] = "X("+spec_names[n]+")";
+      }
+      derive_lst.add("mole_fractions",IndexType::TheCellType(),NUM_SPECIES,
+                     var_names_massfrac,pelelm_dermolefrac,the_same_box);
+
+      // Mixture fraction
+      derive_lst.add("mixture_fraction",IndexType::TheCellType(),1,pelelm_dermixfrac,the_same_box);
+
+      // Progress variable
+      derive_lst.add("progress_variable",IndexType::TheCellType(),1,pelelm_derprogvar,the_same_box);
    }
 
    // Cell average pressure
    derive_lst.add("avg_pressure",IndexType::TheCellType(),1,pelelm_deravgpress,the_same_box);
+
+   // Viscosity
+   derive_lst.add("viscosity",IndexType::TheCellType(),1,pelelm_dervisc,the_same_box);
 
    // Vorticity magnitude
    derive_lst.add("mag_vort",IndexType::TheCellType(),1,pelelm_dermgvort,grow_box_by_two);
 
    // Kinetic energy
    derive_lst.add("kinetic_energy",IndexType::TheCellType(),1,pelelm_derkineticenergy,the_same_box);
-
-   // Mixture fraction
-   derive_lst.add("mixture_fraction",IndexType::TheCellType(),1,pelelm_dermixfrac,the_same_box);
-
-   // Progress variable
-   derive_lst.add("progress_variable",IndexType::TheCellType(),1,pelelm_derprogvar,the_same_box);
 
 #ifdef PELE_USE_EFIELD
    // Charge distribution

--- a/Source/PeleLMTimestep.cpp
+++ b/Source/PeleLMTimestep.cpp
@@ -58,6 +58,17 @@ PeleLM::computeDt(int is_init,
    } else {
       estdt = std::min(estdt,m_prev_dt*m_dtChangeMax);
       estdt = std::min(estdt,m_max_dt);
+      // Shorten the dt to output plt file at exact req. time
+      if (m_plot_per_exact > 0.0) {
+         // Ensure ~O(dt) step by checking a little in advance
+         Real timeToNextPlot = (std::floor( m_cur_time / m_plot_per_exact ) + 1) * m_plot_per_exact - m_cur_time;
+         if ( 2.0 * estdt > timeToNextPlot && timeToNextPlot > estdt ) {
+            estdt = 0.5 * timeToNextPlot;
+         } else {
+            estdt = std::min(estdt,timeToNextPlot);
+         }
+      }
+      // If we're are getting close to the end of the simulation, shorten the dt too
       if (m_stop_time >= 0.0) {
          // Ensure ~O(dt) last step by checking a little in advance
          Real timeLeft = (m_stop_time-m_cur_time);

--- a/Source/PeleLMTransportProp.cpp
+++ b/Source/PeleLMTransportProp.cpp
@@ -28,7 +28,7 @@ void PeleLM::calcViscosity(const TimeStamp &a_time) {
          {
             const Box& gbx     = mfi.growntilebox();
             auto const& rhoY   = ldata_p->state.const_array(mfi,FIRSTSPEC);
-            auto const& T      = ldata_p->state.array(mfi,TEMP);
+            auto const& T      = ldata_p->state.const_array(mfi,TEMP);
             auto const& mu     = ldata_p->visc_cc.array(mfi,0);
 
             amrex::ParallelFor(gbx, [rhoY, T, mu, ltransparm]

--- a/Source/PeleLM_K.H
+++ b/Source/PeleLM_K.H
@@ -64,7 +64,7 @@ AMREX_FORCE_INLINE
 void
 getVelViscosity(int i, int j, int k,
                 amrex::Array4<const amrex::Real> const& rhoY,
-                amrex::Array4<      amrex::Real> const& T,
+                amrex::Array4<const amrex::Real> const& T,
                 amrex::Array4<      amrex::Real> const& mu,
                 pele::physics::transport::TransParm<pele::physics::PhysicsType::eos_type,
                                                     pele::physics::PhysicsType::transport_type> const* trans_parm) noexcept
@@ -83,6 +83,7 @@ getVelViscosity(int i, int j, int k,
    }
 
    rho *= 1.0e-3_rt;                          // MKS -> CGS conversion
+   amrex::Real temp = T(i,j,k);
    amrex::Real dummy_rhoDi[NUM_SPECIES] = {0.0};
    amrex::Real dummy_lambda = 0.0_rt;
    amrex::Real mu_cgs = 0.0_rt;
@@ -93,7 +94,7 @@ getVelViscosity(int i, int j, int k,
    bool get_lam = false;
    bool get_Ddiag = false;
    auto trans = pele::physics::PhysicsType::transport();
-   trans.transport(get_xi, get_mu, get_lam, get_Ddiag, T(i,j,k),
+   trans.transport(get_xi, get_mu, get_lam, get_Ddiag, temp,
                    rho, y, dummy_rhoDi, mu_cgs, dummy_xi, dummy_lambda, trans_parm);
 
    // Do CGS -> MKS conversions


### PR DESCRIPTION
 - derived variable `mole_frac` and `viscosity`
 - when using `amr.plot_per`, I can additionally set `amr.plot_per_exact = 1` to enforce the period between pltfile exactly by adapting the time step size.