### PR TITLE
Add an option to use pc_interp when adding brand new level

### DIFF
--- a/Docs/source/LMeXControls.rst
+++ b/Docs/source/LMeXControls.rst
@@ -135,6 +135,9 @@ The following list of derived variables are available in PeleLMeX:
     * - `HeatRelease`
       - 1
       - Heat release rate from chem. reactions
+    * - `rhominsumrhoY`
+      - 1
+      - Rho minus sum of rhoYs, for debug purposes
 
 Note that `mixture_fraction` and `progress_variable` requires additional inputs from the users as described below.
 

--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -495,6 +495,9 @@ class PeleLM : public amrex::AmrCore {
    void setThermoPress(const PeleLM::TimeStamp &a_time);
    void setThermoPress(int lev, const PeleLM::TimeStamp &a_time);
 
+   // Enforce rho/rhoYs consistency
+   void setRhoToSumRhoY(int lev, const PeleLM::TimeStamp &a_time);
+
    // update Temperature from rhoY and rhoH
    void setTemperature(const PeleLM::TimeStamp &a_time);
    void setTemperature(int lev, const PeleLM::TimeStamp &a_time);
@@ -560,8 +563,11 @@ class PeleLM : public amrex::AmrCore {
 
    //-----------------------------------------------------------------------------
    // BOUNDARY CONDITIONS / FILLPATCH
+   amrex::InterpBase* getInterpolator(int a_method=1);
 
-   amrex::InterpBase* getInterpolator();
+   // Interpolation method for regrid (default to cell cons interp)
+   int m_regrid_interp_method = 1;
+
    // Convert PhysBC into field BCs
    void setBoundaryConditions();
 

--- a/Source/PeleLMDeriveFunc.H
+++ b/Source/PeleLMDeriveFunc.H
@@ -43,6 +43,11 @@ void pelelm_deravgpress (PeleLM* a_pelelm, const amrex::Box& bx, amrex::FArrayBo
                          const amrex::Geometry& geomdata,
                          amrex::Real time, const amrex::Vector<amrex::BCRec> &bcrec, int level);
 
+void pelelm_derrhomrhoy (PeleLM* a_pelelm, const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int ncomp,
+                         const amrex::FArrayBox& statefab, const amrex::FArrayBox& reactfab, const amrex::FArrayBox& pressfab,
+                         const amrex::Geometry& geomdata,
+                         amrex::Real time, const amrex::Vector<amrex::BCRec> &bcrec, int level);
+
 void pelelm_dermgvort (PeleLM* a_pelelm, const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int ncomp,
                        const amrex::FArrayBox& statefab, const amrex::FArrayBox& reactfab, const amrex::FArrayBox& pressfab,
                        const amrex::Geometry& geomdata,

--- a/Source/PeleLMDeriveFunc.cpp
+++ b/Source/PeleLMDeriveFunc.cpp
@@ -120,6 +120,33 @@ void pelelm_dermolefrac (PeleLM* a_pelelm, const Box& bx, FArrayBox& derfab, int
 }
 
 //
+// Extract rho - sum rhoY
+//
+void pelelm_derrhomrhoy (PeleLM* a_pelelm, const Box& bx, FArrayBox& derfab, int dcomp, int ncomp,
+                         const FArrayBox& statefab, const FArrayBox& /*reactfab*/, const FArrayBox& /*pressfab*/,
+                         const Geometry& /*geomdata*/,
+                         Real /*time*/, const Vector<BCRec>& /*bcrec*/, int /*level*/)
+
+{
+    AMREX_ASSERT(derfab.box().contains(bx));
+    AMREX_ASSERT(statefab.box().contains(bx));
+    AMREX_ASSERT(derfab.nComp() >= dcomp + ncomp);
+    AMREX_ASSERT(statefab.nComp() >= NUM_SPECIES+1);
+    AMREX_ASSERT(ncomp == NUM_SPECIES);
+    AMREX_ASSERT(!a_pelelm->m_incompressible);
+    auto const in_dat = statefab.array();
+    auto       der = derfab.array(dcomp);
+    amrex::ParallelFor(bx,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    {
+        der(i,j,k,0) = in_dat(i,j,k,DENSITY);
+        for (int n = 0; n < NUM_SPECIES; n++) {
+            der(i,j,k,0) -= in_dat(i,j,k,FIRSTSPEC+n);
+        }
+    });
+}
+
+//
 // Compute cell averaged pressure from nodes
 //
 void pelelm_deravgpress (PeleLM* a_pelelm, const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,

--- a/Source/PeleLMRegrid.cpp
+++ b/Source/PeleLMRegrid.cpp
@@ -75,6 +75,12 @@ void PeleLM::MakeNewLevelFromCoarse( int lev,
    }
 
    if (!m_incompressible) {
+      // Enforce density / species density consistency
+      // only usefull when using cell cons interp
+      if (m_regrid_interp_method == 1) {
+         setRhoToSumRhoY(lev, AmrNewTime);
+      }
+
       // Initialize thermodynamic pressure
       setThermoPress(lev, AmrNewTime);
    }

--- a/Source/PeleLMSetup.cpp
+++ b/Source/PeleLMSetup.cpp
@@ -543,6 +543,8 @@ void PeleLM::readIOParameters() {
    pp.query("regrid_file", m_regrid_file);
    pp.query("file_stepDigits", m_ioDigits);
    pp.query("use_hdf5_plt",m_write_hdf5_pltfile);
+   pp.query("regrid_interp_method",m_regrid_interp_method);
+   AMREX_ASSERT(m_regrid_interp_method == 0 || m_regrid_interp_method == 1);
 
 }
 

--- a/Source/PeleLMSetup.cpp
+++ b/Source/PeleLMSetup.cpp
@@ -762,6 +762,9 @@ void PeleLM::derivedSetup()
       derive_lst.add("diffcoeff",IndexType::TheCellType(),NUM_SPECIES,
                      var_names_massfrac,pelelm_derdiffc,the_same_box);
 
+      // Rho - sum rhoYs
+      derive_lst.add("rhominsumrhoY",IndexType::TheCellType(),1,pelelm_derrhomrhoy,the_same_box);
+
       // Heat Release
       derive_lst.add("HeatRelease",IndexType::TheCellType(),1,pelelm_derheatrelease,the_same_box);
 


### PR DESCRIPTION
One can use `amr.regrid_interp_method = 0` when adding brand new levels if the usual interpolator introduces issues with new extremas.