### PR TITLE
LES support and unity Le

### DIFF
--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -145,8 +145,8 @@ class PeleLM : public amrex::AmrCore {
       LevelData (amrex::BoxArray const& ba,
                  amrex::DistributionMapping const& dm,
                  amrex::FabFactory<amrex::FArrayBox> const& factory,
-                 int a_incompressible, int a_has_divu, 
-                 int a_nAux, int a_nGrowState);
+                 int a_incompressible, int a_has_divu,
+                 int a_nAux, int a_nGrowState, int a_do_les);
 
       // cell-centered state multifabs
       amrex::MultiFab state;           // Stqte data: velocity, density, rhoYs, rhoH, Temp, RhoRT
@@ -159,6 +159,7 @@ class PeleLM : public amrex::AmrCore {
 
       // cell-centered transport multifabs
       amrex::MultiFab visc_cc;         // Viscosity (dim:1)
+      amrex::MultiFab visc_turb_cc;    // Turbulent Viscosity (dim:1)
       amrex::MultiFab diff_cc;         // Diffusivity (dim:NUM_SPECIES+2)
 #ifdef PELE_USE_EFIELD
       amrex::MultiFab diffE_cc;        // Electron diffusivity (dim:1)
@@ -276,7 +277,7 @@ class PeleLM : public amrex::AmrCore {
    // MAC PROJECTION
 
    void resetMacProjector();
-   
+
    // Predict face velocity using Godunov
    void predictVelocity(std::unique_ptr<AdvanceAdvData> &advData);
 
@@ -312,6 +313,7 @@ class PeleLM : public amrex::AmrCore {
 
    // compute cell-centered diffusivity (stored in LevelData)
    void calcViscosity(const PeleLM::TimeStamp &a_time);
+   void calcTurbViscosity(const PeleLM::TimeStamp &a_time);
    void calcDiffusivity(const PeleLM::TimeStamp &a_time);
    
    // get edge-centered diffusivity on a per level / per comp basis
@@ -1142,9 +1144,19 @@ class PeleLM : public amrex::AmrCore {
    // cc->ec average
    int m_harm_avg_cen2edge = 0;
 
-   // wbar diffusion term
+
+   // Diffusion
+   int m_unity_Le = 0;
+   amrex::Real m_Schmidt_inv = 1.0/0.7;
+   amrex::Real m_Prandtl_inv = 1.0/0.7;
    int m_use_wbar = 1;
 
+   // LES Model
+   bool m_do_les = false;
+   int m_les_verbose = 0;
+   std::string m_les_model = "None";
+   amrex::Real m_les_cs_smag = 0.0;
+   amrex::Real m_les_cs_wales = 0.0;
    // switch on/off different processes
    // TODO: actually implement that
    int m_do_react = 1;

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -42,7 +42,7 @@ PeleLM::getLevelDataPtr(int lev, const PeleLM::TimeStamp &a_time, int /*useUMac*
    } else {
       m_leveldata_floating.reset( new LevelData(grids[lev], dmap[lev], *m_factory[lev],
                                   m_incompressible, m_has_divu,
-                                  m_nAux, m_nGrowState));
+                                  m_nAux, m_nGrowState, m_do_les));
       Real time = getTime(lev,a_time);
       fillpatch_state(lev, time, m_leveldata_floating->state, m_nGrowState);
       //if (useUMac) {

--- a/Source/PeleLMData.cpp
+++ b/Source/PeleLMData.cpp
@@ -6,7 +6,7 @@ PeleLM::LevelData::LevelData(amrex::BoxArray const& ba,
                              amrex::DistributionMapping const& dm,
                              amrex::FabFactory<FArrayBox> const& factory,
                              int a_incompressible, int a_has_divu,
-                             int a_nAux, int a_nGrowState)
+                             int a_nAux, int a_nGrowState, int a_do_les)
 {
    if (a_incompressible ) {
        state.define(  ba, dm, AMREX_SPACEDIM , a_nGrowState, MFInfo(), factory);
@@ -17,6 +17,9 @@ PeleLM::LevelData::LevelData(amrex::BoxArray const& ba,
    press.define(   amrex::convert(ba,IntVect::TheNodeVector()),
                        dm, 1             , 1           , MFInfo(), factory);
    visc_cc.define( ba, dm, 1             , 1           , MFInfo(), factory);
+   if (a_do_les) {
+     visc_turb_cc.define( ba, dm, 1             , 1           , MFInfo(), factory);
+   }
    if (! a_incompressible ) {
       if (a_has_divu) {
          divu.define (ba, dm, 1             , 1           , MFInfo(), factory);
@@ -192,6 +195,9 @@ void
 PeleLM::copyTransportOldToNew() {
    for (int lev = 0; lev <= finest_level; lev++ ) {
       MultiFab::Copy(m_leveldata_new[lev]->visc_cc,m_leveldata_old[lev]->visc_cc,0,0,1,1);
+      if (m_do_les) {
+         MultiFab::Copy(m_leveldata_new[lev]->visc_turb_cc,m_leveldata_old[lev]->visc_turb_cc,0,0,1,1);
+      }
       if ( !m_incompressible ) {
          MultiFab::Copy(m_leveldata_new[lev]->diff_cc,m_leveldata_old[lev]->diff_cc,0,0,NUM_SPECIES+2,1);
 #ifdef PELE_USE_EFIELD

--- a/Source/PeleLMDeriveFunc.H
+++ b/Source/PeleLMDeriveFunc.H
@@ -63,6 +63,11 @@ void pelelm_dervisc (PeleLM* a_pelelm, const amrex::Box& bx, amrex::FArrayBox& d
                      const amrex::Geometry& geomdata,
                      amrex::Real time, const amrex::Vector<amrex::BCRec> &bcrec, int level);
 
+void pelelm_derviscturb (PeleLM* a_pelelm, const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int ncomp,
+                         const amrex::FArrayBox& statefab, const amrex::FArrayBox& reactfab, const amrex::FArrayBox& pressfab,
+                         const amrex::Geometry& geomdata,
+                         amrex::Real time, const amrex::Vector<amrex::BCRec> &bcrec, int level);
+
 void pelelm_derdiffc (PeleLM* a_pelelm, const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int ncomp,
                       const amrex::FArrayBox& statefab, const amrex::FArrayBox& reactfab, const amrex::FArrayBox& pressfab,
                       const amrex::Geometry& geomdata,

--- a/Source/PeleLMInit.cpp
+++ b/Source/PeleLMInit.cpp
@@ -54,10 +54,10 @@ void PeleLM::MakeNewLevelFromScratch( int lev,
    // Initialize the LevelData
    m_leveldata_old[lev].reset(new LevelData(grids[lev], dmap[lev], *m_factory[lev],
                                             m_incompressible, m_has_divu,
-                                            m_nAux, m_nGrowState));
+                                            m_nAux, m_nGrowState, m_do_les));
    m_leveldata_new[lev].reset(new LevelData(grids[lev], dmap[lev], *m_factory[lev],
                                             m_incompressible, m_has_divu,
-                                            m_nAux, m_nGrowState));
+                                            m_nAux, m_nGrowState, m_do_les));
 
    if (max_level > 0 && lev != max_level) {
       m_coveredMask[lev].reset(new iMultiFab(grids[lev], dmap[lev], 1, 0));

--- a/Source/PeleLMRegrid.cpp
+++ b/Source/PeleLMRegrid.cpp
@@ -45,11 +45,11 @@ void PeleLM::MakeNewLevelFromCoarse( int lev,
    // New leveldatas
    std::unique_ptr<LevelData> n_leveldata_old( new LevelData(ba, dm, *new_fact,
                                                    m_incompressible, m_has_divu,
-                                                   m_nAux, m_nGrowState));
+                                                   m_nAux, m_nGrowState, m_do_les));
 
    std::unique_ptr<LevelData> n_leveldata_new( new LevelData(ba, dm, *new_fact,
                                                    m_incompressible, m_has_divu,
-                                                   m_nAux, m_nGrowState));
+                                                   m_nAux, m_nGrowState, m_do_les));
 
    // Fill the leveldata_new
    fillcoarsepatch_state(lev, time, n_leveldata_new->state, m_nGrowState);
@@ -135,11 +135,13 @@ void PeleLM::RemakeLevel( int lev,
    // New leveldatas
    std::unique_ptr<LevelData> n_leveldata_old( new LevelData(ba, dm, *new_fact,
                                                    m_incompressible, m_has_divu,
-                                                   m_nAux, m_nGrowState));
+                                                   m_nAux, m_nGrowState,
+                                                   m_do_les));
 
    std::unique_ptr<LevelData> n_leveldata_new( new LevelData(ba, dm, *new_fact,
                                                    m_incompressible, m_has_divu,
-                                                   m_nAux, m_nGrowState));
+                                                   m_nAux, m_nGrowState,
+                                                   m_do_les));
 
    // Fill the leveldata_new
    fillpatch_state(lev, time, n_leveldata_new->state, m_nGrowState);

--- a/Source/PeleLMSetup.cpp
+++ b/Source/PeleLMSetup.cpp
@@ -325,7 +325,7 @@ void PeleLM::readParameters() {
      m_les_verbose = m_verbose;
      pp.query("les_v", m_les_verbose);
 #ifdef AMREX_USE_EB
-     amrex::Warning("Compatibility of LES implementation with EB has not yet been verified")
+     amrex::Warning("Compatibility of LES implementation with EB has not yet been verified");
 #endif
    }
 

--- a/Source/PeleLM_K.H
+++ b/Source/PeleLM_K.H
@@ -7,6 +7,58 @@
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
+getTransportCoeffUnityLe(int i, int j, int k,
+                         amrex::Real ScInv, amrex::Real PrInv,
+                         amrex::Array4<const amrex::Real> const& rhoY,
+                         amrex::Array4<const amrex::Real> const& T,
+                         amrex::Array4<      amrex::Real> const& rhoDi,
+                         amrex::Array4<      amrex::Real> const& lambda,
+                         amrex::Array4<      amrex::Real> const& mu,
+                         pele::physics::transport::TransParm<pele::physics::PhysicsType::eos_type,
+                         pele::physics::PhysicsType::transport_type> const* trans_parm) noexcept
+{
+   using namespace amrex::literals;
+
+   auto eos = pele::physics::PhysicsType::eos();
+   // Get rho & Y from rhoY
+   amrex::Real rho = 0.0_rt;
+   for (int n = 0; n < NUM_SPECIES; n++) {
+      rho += rhoY(i,j,k,n);
+   }
+   amrex::Real rhoinv = 1.0_rt / rho;
+   amrex::Real y[NUM_SPECIES] = {0.0};
+   for (int n = 0; n < NUM_SPECIES; n++) {
+      y[n] = rhoY(i,j,k,n) * rhoinv;
+   }
+   rho *= 1.0e-3_rt;                          // MKS -> CGS conversion
+   amrex::Real Tloc = T(i,j,k);               // So that we can use const_array
+
+   amrex::Real rhoDi_cgs[NUM_SPECIES] = {0.0};
+   amrex::Real lambda_cgs = 0.0_rt;
+   amrex::Real mu_cgs = 0.0_rt;
+   amrex::Real dummy_xi = 0.0_rt;
+
+   bool get_xi = false;
+   bool get_mu = true;
+   bool get_lam = false;
+   bool get_Ddiag = false;
+   auto trans = pele::physics::PhysicsType::transport();
+   trans.transport(get_xi, get_mu, get_lam, get_Ddiag, Tloc,
+                   rho, y, rhoDi_cgs, mu_cgs, dummy_xi, lambda_cgs, trans_parm);
+
+   mu(i,j,k) = mu_cgs * 1.0e-1_rt;                       // CGS -> MKS conversions
+   for (int n = 0; n < NUM_SPECIES; n++) {
+      rhoDi(i,j,k,n) = mu_cgs * 1.0e-1_rt * ScInv;       // Constant Schmidt number
+   }
+
+   amrex::Real cpmix = 0.0_rt;
+   eos.TY2Cp(T(i,j,k), y, cpmix);
+   lambda(i,j,k) = mu_cgs * PrInv * cpmix * 1.0e-5_rt;   // Constant Prandtl number
+}
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+void
 getTransportCoeff(int i, int j, int k,
                   amrex::Array4<const amrex::Real> const& rhoY,
                   amrex::Array4<const amrex::Real> const& T,
@@ -799,4 +851,161 @@ getGammaInv(int i, int j, int k,
 
    return gammainv;
 }
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::GpuArray<amrex::Real, AMREX_SPACEDIM*AMREX_SPACEDIM>
+getVelGrad(int i, int j, int k,
+           amrex::Array4<const amrex::Real> const& vel_array,
+           amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const& dxinv) noexcept
+{
+  // Centered difference evaluation of velocity graident tensor
+  // Requires one additional ghost cell to be valid vs. box where evaluation is done
+  // The derivatives are put in the array with the following order:
+  // component: 0    ,  1    ,  2    ,  3    ,  4    , 5    ,  6    ,  7    ,  8
+  // in 2D:     dU/dx,  dV/dx,  dU/dy,  dV/dy
+  // in 3D:     dU/dx,  dV/dx,  dW/dx,  dU/dy,  dV/dy, dW/dy,  dU/dz,  dV/dz,  dW/dz
+  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM*AMREX_SPACEDIM> vel_grad;
+  for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+    AMREX_D_TERM(vel_grad[                   idim] = 0.5*(vel_array(i+1,j,k,idim) - vel_array(i-1,j,k,idim))*dxinv[0];,
+                 vel_grad[  AMREX_SPACEDIM + idim] = 0.5*(vel_array(i,j+1,k,idim) - vel_array(i,j-1,k,idim))*dxinv[1];,
+                 vel_grad[2*AMREX_SPACEDIM + idim] = 0.5*(vel_array(i,j,k+1,idim) - vel_array(i,j,k-1,idim))*dxinv[2];);
+  }
+  return vel_grad;
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+getSijSij(amrex::GpuArray<amrex::Real, AMREX_SPACEDIM*AMREX_SPACEDIM> const& vel_grad) noexcept
+{
+  // This function returns SijSij, not strain rate magnitude |S| = sqrt(2 SijSij)
+  amrex::Real SijSij = 0.0;
+  for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+    for (int jdim = 0; jdim < AMREX_SPACEDIM; ++jdim) {
+      // Sij = 0.5(dui/dxj + duj/dxi)
+      amrex::Real Sij = 0.5*(vel_grad[idim*AMREX_SPACEDIM + jdim] + vel_grad[jdim*AMREX_SPACEDIM + idim]);
+      SijSij += Sij*Sij;
+    }
+  }
+  return SijSij;
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+getVelGradTerm(amrex::GpuArray<amrex::Real, AMREX_SPACEDIM*AMREX_SPACEDIM> const& vel_grad) noexcept
+{
+  // Compute S^d_ij*S^d_ij
+  // S^d_ij = 0.5(g2_ij + g2_ji) - (1/3)*delta_ij*g2_kk
+  // g2_ij = du_i/dx_l * du_l/dx_j
+  // Therefore, g2_kk = du_k/dx_l * du_l/dx_k
+  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM*AMREX_SPACEDIM> g2_ij;
+  for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+    for (int jdim = 0; jdim < AMREX_SPACEDIM; ++jdim) {
+      g2_ij[idim*AMREX_SPACEDIM + jdim] = AMREX_D_TERM(vel_grad[idim*AMREX_SPACEDIM + 0]*vel_grad[0*AMREX_SPACEDIM + jdim],
+                                                       + vel_grad[idim*AMREX_SPACEDIM + 1]*vel_grad[1*AMREX_SPACEDIM + jdim],
+                                                       + vel_grad[idim*AMREX_SPACEDIM + 2]*vel_grad[2*AMREX_SPACEDIM + jdim]);
+    }
+  }
+  amrex::Real g2_kk_third = (1.0/AMREX_SPACEDIM) * (AMREX_D_TERM(g2_ij[0],
+                                                                 + g2_ij[AMREX_SPACEDIM + 1],
+                                                                 + g2_ij[2*AMREX_SPACEDIM + 2]));
+
+  amrex::Real SdijSdij = 0.0;
+  for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+    for (int jdim = 0; jdim < AMREX_SPACEDIM; ++jdim) {
+      amrex::Real Sdij = (idim == jdim) ? g2_ij[idim*AMREX_SPACEDIM + jdim] - g2_kk_third
+        : 0.5*(g2_ij[idim*AMREX_SPACEDIM + jdim] + g2_ij[jdim*AMREX_SPACEDIM + idim]);
+      SdijSdij += Sdij*Sdij;
+    }
+  }
+  return SdijSdij;
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+void
+getTurbViscSmagorinsky(int i, int j, int k,
+                       amrex::Real prefactor,
+                       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const& dxinv,
+                       amrex::Array4<const amrex::Real> const& vel,
+                       amrex::Array4<const amrex::Real> const& rho,
+                       amrex::Array4<      amrex::Real> const& mu_t) noexcept
+{
+   using namespace amrex::literals;
+
+   // mu_t = rho * Cs * Delta^2 * |S|    where |S| = sqrt(2 SijSij)
+
+   amrex::GpuArray<amrex::Real,AMREX_SPACEDIM*AMREX_SPACEDIM> Ugrad = getVelGrad(i,j,k,vel,dxinv);
+   amrex::Real Smag = std::sqrt(2.0 * getSijSij(Ugrad));
+   mu_t(i,j,k) = prefactor * rho(i,j,k) * Smag;
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+void
+getTurbViscWALES(int i, int j, int k,
+                 amrex::Real prefactor,
+                 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const& dxinv,
+                 amrex::Array4<const amrex::Real> const& vel,
+                 amrex::Array4<const amrex::Real> const& rho,
+                 amrex::Array4<      amrex::Real> const& mu_t) noexcept
+{
+   using namespace amrex::literals;
+
+   // From Ducros, Nicoud, and Poinsot 1999
+   // mu_t = rho * Cs * Delta^2 * (S^d_ijS^d_ij)^(3/2) / (SijSij^(5/2) + (S^d_ijS^d_ij)^(5/4) + smallnum)
+   // smallnum included to make sure denom is nonzero
+
+   amrex::GpuArray<amrex::Real,AMREX_SPACEDIM*AMREX_SPACEDIM> Ugrad = getVelGrad(i,j,k,vel,dxinv);
+   amrex::Real SijSij = getSijSij(Ugrad);
+   amrex::Real Sterm52 = std::pow(SijSij, 2.5);
+   amrex::Real Sdterm = getVelGradTerm(Ugrad); // (S^d_ijS^d_ij)
+   amrex::Real Sdterm14 = std::pow(Sdterm, 0.25);
+   amrex::Real Sdterm54 = Sdterm*Sdterm14;
+   amrex::Real Sdterm32 = Sdterm54*Sdterm14;
+   mu_t(i,j,k) = prefactor * rho(i,j,k) * Sdterm32 / (Sterm52 + Sdterm54 + 1.0e-12);
+}
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+void
+addTurbulentTransportToMolecular(int i, int j, int k,
+                                 amrex::Real Sc_inv, amrex::Real Pr_inv,
+                                 amrex::Array4<const amrex::Real> const& rhoY,
+                                 amrex::Array4<const amrex::Real> const& T,
+                                 amrex::Array4<const amrex::Real> const& mu_t,
+                                 amrex::Array4<      amrex::Real> const& rhoD,
+                                 amrex::Array4<      amrex::Real> const& lambda,
+                                 amrex::Array4<      amrex::Real> const& mu) noexcept
+{
+   using namespace amrex::literals;
+
+   // species diffusivities: pD_eff = rhoD_molec + mu_t/Sc_t
+   amrex::Real rhoD_t = mu_t(i,j,k) * Sc_inv;
+   for (int n = 0; n < NUM_SPECIES; n++) {
+     rhoD(i,j,k,n) += rhoD_t;
+   }
+
+   // thermal conductivity: lambda_t = lambda_molec + cp*mu_t/Pr_t
+   // Get rho & Y from rhoY
+   amrex::Real rho = 0.0_rt;
+   for (int n = 0; n < NUM_SPECIES; n++) {
+     rho += rhoY(i,j,k,n);
+   }
+   amrex::Real rhoinv = 1.0_rt / rho;
+   amrex::Real y[NUM_SPECIES] = {0.0};
+   for (int n = 0; n < NUM_SPECIES; n++) {
+     y[n] = rhoY(i,j,k,n) * rhoinv;
+   }
+   auto eos = pele::physics::PhysicsType::eos();
+   amrex::Real Cp;
+   eos.TY2Cp(T(i,j,k),y,Cp);
+   lambda(i,j,k)  += mu_t(i,j,k) * Cp * Pr_inv * 0.0001; // include cgs -> mks for Cp
+
+   // viscosity: mu_eff = mu_molec + mu_t
+   mu(i,j,k) += mu_t(i,j,k);
+}
+
 #endif


### PR DESCRIPTION
This PR enables LES transport models for scalars and momentum in PeleLMeX. The turbulent viscosity is computed either using constant coefficient Smagorinsky or WALES. Turbulent transport for species and enthalpy are applied using this turbulent viscosity and constant assumed Schmidt and Prandtl numbers. 

A few notes on the implementation:
- Turbulent viscosity is computed based on the velocity field at the old timestep (N). Because the velocity field is not updated until the very end of the timestep, this means that when diffusion terms at N+1 are computed, the turbulent part fo the diffusion coefficient is still based on data for timestep N. This limitation would also be present for the IAMR implementation.
- Turbulent viscosity is computed at cell centers using centered differences to evaluate velocity gradients at the cell centers. This is so they can be directly added to the molecular diffusion coefficients, which are computed at cell centers. 
- EB compatibility not tested/supported yet

This PR also pulls in the unity Lewis number diffusion feature from LM, as that may often be desired for LES. 

Draft until documentation is added.