### PR TITLE
LES Transport and Unity Lewis Numbers

### DIFF
--- a/Docs/source/manual/LMeXControls.rst
+++ b/Docs/source/manual/LMeXControls.rst
@@ -190,7 +190,7 @@ Transport coeffs and LES
     peleLM.les_cm_wale = 0.60              # [OPT, DEF=0.60] If using WALE LES model, provides model coefficient
     peleLM.les_v = 0                       # [OPT, DEF=0] Verbosity level for LES model
     peleLM.plot_les = 0                    # [OPT, DEF=0] If doing LES, whether to plot the turbulent viscosity
-    
+
 Chemistry integrator
 --------------------
 

--- a/Docs/source/manual/LMeXControls.rst
+++ b/Docs/source/manual/LMeXControls.rst
@@ -177,6 +177,20 @@ PeleLMeX algorithm
     peleLM.deltaT_tol = 1e-10              # [OPT, DEF=1.e-10] Tolerance of the deltaT solve
     peleLM.evaluate_vars =...              # [OPT, DEF=""] In evaluate mode, list unitTest: diffTerm, divU, instRR, transportCC
 
+Transport coeffs and LES
+------------------------
+
+::
+
+    #-----------------------DIFFUSION AND LES MODEL CONTROL-----------------------
+    peleLM.unity_Le = 0                    # [OPT, DEF=0] Use the unity Lewis number approximation for diffusivities
+    peleLM.Prandtl = 0.7                   # [OPT, DEF=0.7] If unity_Le or doing LES, specifies the Prandtl number
+    peleLM.les_model = "None"              # [OPT, DEF="None"] Model to compute turbulent viscosity: None, Smagorinsky, WALE
+    peleLM.les_cs_smag = 0.18              # [OPT, DEF=0.18] If using Smagorinsky LES model, provides model coefficient
+    peleLM.les_cm_wale = 0.60              # [OPT, DEF=0.60] If using WALE LES model, provides model coefficient
+    peleLM.les_v = 0                       # [OPT, DEF=0] Verbosity level for LES model
+    peleLM.plot_les = 0                    # [OPT, DEF=0] If doing LES, whether to plot the turbulent viscosity
+    
 Chemistry integrator
 --------------------
 

--- a/Docs/source/manual/Model.rst
+++ b/Docs/source/manual/Model.rst
@@ -394,7 +394,7 @@ where filtered quantities are indicated with an overbar, Favre-filtered quantiti
 a tilde. In the WALE model, it is computed as:
 
 .. math::
-   \mu_t = \overline{\rho} C_m^2 \Delta^2 \frac{\left(\widetilde{S}_{ij}^{d}\widetilde{S}_{ij}^{d} \right)^{3/2} + }{\left(\widetilde{S}_{ij}\widetilde{S}_{ij} \right)^{5/2} + \left(\widetilde{S}_{ij}^{d}\widetilde{S}_{ij}^{d} \right)^{5/4}}, 
+   \mu_t = \overline{\rho} C_m^2 \Delta^2 \frac{\left(\widetilde{S}_{ij}^{d}\widetilde{S}_{ij}^{d} \right)^{3/2} + }{\left(\widetilde{S}_{ij}\widetilde{S}_{ij} \right)^{5/2} + \left(\widetilde{S}_{ij}^{d}\widetilde{S}_{ij}^{d} \right)^{5/4}},
    \hspace{12pt} \widetilde{S}_{ij}^d = \frac{1}{2}\left( \left(\frac{\partial \widetilde{u}_i}{\partial x_j} \right)^2 + \left(\frac{\partial \widetilde{u}_j}{\partial x_i} \right)^2 \right) - \frac{\delta_{ij}}{3} \left(\frac{\partial \widetilde{u}_k}{\partial x_k} \right)^{2}.
 
 The total diffusive transport of momentum from both viscous and turbulent stresses is then computed as
@@ -403,9 +403,9 @@ The total diffusive transport of momentum from both viscous and turbulent stress
    \frac{\partial}{\partial x_j}{ \left( \bar{\sigma}_{ij} \right)}
    - \frac{\partial}{\partial x_j}{ \left(\bar{\rho}\widetilde{u_i u_j} - \bar{\rho}\widetilde{u_i} \widetilde{u_j} \right)}
    = \frac{\partial}{\partial x_j}\left[\left(\widetilde{\mu} + \mu_t \right)\left(\frac{\partial \widetilde{u}_i}{\partial x_j}
-   + \frac{\partial \widetilde{u}_j}{\partial x_i}- \frac{2}{3} \frac{\partial \widetilde{u}_k}{\partial x_k}\delta_{ij} \right)  \right] 
+   + \frac{\partial \widetilde{u}_j}{\partial x_i}- \frac{2}{3} \frac{\partial \widetilde{u}_k}{\partial x_k}\delta_{ij} \right)  \right]
 
-The thermal conducivity and species diffusivities are similarly modified with turbulent contributions, :math:`\lambda_t = \mu_t \widetilde{c_p} / Pr_t` and :math:`(\rho D)_t = \mu_t/Sc_t`. The solution algorithm is unchanged other than the addition of these turbulent coefficients to the corresponding molecular transport properties. Nominal values for the model coefficients are :math:`c_s = 0.18`, :math:`c_m = 0.60`, and :math:`Sc_t = Pr_t = 0.7`. 
+The thermal conducivity and species diffusivities are similarly modified with turbulent contributions, :math:`\lambda_t = \mu_t \widetilde{c_p} / Pr_t` and :math:`(\rho D)_t = \mu_t/Sc_t`. The solution algorithm is unchanged other than the addition of these turbulent coefficients to the corresponding molecular transport properties. Nominal values for the model coefficients are :math:`c_s = 0.18`, :math:`c_m = 0.60`, and :math:`Sc_t = Pr_t = 0.7`.
 
 **Limitations**: Because the turbulent transport coefficients are nonlinear functions of the velocity field, the treatment of
 the diffusion terms is not fully implicity when LES models are active. While the implicit solves as described above are kept

--- a/Docs/source/manual/Model.rst
+++ b/Docs/source/manual/Model.rst
@@ -377,3 +377,38 @@ efficiency of the multigrid appraoch relies on generating coarse version of the 
 supported by AMReX) and the linear solvers are no longer able to robustly tackle projections and implicit diffusion solves. AMReX
 include an interface to HYPRE which can help circumvent the issue by sending the coarse-level geometry directly to HYPRE algebraic
 multigrid solvers. More details on how to use HYPRE is provided in control Section.
+
+Large Eddy Simulation
+^^^^^^^^^^^^^^^^^^^^^
+
+To provide closure for the unresolved trubulent stress/flux terms in Large Eddy Simulation (LES), PeleLMeX supports the
+constant-coefficient Smagorinsky and WALE models for turbulent transport of momentum, species, and energy. These models are
+based on a gradient transport assumption, resulting in terms analagous to the molecular transport of these quantities, but with
+modified turbulent transport coefficients. In the Smgorinsky model, the turbulent viscosity :math:`\mu_t` is computed as:
+
+.. math::
+
+   \mu_t = \overline{\rho} C_s^2 \bar{\Delta}^2 |\widetilde{S}|, \hspace{12pt}  \widetilde{S}_{ij} = \frac{1}{2} \left(\frac{\partial u_i}{\partial x_j} + \frac{\partial u_j}{\partial x_i} \right).
+
+where filtered quantities are indicated with an overbar, Favre-filtered quantities are indicated with
+a tilde. In the WALE model, it is computed as:
+
+.. math::
+   \mu_t = \overline{\rho} C_m^2 \Delta^2 \frac{\left(\widetilde{S}_{ij}^{d}\widetilde{S}_{ij}^{d} \right)^{3/2} + }{\left(\widetilde{S}_{ij}\widetilde{S}_{ij} \right)^{5/2} + \left(\widetilde{S}_{ij}^{d}\widetilde{S}_{ij}^{d} \right)^{5/4}}, 
+   \hspace{12pt} \widetilde{S}_{ij}^d = \frac{1}{2}\left( \left(\frac{\partial \widetilde{u}_i}{\partial x_j} \right)^2 + \left(\frac{\partial \widetilde{u}_j}{\partial x_i} \right)^2 \right) - \frac{\delta_{ij}}{3} \left(\frac{\partial \widetilde{u}_k}{\partial x_k} \right)^{2}.
+
+The total diffusive transport of momentum from both viscous and turbulent stresses is then computed as
+
+.. math::
+   \frac{\partial}{\partial x_j}{ \left( \bar{\sigma}_{ij} \right)}
+   - \frac{\partial}{\partial x_j}{ \left(\bar{\rho}\widetilde{u_i u_j} - \bar{\rho}\widetilde{u_i} \widetilde{u_j} \right)}
+   = \frac{\partial}{\partial x_j}\left[\left(\widetilde{\mu} + \mu_t \right)\left(\frac{\partial \widetilde{u}_i}{\partial x_j}
+   + \frac{\partial \widetilde{u}_j}{\partial x_i}- \frac{2}{3} \frac{\partial \widetilde{u}_k}{\partial x_k}\delta_{ij} \right)  \right] 
+
+The thermal conducivity and species diffusivities are similarly modified with turbulent contributions, :math:`\lambda_t = \mu_t \widetilde{c_p} / Pr_t` and :math:`(\rho D)_t = \mu_t/Sc_t`. The solution algorithm is unchanged other than the addition of these turbulent coefficients to the corresponding molecular transport properties. Nominal values for the model coefficients are :math:`c_s = 0.18`, :math:`c_m = 0.60`, and :math:`Sc_t = Pr_t = 0.7`. 
+
+**Limitations**: Because the turbulent transport coefficients are nonlinear functions of the velocity field, the treatment of
+the diffusion terms is not fully implicity when LES models are active. While the implicit solves as described above are kept
+in place to ensure numerical stability, the turbulent transport coefficients are evaluated only at the old timestep, with the
+old turbulent values also used to approximate the values at the new timestep. Additionally, the present implementation cannot
+be used with EB or EFIELD.

--- a/Source/DiffusionOp.H
+++ b/Source/DiffusionOp.H
@@ -131,6 +131,9 @@ public:
                          const amrex::BCRec &a_bcrec,
                          amrex::Real dt);
 
+  void computeGradientTensor(amrex::Vector<amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM>> const& a_velgrad,
+                             amrex::Vector<amrex::MultiFab const*> const& a_vel);
+
 private:
 
    void readParameters ();
@@ -142,10 +145,12 @@ private:
    // Apply operator
    std::unique_ptr<amrex::MLEBTensorOp> m_apply_op;
    std::unique_ptr<amrex::MLEBTensorOp> m_solve_op;
+   std::unique_ptr<amrex::MLEBTensorOp> m_gradient_op;
 #else
    // Apply operator
    std::unique_ptr<amrex::MLTensorOp> m_apply_op;
    std::unique_ptr<amrex::MLTensorOp> m_solve_op;
+   std::unique_ptr<amrex::MLTensorOp> m_gradient_op;
 #endif
 
    int m_verbose = 0;

--- a/Source/DiffusionOp.H
+++ b/Source/DiffusionOp.H
@@ -145,12 +145,10 @@ private:
    // Apply operator
    std::unique_ptr<amrex::MLEBTensorOp> m_apply_op;
    std::unique_ptr<amrex::MLEBTensorOp> m_solve_op;
-   std::unique_ptr<amrex::MLEBTensorOp> m_gradient_op;
 #else
    // Apply operator
    std::unique_ptr<amrex::MLTensorOp> m_apply_op;
    std::unique_ptr<amrex::MLTensorOp> m_solve_op;
-   std::unique_ptr<amrex::MLTensorOp> m_gradient_op;
 #endif
 
    int m_verbose = 0;

--- a/Source/DiffusionOp.cpp
+++ b/Source/DiffusionOp.cpp
@@ -191,9 +191,11 @@ void DiffusionOp::diffuse_scalar(Vector<MultiFab*> const& a_phi, int phi_comp,
 
          if (have_bcoeff) {
             int doZeroVisc = 1;
+            int addTurbContrib = 1;
             Vector<BCRec> subBCRec = {a_bcrec.begin()+comp,a_bcrec.begin()+comp+m_ncomp};
             Array<MultiFab,AMREX_SPACEDIM> bcoeff_ec = m_pelelm->getDiffusivity(lev, bcoeff_comp+comp, m_ncomp,
-                                                                                doZeroVisc, subBCRec, *a_bcoeff[lev]);
+                                                                                doZeroVisc, subBCRec, *a_bcoeff[lev],
+                                                                                addTurbContrib);
 #ifdef AMREX_USE_EB
             m_scal_solve_op->setBCoeffs(lev, GetArrOfConstPtrs(bcoeff_ec), MLMG::Location::FaceCentroid);
 #else
@@ -314,9 +316,11 @@ void DiffusionOp::computeDiffLap(Vector<MultiFab*> const& a_laps, int lap_comp,
           laps.emplace_back(*a_laps[lev],amrex::make_alias,lap_comp+comp,m_ncomp);
           component.emplace_back(phi[lev],amrex::make_alias,comp,m_ncomp);
           int doZeroVisc = 0;
+          int addTurbContrib = 0;
           Vector<BCRec> subBCRec = {a_bcrec.begin()+comp,a_bcrec.begin()+comp+m_ncomp};
           Array<MultiFab,AMREX_SPACEDIM> bcoeff_ec = m_pelelm->getDiffusivity(lev, bcoeff_comp+comp, m_ncomp,
-                                                                              doZeroVisc, subBCRec, *a_bcoeff[lev]);
+                                                                              doZeroVisc, subBCRec, *a_bcoeff[lev],
+                                                                              addTurbContrib);
 
 #ifdef AMREX_USE_EB
           m_scal_apply_op->setBCoeffs(lev, GetArrOfConstPtrs(bcoeff_ec), MLMG::Location::FaceCentroid);
@@ -411,9 +415,11 @@ void DiffusionOp::computeDiffFluxes(Vector<Array<MultiFab*,AMREX_SPACEDIM>> cons
          }
          component.emplace_back(phi[lev],amrex::make_alias,comp,m_ncomp);
          int doZeroVisc = 1;
+         int addTurbContrib = 1;
          Vector<BCRec> subBCRec = {a_bcrec.begin()+comp,a_bcrec.begin()+comp+m_ncomp};
          Array<MultiFab,AMREX_SPACEDIM> bcoeff_ec = m_pelelm->getDiffusivity(lev, bcoeff_comp+comp, m_ncomp,
-                                                                             doZeroVisc, subBCRec, *a_bcoeff[lev]);
+                                                                             doZeroVisc, subBCRec, *a_bcoeff[lev],
+                                                                             addTurbContrib);
          laps.emplace_back(a_phi[lev]->boxArray(), a_phi[lev]->DistributionMap(),
                            m_ncomp, 1, MFInfo(), a_phi[lev]->Factory());
 #ifdef AMREX_USE_EB
@@ -599,6 +605,67 @@ DiffusionTensorOp::DiffusionTensorOp (PeleLM* a_pelelm)
    m_apply_op->setDomainBC(m_pelelm->getDiffusionTensorOpBC(Orientation::low,bcRecVel),
                            m_pelelm->getDiffusionTensorOpBC(Orientation::high,bcRecVel));
 
+   // Gradient Operator
+   LPInfo info_gradient;
+#ifdef AMREX_USE_EB
+   m_gradient_op.reset(new MLEBTensorOp(m_pelelm->Geom(0,finest_level),
+                                        m_pelelm->boxArray(0,finest_level),
+                                        m_pelelm->DistributionMap(0,finest_level),
+                                        info_gradient,ebfactVec));
+#else
+   m_gradient_op.reset(new MLTensorOp(m_pelelm->Geom(0,finest_level),
+                                      m_pelelm->boxArray(0,finest_level),
+                                      m_pelelm->DistributionMap(0,finest_level),
+                                      info_gradient));
+#endif
+   m_gradient_op->setMaxOrder(m_mg_maxorder);
+   m_gradient_op->setDomainBC(m_pelelm->getDiffusionTensorOpBC(Orientation::low,bcRecVel),
+                              m_pelelm->getDiffusionTensorOpBC(Orientation::high,bcRecVel));
+}
+
+void DiffusionTensorOp::computeGradientTensor (Vector<Array<MultiFab*, AMREX_SPACEDIM>> const& a_velgrad,
+                                               Vector<MultiFab const*> const& a_vel)
+{
+   // This function returns the velocity gradient tensor at faces
+   //
+   // The derivatives are put in the array with the following order:
+   // component: 0    ,  1    ,  2    ,  3    ,  4    , 5    ,  6    ,  7    ,  8
+   // in 2D:     dU/dx,  dV/dx,  dU/dy,  dV/dy
+   // in 3D:     dU/dx,  dV/dx,  dW/dx,  dU/dy,  dV/dy, dW/dy,  dU/dz,  dV/dz,  dW/dz
+
+   int finest_level = m_pelelm->finestLevel();
+
+   // Duplicate vel since it may be modified by the TensorOp
+   Vector<MultiFab> vel(finest_level+1);
+   for (int lev = 0; lev <= finest_level; ++lev) {
+      vel[lev].define(a_vel[lev]->boxArray(), a_vel[lev]->DistributionMap(),
+                     AMREX_SPACEDIM, 1, MFInfo(), a_vel[lev]->Factory());
+      MultiFab::Copy(vel[lev], *a_vel[lev], 0, 0, AMREX_SPACEDIM, 1);
+   }
+
+   // Set up some parameters
+   m_gradient_op->setMaxOrder(m_mg_maxorder);
+   m_gradient_op->setScalars(0.0,1.0);
+   for (int lev = 0; lev <= finest_level; ++lev) {
+     m_gradient_op->setShearViscosity(lev,0.0);
+     m_gradient_op->setLevelBC(lev, &vel[lev]);
+   }
+
+   // Dummy variable for applying MLMG operator
+   amrex::Vector<amrex::MultiFab> divtau;
+   for (int lev = 0; lev <= finest_level; ++lev) {
+     divtau.emplace_back(a_vel[lev]->boxArray(), a_vel[lev]->DistributionMap(),
+                         AMREX_SPACEDIM, 1, MFInfo(), a_vel[lev]->Factory());
+   }
+
+   // Create MLMG object and apply to setup BCs, etc
+   MLMG mlmg(*m_gradient_op);
+   mlmg.apply(GetVecOfPtrs(divtau), GetVecOfPtrs(vel));
+
+   // Compute the velocity gradient on faces
+   for (int lev = 0; lev <= finest_level; ++lev) {
+     m_gradient_op->compVelGrad(lev, a_velgrad[lev], vel[lev], MLLinOp::Location::FaceCentroid);
+   }
 }
 
 void DiffusionTensorOp::compute_divtau (Vector<MultiFab*> const& a_divtau,
@@ -637,8 +704,10 @@ void DiffusionTensorOp::compute_divtau (Vector<MultiFab*> const& a_divtau,
           m_apply_op->setACoeffs(lev, *a_density[lev]);
        }
        int doZeroVisc = 0;
+       int addTurbContrib = 1;
        Array<MultiFab,AMREX_SPACEDIM> beta_ec = m_pelelm->getDiffusivity(lev, 0, 1,
-                                                                         doZeroVisc, {a_bcrec}, *a_beta[lev]);
+                                                                         doZeroVisc, {a_bcrec}, *a_beta[lev],
+                                                                         addTurbContrib);
        m_apply_op->setShearViscosity(lev, GetArrOfConstPtrs(beta_ec), MLMG::Location::FaceCentroid);
        m_apply_op->setEBShearViscosity(lev, *a_beta[lev]);
        m_apply_op->setLevelBC(lev, &vel[lev]);
@@ -660,8 +729,10 @@ void DiffusionTensorOp::compute_divtau (Vector<MultiFab*> const& a_divtau,
           m_apply_op->setACoeffs(lev, *a_density[lev]);
        }
        int doZeroVisc = 0;
+       int addTurbContrib = 1;
        Array<MultiFab,AMREX_SPACEDIM> beta_ec = m_pelelm->getDiffusivity(lev, 0, 1,
-                                                                         doZeroVisc, {a_bcrec}, *a_beta[lev]);
+                                                                         doZeroVisc, {a_bcrec}, *a_beta[lev],
+                                                                         addTurbContrib);
        m_apply_op->setShearViscosity(lev, GetArrOfConstPtrs(beta_ec));
        m_apply_op->setLevelBC(lev, &vel[lev]);
    }
@@ -714,8 +785,10 @@ void DiffusionTensorOp::diffuse_velocity (Vector<MultiFab*> const& a_vel,
           m_solve_op->setACoeffs(lev, m_pelelm->m_rho);
        }
        int doZeroVisc = 0;
+       int addTurbContrib = 1;
        Array<MultiFab,AMREX_SPACEDIM> beta_ec = m_pelelm->getDiffusivity(lev, 0, 1,
-                                                                         doZeroVisc, {a_bcrec}, *a_beta[lev]);
+                                                                         doZeroVisc, {a_bcrec}, *a_beta[lev],
+                                                                         addTurbContrib);
 #ifdef AMREX_USE_EB
        m_solve_op->setShearViscosity(lev, GetArrOfConstPtrs(beta_ec), MLMG::Location::FaceCentroid);
        m_solve_op->setEBShearViscosity(lev, *a_beta[lev]);

--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -147,7 +147,7 @@ class PeleLM : public amrex::AmrCore {
                  amrex::DistributionMapping const& dm,
                  amrex::FabFactory<amrex::FArrayBox> const& factory,
                  int a_incompressible, int a_has_divu,
-                 int a_nAux, int a_nGrowState);
+                 int a_nAux, int a_nGrowState, int a_do_les);
 
       // cell-centered state multifabs
       amrex::MultiFab state;           // Stqte data: velocity, density, rhoYs, rhoH, Temp, RhoRT
@@ -160,6 +160,8 @@ class PeleLM : public amrex::AmrCore {
 
       // cell-centered transport multifabs
       amrex::MultiFab visc_cc;         // Viscosity (dim:1)
+      amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> visc_turb_fc;    // Turbulent Viscosity (dim:)
+      amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> lambda_turb_fc;    // Turbulent thermal conductivity (dim:)
       amrex::MultiFab diff_cc;         // Diffusivity (dim:NUM_SPECIES+2)
 #ifdef PELE_USE_EFIELD
       amrex::MultiFab diffE_cc;        // Electron diffusivity (dim:1)
@@ -313,13 +315,15 @@ class PeleLM : public amrex::AmrCore {
 
    // compute cell-centered diffusivity (stored in LevelData)
    void calcViscosity(const PeleLM::TimeStamp &a_time);
+   void calcTurbViscosity(const PeleLM::TimeStamp &a_time);
    void calcDiffusivity(const PeleLM::TimeStamp &a_time);
 
    // get edge-centered diffusivity on a per level / per comp basis
    amrex::Array<amrex::MultiFab,AMREX_SPACEDIM>
    getDiffusivity(int lev, int beta_comp, int ncomp, int doZeroVisc,
                   amrex::Vector<amrex::BCRec> a_bcrec,
-                  const amrex::MultiFab &a_diff_cc);
+                  const amrex::MultiFab &a_diff_cc,
+                  int addTurbContrib = 0);
 
    // get species/enthalpy differential diffusion fluxes
    void computeDifferentialDiffusionFluxes(const PeleLM::TimeStamp &a_time,
@@ -1153,8 +1157,21 @@ class PeleLM : public amrex::AmrCore {
    // cc->ec average
    int m_harm_avg_cen2edge = 0;
 
-   // wbar diffusion term
+
+   // Diffusion
+   int m_unity_Le = 0;
+   amrex::Real m_Schmidt_inv = 1.0/0.7;
+   amrex::Real m_Prandtl_inv = 1.0/0.7;
    int m_use_wbar = 1;
+
+   // LES Model
+   bool m_do_les = false;
+   bool m_plot_les = false;
+   int m_les_verbose = 0;
+   std::string m_les_model = "None";
+   amrex::Real m_les_cs_smag = 0.0;
+   amrex::Real m_les_cs_wale = 0.0;
+   amrex::Vector<amrex::Real> m_turb_visc_time;
 
    // switch on/off different processes
    // TODO: actually implement that

--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -1169,8 +1169,8 @@ class PeleLM : public amrex::AmrCore {
    bool m_plot_les = false;
    int m_les_verbose = 0;
    std::string m_les_model = "None";
-   amrex::Real m_les_cs_smag = 0.0;
-   amrex::Real m_les_cs_wale = 0.0;
+   amrex::Real m_les_cs_smag = 0.18;
+   amrex::Real m_les_cm_wale = 0.60;
    amrex::Vector<amrex::Real> m_turb_visc_time;
 
    // switch on/off different processes

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -38,7 +38,7 @@ PeleLM::getLevelDataPtr(int lev, const PeleLM::TimeStamp &a_time, int /*useUMac*
    } else {
       m_leveldata_floating.reset( new LevelData(grids[lev], dmap[lev], *m_factory[lev],
                                   m_incompressible, m_has_divu,
-                                  m_nAux, m_nGrowState));
+                                  m_nAux, m_nGrowState, m_do_les));
       Real time = getTime(lev,a_time);
       fillpatch_state(lev, time, m_leveldata_floating->state, m_nGrowState);
       //if (useUMac) {

--- a/Source/PeleLMData.cpp
+++ b/Source/PeleLMData.cpp
@@ -6,7 +6,7 @@ PeleLM::LevelData::LevelData(amrex::BoxArray const& ba,
                              amrex::DistributionMapping const& dm,
                              amrex::FabFactory<FArrayBox> const& factory,
                              int a_incompressible, int a_has_divu,
-                             int a_nAux, int a_nGrowState)
+                             int a_nAux, int a_nGrowState, int a_do_les)
 {
    if (a_incompressible ) {
        state.define(  ba, dm, AMREX_SPACEDIM , a_nGrowState, MFInfo(), factory);
@@ -17,6 +17,14 @@ PeleLM::LevelData::LevelData(amrex::BoxArray const& ba,
    press.define(   amrex::convert(ba,IntVect::TheNodeVector()),
                        dm, 1             , 1           , MFInfo(), factory);
    visc_cc.define( ba, dm, 1             , 1           , MFInfo(), factory);
+   if (a_do_les) {
+     for (int i; i < AMREX_SPACEDIM; ++i) {
+       visc_turb_fc[i].define(amrex::convert(ba,IntVect::TheDimensionVector(i)), dm, 1, 0, MFInfo(), factory);
+       if (!a_incompressible) {
+         lambda_turb_fc[i].define(amrex::convert(ba,IntVect::TheDimensionVector(i)), dm, 1, 0, MFInfo(), factory);
+       }
+     }
+   }
    if (! a_incompressible ) {
       if (a_has_divu) {
          divu.define (ba, dm, 1             , 1           , MFInfo(), factory);

--- a/Source/PeleLMData.cpp
+++ b/Source/PeleLMData.cpp
@@ -18,7 +18,7 @@ PeleLM::LevelData::LevelData(amrex::BoxArray const& ba,
                        dm, 1             , 1           , MFInfo(), factory);
    visc_cc.define( ba, dm, 1             , 1           , MFInfo(), factory);
    if (a_do_les) {
-     for (int i; i < AMREX_SPACEDIM; ++i) {
+     for (int i = 0; i < AMREX_SPACEDIM; ++i) {
        visc_turb_fc[i].define(amrex::convert(ba,IntVect::TheDimensionVector(i)), dm, 1, 0, MFInfo(), factory);
        if (!a_incompressible) {
          lambda_turb_fc[i].define(amrex::convert(ba,IntVect::TheDimensionVector(i)), dm, 1, 0, MFInfo(), factory);

--- a/Source/PeleLMDeriveFunc.cpp
+++ b/Source/PeleLMDeriveFunc.cpp
@@ -582,7 +582,7 @@ void pelelm_derdiffc (PeleLM* a_pelelm, const Box& bx, FArrayBox& derfab, int dc
     auto         mu  = dummies.array(1);
     auto const* ltransparm = a_pelelm->trans_parms.device_trans_parm();
     amrex::Real ScInv = a_pelelm->m_Schmidt_inv;
-    amrex::Real PrInv = a_pelelm->m_Schmidt_inv;
+    amrex::Real PrInv = a_pelelm->m_Prandtl_inv;
     int unity_Le = a_pelelm->m_unity_Le;
     amrex::ParallelFor(bx,
     [rhoY,T,rhoD,lambda,mu,ltransparm,unity_Le,ScInv,PrInv]
@@ -616,7 +616,7 @@ void pelelm_derlambda (PeleLM* a_pelelm, const Box& bx, FArrayBox& derfab, int d
     auto         mu  = dummies.array(0);
     auto const* ltransparm = a_pelelm->trans_parms.device_trans_parm();
     amrex::Real ScInv = a_pelelm->m_Schmidt_inv;
-    amrex::Real PrInv = a_pelelm->m_Schmidt_inv;
+    amrex::Real PrInv = a_pelelm->m_Prandtl_inv;
     int unity_Le = a_pelelm->m_unity_Le;
     amrex::ParallelFor(bx,
     [rhoY,T,rhoD,lambda,mu,ltransparm,unity_Le,ScInv,PrInv]

--- a/Source/PeleLMDeriveFunc.cpp
+++ b/Source/PeleLMDeriveFunc.cpp
@@ -581,10 +581,18 @@ void pelelm_derdiffc (PeleLM* a_pelelm, const Box& bx, FArrayBox& derfab, int dc
     auto     lambda  = dummies.array(0);
     auto         mu  = dummies.array(1);
     auto const* ltransparm = a_pelelm->trans_parms.device_trans_parm();
+    amrex::Real ScInv = a_pelelm->m_Schmidt_inv;
+    amrex::Real PrInv = a_pelelm->m_Schmidt_inv;
+    int unity_Le = a_pelelm->m_unity_Le;
     amrex::ParallelFor(bx,
-    [rhoY,T,rhoD,lambda,mu,ltransparm] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [rhoY,T,rhoD,lambda,mu,ltransparm,unity_Le,ScInv,PrInv]
+    AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
+      if (unity_Le) {
+        getTransportCoeffUnityLe(i, j, k, ScInv, PrInv, rhoY, T, rhoD, lambda, mu, ltransparm);
+      } else {
         getTransportCoeff(i, j, k, rhoY, T, rhoD, lambda, mu, ltransparm);
+      }
     });
 }
 
@@ -607,9 +615,17 @@ void pelelm_derlambda (PeleLM* a_pelelm, const Box& bx, FArrayBox& derfab, int d
     auto     lambda  = derfab.array(dcomp);
     auto         mu  = dummies.array(0);
     auto const* ltransparm = a_pelelm->trans_parms.device_trans_parm();
+    amrex::Real ScInv = a_pelelm->m_Schmidt_inv;
+    amrex::Real PrInv = a_pelelm->m_Schmidt_inv;
+    int unity_Le = a_pelelm->m_unity_Le;
     amrex::ParallelFor(bx,
-    [rhoY,T,rhoD,lambda,mu,ltransparm] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [rhoY,T,rhoD,lambda,mu,ltransparm,unity_Le,ScInv,PrInv]
+    AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
+      if (unity_Le) {
+        getTransportCoeffUnityLe(i, j, k, ScInv, PrInv, rhoY, T, rhoD, lambda, mu, ltransparm);
+      } else {
         getTransportCoeff(i, j, k, rhoY, T, rhoD, lambda, mu, ltransparm);
+      }
     });
 }

--- a/Source/PeleLMDiffusion.cpp
+++ b/Source/PeleLMDiffusion.cpp
@@ -324,7 +324,8 @@ void PeleLM::addWbarTerm(const Vector<Array<MultiFab*,AMREX_SPACEDIM> > &a_spflu
 
       // Get edge diffusivity
       int doZeroVisc = 1;
-      Array<MultiFab,AMREX_SPACEDIM> beta_ec = getDiffusivity(lev, 0, NUM_SPECIES, doZeroVisc, bcRecSpec, *a_beta[lev]);
+      int addTurbContrib = 0;
+      Array<MultiFab,AMREX_SPACEDIM> beta_ec = getDiffusivity(lev, 0, NUM_SPECIES, doZeroVisc, bcRecSpec, *a_beta[lev], addTurbContrib);
 
       const Box& domain = geom[lev].Domain();
       bool use_harmonic_avg = m_harm_avg_cen2edge ? true : false;
@@ -555,7 +556,8 @@ void PeleLM::computeSpeciesEnthalpyFlux(const Vector<Array<MultiFab*,AMREX_SPACE
       //------------------------------------------------------------------------
       // Get the face-centered species enthalpies
       int doZeroVisc = 0;
-      Array<MultiFab,AMREX_SPACEDIM> Enth_ec = getDiffusivity(lev, 0, NUM_SPECIES, doZeroVisc, bcRecSpec, Enth);
+      int addTurbContrib = 0;
+      Array<MultiFab,AMREX_SPACEDIM> Enth_ec = getDiffusivity(lev, 0, NUM_SPECIES, doZeroVisc, bcRecSpec, Enth, addTurbContrib);
 
       //------------------------------------------------------------------------
       // Compute \sum_k { \Flux_k * h_k }

--- a/Source/PeleLMInit.cpp
+++ b/Source/PeleLMInit.cpp
@@ -54,10 +54,10 @@ void PeleLM::MakeNewLevelFromScratch( int lev,
    // Initialize the LevelData
    m_leveldata_old[lev].reset(new LevelData(grids[lev], dmap[lev], *m_factory[lev],
                                             m_incompressible, m_has_divu,
-                                            m_nAux, m_nGrowState));
+                                            m_nAux, m_nGrowState, m_do_les));
    m_leveldata_new[lev].reset(new LevelData(grids[lev], dmap[lev], *m_factory[lev],
                                             m_incompressible, m_has_divu,
-                                            m_nAux, m_nGrowState));
+                                            m_nAux, m_nGrowState, m_do_les));
 
    if (max_level > 0 && lev != max_level) {
       m_coveredMask[lev].reset(new iMultiFab(grids[lev], dmap[lev], 1, 0));

--- a/Source/PeleLMPlot.cpp
+++ b/Source/PeleLMPlot.cpp
@@ -329,6 +329,7 @@ void PeleLM::WritePlotFile() {
                                                                                 + mut_arr_y[box_no](i,j,k) + mut_arr_y[box_no](i,j+1,k),
                                                                                 + mut_arr_z[box_no](i,j,k) + mut_arr_z[box_no](i,j,k+1)));
                            });
+        Gpu::streamSynchronize();
         cnt += 1;
       }
 

--- a/Source/PeleLMPlot.cpp
+++ b/Source/PeleLMPlot.cpp
@@ -122,6 +122,10 @@ void PeleLM::WritePlotFile() {
    }
 #endif
 
+   if (m_do_les && m_plot_les) {
+     ncomp += 1;
+   }
+
    //----------------------------------------------------------------
    // Plot MultiFabs
    Vector<MultiFab> mf_plt(finest_level + 1);
@@ -222,6 +226,9 @@ void PeleLM::WritePlotFile() {
    }
 #endif
 
+   if (m_do_les && m_plot_les) {
+     plt_VarsName.push_back("viscturb");
+   }
 
    //----------------------------------------------------------------
    // Fill the plot MultiFabs
@@ -304,8 +311,27 @@ void PeleLM::WritePlotFile() {
 #ifdef PELE_USE_EFIELD
       if (m_do_extraEFdiags) {
           MultiFab::Copy(mf_plt[lev], *m_ionsFluxes[lev], 0, cnt, m_ionsFluxes[lev]->nComp(),0);
+          cnt += m_ionsFluxes[lev]->nComp();
       }
 #endif
+
+      if (m_do_les && m_plot_les) {
+        constexpr amrex::Real fact = 0.5/AMREX_SPACEDIM;
+        auto const& plot_arr = mf_plt[lev].arrays();
+        AMREX_D_TERM(auto const& mut_arr_x = m_leveldata_old[lev]->visc_turb_fc[0].const_arrays();,
+                     auto const& mut_arr_y = m_leveldata_old[lev]->visc_turb_fc[1].const_arrays();,
+                     auto const& mut_arr_z = m_leveldata_old[lev]->visc_turb_fc[2].const_arrays();)
+        // interpolate turbulent viscosity from faces to centers
+        amrex::ParallelFor(mf_plt[lev], [plot_arr, fact, AMREX_D_DECL(mut_arr_x, mut_arr_y, mut_arr_z), cnt]
+                           AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+                           {
+                             plot_arr[box_no](i,j,k,cnt) = fact*( AMREX_D_TERM( mut_arr_x[box_no](i,j,k) + mut_arr_x[box_no](i+1,j,k),
+                                                                                + mut_arr_y[box_no](i,j,k) + mut_arr_y[box_no](i,j+1,k),
+                                                                                + mut_arr_z[box_no](i,j,k) + mut_arr_z[box_no](i,j,k+1)));
+                           });
+        cnt += 1;
+      }
+
 #ifdef AMREX_USE_EB
       EB_set_covered(mf_plt[lev],0.0);
 #endif

--- a/Source/PeleLMRegrid.cpp
+++ b/Source/PeleLMRegrid.cpp
@@ -45,11 +45,11 @@ void PeleLM::MakeNewLevelFromCoarse( int lev,
    // New leveldatas
    std::unique_ptr<LevelData> n_leveldata_old( new LevelData(ba, dm, *new_fact,
                                                    m_incompressible, m_has_divu,
-                                                   m_nAux, m_nGrowState));
+                                                   m_nAux, m_nGrowState, m_do_les));
 
    std::unique_ptr<LevelData> n_leveldata_new( new LevelData(ba, dm, *new_fact,
                                                    m_incompressible, m_has_divu,
-                                                   m_nAux, m_nGrowState));
+                                                   m_nAux, m_nGrowState, m_do_les));
 
    // Fill the leveldata_new
    fillcoarsepatch_state(lev, time, n_leveldata_new->state, m_nGrowState);
@@ -141,11 +141,13 @@ void PeleLM::RemakeLevel( int lev,
    // New leveldatas
    std::unique_ptr<LevelData> n_leveldata_old( new LevelData(ba, dm, *new_fact,
                                                    m_incompressible, m_has_divu,
-                                                   m_nAux, m_nGrowState));
+                                                   m_nAux, m_nGrowState,
+                                                   m_do_les));
 
    std::unique_ptr<LevelData> n_leveldata_new( new LevelData(ba, dm, *new_fact,
                                                    m_incompressible, m_has_divu,
-                                                   m_nAux, m_nGrowState));
+                                                   m_nAux, m_nGrowState,
+                                                   m_do_les));
 
    // Fill the leveldata_new
    fillpatch_state(lev, time, n_leveldata_new->state, m_nGrowState);

--- a/Source/PeleLMSetup.cpp
+++ b/Source/PeleLMSetup.cpp
@@ -317,9 +317,9 @@ void PeleLM::readParameters() {
      m_do_les = false;
    } else {
      if (m_les_model == "Smagorinsky") {
-       pp.get("les_cs_smag", m_les_cs_smag);
+       pp.query("les_cs_smag", m_les_cs_smag);
      } else if (m_les_model == "WALE") {
-       pp.get("les_cs_wale", m_les_cs_wale);
+       pp.query("les_cm_wale", m_les_cm_wale);
      } else {
        amrex::Abort("LES model must be None, Smagorinsky, or WALE. Invalid choie: " + m_les_model);
      }

--- a/Source/PeleLMSetup.cpp
+++ b/Source/PeleLMSetup.cpp
@@ -83,6 +83,12 @@ void PeleLM::Setup() {
    if (!m_incompressible) {
       amrex::Print() << " Initialization of Transport ... \n";
       trans_parms.allocate();
+      if (m_les_verbose and m_do_les)
+        amrex::Print() << "    Using LES in transport with Sc = " << 1.0/m_Schmidt_inv
+                       << " and Pr = " << 1.0/m_Prandtl_inv << std::endl;
+      if (m_verbose and m_unity_Le)
+        amrex::Print() << "    Using Le = 1 transport with Sc = " << 1.0/m_Schmidt_inv
+                       << " and Pr = " << 1.0/m_Prandtl_inv << std::endl;
       if (m_do_react) {
          int reactor_type = 2;
          int ncells_chem = 1;
@@ -303,15 +309,55 @@ void PeleLM::readParameters() {
       m_gravity[idim] = grav[idim];
    }
 
+   // -----------------------------------------
+   // LES
+   // -----------------------------------------
+   pp.query("les_model", m_les_model);
+   if (m_les_model == "None") {
+     m_do_les = false;
+   } else {
+     if (m_les_model == "Smagorinsky") {
+       pp.get("les_cs_smag", m_les_cs_smag);
+     } else if (m_les_model == "WALE") {
+       pp.get("les_cs_wale", m_les_cs_wale);
+     } else {
+       amrex::Abort("LES model must be None, Smagorinsky, or WALE. Invalid choie: " + m_les_model);
+     }
+     m_do_les = true;
+     m_les_verbose = m_verbose;
+     pp.query("plot_les", m_plot_les);
+     pp.query("les_v", m_les_verbose);
+     for (int lev=0; lev<= max_level ; ++lev) {
+       m_turb_visc_time.push_back(-1.0E200);
+     }
+#ifdef AMREX_USE_EB
+     amrex::Abort("LES implementation with EB depends on EB compVelGrad in amrex");
+#endif
+#ifdef PELE_USE_EFIELD
+     amrex::Abort("LES implementation is not yet compatible with efield/ions");
+#endif
+   }
 
    // -----------------------------------------
    // diffusion
    pp.query("use_wbar",m_use_wbar);
+   pp.query("unity_Le",m_unity_Le);
+   if (m_use_wbar and m_unity_Le) {
+     m_use_wbar = 0;
+     amrex::Print() << "WARNING: use_wbar set to false because unity_Le is true"
+                    << std::endl;
+   }
    pp.query("deltaT_verbose",m_deltaT_verbose);
    pp.query("deltaT_iterMax",m_deltaTIterMax);
    pp.query("deltaT_tol",m_deltaT_norm_max);
    pp.query("deltaT_crashIfFailing",m_crashOnDeltaTFail);
 
+   if (m_do_les or m_unity_Le) {
+     amrex::Real Prandtl = 0.7;
+     pp.query("Prandtl", Prandtl);
+     m_Schmidt_inv = 1.0/Prandtl;
+     m_Prandtl_inv = 1.0/Prandtl;
+   }
 
    // -----------------------------------------
    // initialization

--- a/Source/PeleLMTransportProp.cpp
+++ b/Source/PeleLMTransportProp.cpp
@@ -69,6 +69,7 @@ void PeleLM::calcTurbViscosity(const TimeStamp &a_time) {
                                               Array4<Real const>(state_arr[box_no], TEMP),
                                               Array4<Real      >(cp_arr[box_no]) );
                           });
+       Gpu::streamSynchronize();
 
        // this function really just interpolates CCs to FCs in this case
        int doZeroVisc = 0;
@@ -106,6 +107,7 @@ void PeleLM::calcTurbViscosity(const TimeStamp &a_time) {
                                                 Array4<Real      >(mut_arr[box_no]) );
                             });
        }
+       Gpu::streamSynchronize();
 
        // Compute lambda_turb = alpha_t * cp = mu_t / Pr_t * cp
        if (!m_incompressible) {
@@ -115,7 +117,6 @@ void PeleLM::calcTurbViscosity(const TimeStamp &a_time) {
        }
      }
    }
-   Gpu::streamSynchronize();
 }
 
 void PeleLM::calcViscosity(const TimeStamp &a_time) {

--- a/Source/PeleLMTransportProp.cpp
+++ b/Source/PeleLMTransportProp.cpp
@@ -1,11 +1,122 @@
 #include <PeleLM.H>
 #include <PeleLM_K.H>
 #include <pelelm_prob.H>
+#include <DiffusionOp.H>
 #ifdef PELE_USE_EFIELD
 #include <PeleLMEF_K.H>
 #endif
 
 using namespace amrex;
+
+void PeleLM::calcTurbViscosity(const TimeStamp &a_time) {
+   BL_PROFILE("PeleLM::calcTurbViscosity()");
+
+   // We shouldn't be here unless we're doing LES
+   AMREX_ALWAYS_ASSERT(m_do_les);
+
+   if (m_les_verbose > 0) {
+     amrex::Print() << "   Computing Turbulent Viscosity with LES model: " << m_les_model
+                    << " for time " << getTime(0, a_time) << std::endl;
+   }
+
+   // Create temporary multifab to store velocity gradient tensor
+   amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> GradVel(finest_level+1);
+   for (int lev = 0; lev <= finest_level; ++lev) {
+     auto ldata_p = getLevelDataPtr(lev,a_time);
+     const auto& ba = ldata_p->state.boxArray();
+     const auto& dm = ldata_p->state.DistributionMap();
+     const auto& factory = ldata_p->state.Factory();
+     constexpr int ncomp = AMREX_SPACEDIM*AMREX_SPACEDIM;
+     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+       GradVel[lev][idim].define(amrex::convert(ba,IntVect::TheDimensionVector(idim)), dm,
+                                 ncomp, 0, MFInfo(), factory);
+     }
+   }
+
+   // compute the velocity gradient
+   getDiffusionTensorOp()->computeGradientTensor(GetVecOfArrOfPtrs(GradVel),
+                                                 GetVecOfConstPtrs(getVelocityVect(a_time)));
+
+   for (int lev = 0; lev <= finest_level; ++lev) {
+     auto ldata_p = getLevelDataPtr(lev,a_time);
+
+     // Get density and cp (if needed) at faces for computing turbulent transport properties
+     amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> dens_fc;
+     amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> cp_fc;
+     amrex::MultiFab cp_cc;
+     const auto& ba = ldata_p->state.boxArray();
+     const auto& dm = ldata_p->state.DistributionMap();
+     const auto& factory = ldata_p->state.Factory();
+     if (m_incompressible) {
+       // just set density as a constant; don't need to worry about cp
+       for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+         dens_fc[idim].define(amrex::convert(ba,IntVect::TheDimensionVector(idim)), dm,
+                              1, 0, MFInfo(), factory);
+         dens_fc[idim].setVal(m_rho);
+       }
+     } else {
+       // get cp_cc (valid in 1 grow cell for interpolation to FCs)
+       int ngrow = 1;
+       cp_cc.define(ba, dm, 1, ngrow, MFInfo(), factory);
+       auto const& state_arr      = ldata_p->state.const_arrays();
+       auto const& cp_arr       = cp_cc.arrays();
+       amrex::ParallelFor(cp_cc, cp_cc.nGrowVect(), [=]
+                          AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+                          {
+                            getCpmixGivenRYT( i, j, k,
+                                              Array4<Real const>(state_arr[box_no], DENSITY),
+                                              Array4<Real const>(state_arr[box_no], FIRSTSPEC),
+                                              Array4<Real const>(state_arr[box_no], TEMP),
+                                              Array4<Real      >(cp_arr[box_no]) );
+                          });
+
+       // this function really just interpolates CCs to FCs in this case
+       int doZeroVisc = 0;
+       auto bcRec = fetchBCRecArray(DENSITY,1);
+       dens_fc = getDiffusivity(lev,DENSITY,1,doZeroVisc,{bcRec},ldata_p->state);
+       cp_fc   = getDiffusivity(lev,0      ,1,doZeroVisc,{bcRec},cp_cc);
+     }
+
+     // Now we compute the turbulent viscosity at faces
+     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+       auto const& velgrad_arr = GradVel[lev][idim].const_arrays();
+       auto const& dens_arr = dens_fc[idim].const_arrays();
+       auto const& mut_arr = ldata_p->visc_turb_fc[idim].arrays();
+       const amrex::Real l_scale = std::sqrt(AMREX_D_TERM(geom[lev].CellSize(0)*geom[lev].CellSize(0),
+                                                          + geom[lev].CellSize(1)*geom[lev].CellSize(1),
+                                                          + geom[lev].CellSize(2)*geom[lev].CellSize(2)));
+       if (m_les_model == "Smagorinsky") {
+         const amrex::Real prefact = m_les_cs_smag * l_scale * l_scale;
+         amrex::ParallelFor(ldata_p->visc_turb_fc[idim], ldata_p->visc_turb_fc[idim].nGrowVect(), [=]
+                            AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+                            {
+                              getTurbViscSmagorinsky( i, j, k, prefact,
+                                                      Array4<Real const>(velgrad_arr[box_no]),
+                                                      Array4<Real const>(dens_arr[box_no]),
+                                                      Array4<Real      >(mut_arr[box_no]) );
+                            });
+       } else if (m_les_model == "WALE") {
+         const amrex::Real prefact = m_les_cs_wale * l_scale * l_scale;
+         amrex::ParallelFor(ldata_p->visc_turb_fc[idim], ldata_p->visc_turb_fc[idim].nGrowVect(), [=]
+                            AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+                            {
+                              getTurbViscWALE( i, j, k, prefact,
+                                                Array4<Real const>(velgrad_arr[box_no]),
+                                                Array4<Real const>(dens_arr[box_no]),
+                                                Array4<Real      >(mut_arr[box_no]) );
+                            });
+       }
+
+       // Compute lambda_turb = alpha_t * cp = mu_t / Pr_t * cp
+       if (!m_incompressible) {
+         amrex::MultiFab::Copy(ldata_p->lambda_turb_fc[idim], ldata_p->visc_turb_fc[idim], 0, 0, 1, 0);
+         amrex::MultiFab::Multiply(ldata_p->lambda_turb_fc[idim], cp_fc[idim], 0, 0, 1, 0);
+         ldata_p->lambda_turb_fc[idim].mult(m_Prandtl_inv);
+       }
+     }
+   }
+   Gpu::streamSynchronize();
+}
 
 void PeleLM::calcViscosity(const TimeStamp &a_time) {
    BL_PROFILE("PeleLM::calcViscosity()");
@@ -54,28 +165,42 @@ void PeleLM::calcDiffusivity(const TimeStamp &a_time) {
       auto const& dma = ldata_p->diff_cc.arrays();
 #ifdef PELE_USE_EFIELD
       auto const& kma = ldata_p->mob_cc.arrays();
-      auto eos = pele::physics::PhysicsType::eos();
       GpuArray<Real,NUM_SPECIES> mwt{0.0};
-      eos.molecular_weight(mwt.arr);
+      {
+        auto eos = pele::physics::PhysicsType::eos();
+        eos.molecular_weight(mwt.arr);
+      }
 #endif
 
+      amrex::Real Sc_inv = m_Schmidt_inv;
+      amrex::Real Pr_inv = m_Prandtl_inv;
+      int  do_unity_le = m_unity_Le;
       amrex::ParallelFor(ldata_p->diff_cc, ldata_p->diff_cc.nGrowVect(), [=]
       AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
       {
-         // TODO: unity Lewis
-         getTransportCoeff( i, j, k,
-                            Array4<Real const>(sma[box_no],FIRSTSPEC),
-                            Array4<Real const>(sma[box_no],TEMP),
-                            Array4<Real      >(dma[box_no],0),
-                            Array4<Real      >(dma[box_no],NUM_SPECIES),
-                            Array4<Real      >(dma[box_no],NUM_SPECIES+1),
-                            ltransparm);
+        if (do_unity_le) {
+          getTransportCoeffUnityLe( i, j, k, Sc_inv, Pr_inv,
+                                    Array4<Real const>(sma[box_no],FIRSTSPEC),
+                                    Array4<Real const>(sma[box_no],TEMP),
+                                    Array4<Real      >(dma[box_no],0),
+                                    Array4<Real      >(dma[box_no],NUM_SPECIES),
+                                    Array4<Real      >(dma[box_no],NUM_SPECIES+1),
+                                    ltransparm);
+        } else {
+          getTransportCoeff( i, j, k,
+                             Array4<Real const>(sma[box_no],FIRSTSPEC),
+                             Array4<Real const>(sma[box_no],TEMP),
+                             Array4<Real      >(dma[box_no],0),
+                             Array4<Real      >(dma[box_no],NUM_SPECIES),
+                             Array4<Real      >(dma[box_no],NUM_SPECIES+1),
+                             ltransparm);
+        }
 #ifdef PELE_USE_EFIELD
-         getKappaSp( i, j, k, mwt.arr, zk,
-                     Array4<Real const>(sma[box_no],FIRSTSPEC),
-                     Array4<Real      >(dma[box_no],0),
-                     Array4<Real const>(sma[box_no],TEMP),
-                     Array4<Real      >(kma[box_no],0));
+        getKappaSp( i, j, k, mwt.arr, zk,
+                    Array4<Real const>(sma[box_no],FIRSTSPEC),
+                    Array4<Real      >(dma[box_no],0),
+                    Array4<Real const>(sma[box_no],TEMP),
+                    Array4<Real      >(kma[box_no],0));
 #endif
       });
    }
@@ -85,7 +210,8 @@ void PeleLM::calcDiffusivity(const TimeStamp &a_time) {
 Array<MultiFab,AMREX_SPACEDIM>
 PeleLM::getDiffusivity(int lev, int beta_comp, int ncomp, int doZeroVisc,
                        Vector<BCRec> bcrec,
-                       MultiFab const& beta_cc)
+                       MultiFab const& beta_cc,
+                       int addTurbContrib)
 {
    BL_PROFILE("PeleLM::getDiffusivity()");
 
@@ -136,6 +262,47 @@ PeleLM::getDiffusivity(int lev, int beta_comp, int ncomp, int doZeroVisc,
       }
    }
 #endif
+
+   // Add the turbulent component if desired
+   // Use the following relationships to translate from the ncomp and beta_comp to the component
+   // ncomp = NUM_SPECIES, beta_comp = 0           --> SPECIES DIFFUSIVITY
+   // ncomp = 1          , beta_comp = NUM_SPECIES --> THERMAL CONDUCTIVITY
+   // ncomp = 1          , beta_comp = 0           --> VISCOSITY
+   // If PELE_USE_EFIELD is active, these relationships will not hold and LES is not supported
+   if (addTurbContrib and m_do_les) {
+
+     // If initializing the simulation, always recompute turbulent viscosity
+     // otherwise, only recompute once per level per timestep (at old time)
+     // calcTurbViscosity computes for all levels, so only call from the base level
+     TimeStamp tstamp;
+     if (getTime(lev, AmrNewTime) == 0.0 ) {
+       tstamp = AmrNewTime;
+       if (lev == 0) {
+         calcTurbViscosity(tstamp);
+       }
+     } else if (lev == 0 and getTime(lev, AmrOldTime) > m_turb_visc_time[lev]) {
+       tstamp = AmrOldTime;
+       calcTurbViscosity(tstamp);
+       m_turb_visc_time[lev] = getTime(lev, AmrOldTime);
+     } else {
+       tstamp = AmrOldTime;
+     }
+     auto ldata_p = getLevelDataPtr(lev,tstamp);
+
+     // Identify and add the correct turbulent contribution
+     for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+       if ((ncomp == 1) and (beta_comp == 0)) { // Viscosity
+         amrex::MultiFab::Add(beta_ec[idim], ldata_p->visc_turb_fc[idim], 0, 0, 1, 0);
+       } else if ((ncomp == NUM_SPECIES) and (beta_comp == 0)) { // Species diffusivity
+         for (int ispec = 0; ispec < NUM_SPECIES; ispec++)
+           amrex::MultiFab::Saxpy(beta_ec[idim], m_Schmidt_inv, ldata_p->visc_turb_fc[idim], 0, ispec, 1, 0);
+       } else if ((ncomp == 1) and (beta_comp == NUM_SPECIES)) { // Thermal conductivity
+         amrex::MultiFab::Add(beta_ec[idim], ldata_p->lambda_turb_fc[idim], 0, 0, 1, 0);
+       } else  { // Invalid
+         amrex::Abort("getDiffusivity(): LES model is on but cannot provide a turbulent transport coefficient");
+       }
+     }
+   }
 
    // Enable zeroing diffusivity on faces to produce walls
    if (doZeroVisc) {

--- a/Source/PeleLMTransportProp.cpp
+++ b/Source/PeleLMTransportProp.cpp
@@ -86,7 +86,7 @@ void PeleLM::calcTurbViscosity(const TimeStamp &a_time) {
                                                           + geom[lev].CellSize(1)*geom[lev].CellSize(1),
                                                           + geom[lev].CellSize(2)*geom[lev].CellSize(2)));
        if (m_les_model == "Smagorinsky") {
-         const amrex::Real prefact = m_les_cs_smag * l_scale * l_scale;
+         const amrex::Real prefact = m_les_cs_smag * m_les_cs_smag * l_scale * l_scale;
          amrex::ParallelFor(ldata_p->visc_turb_fc[idim], ldata_p->visc_turb_fc[idim].nGrowVect(), [=]
                             AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
                             {
@@ -96,7 +96,7 @@ void PeleLM::calcTurbViscosity(const TimeStamp &a_time) {
                                                       Array4<Real      >(mut_arr[box_no]) );
                             });
        } else if (m_les_model == "WALE") {
-         const amrex::Real prefact = m_les_cs_wale * l_scale * l_scale;
+         const amrex::Real prefact = m_les_cm_wale * m_les_cm_wale * l_scale * l_scale;
          amrex::ParallelFor(ldata_p->visc_turb_fc[idim], ldata_p->visc_turb_fc[idim].nGrowVect(), [=]
                             AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
                             {

--- a/Source/PeleLM_K.H
+++ b/Source/PeleLM_K.H
@@ -7,6 +7,58 @@
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
+getTransportCoeffUnityLe(int i, int j, int k,
+                         amrex::Real ScInv, amrex::Real PrInv,
+                         amrex::Array4<const amrex::Real> const& rhoY,
+                         amrex::Array4<const amrex::Real> const& T,
+                         amrex::Array4<      amrex::Real> const& rhoDi,
+                         amrex::Array4<      amrex::Real> const& lambda,
+                         amrex::Array4<      amrex::Real> const& mu,
+                         pele::physics::transport::TransParm<pele::physics::PhysicsType::eos_type,
+                         pele::physics::PhysicsType::transport_type> const* trans_parm) noexcept
+{
+   using namespace amrex::literals;
+
+   auto eos = pele::physics::PhysicsType::eos();
+   // Get rho & Y from rhoY
+   amrex::Real rho = 0.0_rt;
+   for (int n = 0; n < NUM_SPECIES; n++) {
+      rho += rhoY(i,j,k,n);
+   }
+   amrex::Real rhoinv = 1.0_rt / rho;
+   amrex::Real y[NUM_SPECIES] = {0.0};
+   for (int n = 0; n < NUM_SPECIES; n++) {
+      y[n] = rhoY(i,j,k,n) * rhoinv;
+   }
+   rho *= 1.0e-3_rt;                          // MKS -> CGS conversion
+   amrex::Real Tloc = T(i,j,k);               // So that we can use const_array
+
+   amrex::Real rhoDi_cgs[NUM_SPECIES] = {0.0};
+   amrex::Real lambda_cgs = 0.0_rt;
+   amrex::Real mu_cgs = 0.0_rt;
+   amrex::Real dummy_xi = 0.0_rt;
+
+   bool get_xi = false;
+   bool get_mu = true;
+   bool get_lam = false;
+   bool get_Ddiag = false;
+   auto trans = pele::physics::PhysicsType::transport();
+   trans.transport(get_xi, get_mu, get_lam, get_Ddiag, Tloc,
+                   rho, y, rhoDi_cgs, mu_cgs, dummy_xi, lambda_cgs, trans_parm);
+
+   mu(i,j,k) = mu_cgs * 1.0e-1_rt;                       // CGS -> MKS conversions
+   for (int n = 0; n < NUM_SPECIES; n++) {
+      rhoDi(i,j,k,n) = mu_cgs * 1.0e-1_rt * ScInv;       // Constant Schmidt number
+   }
+
+   amrex::Real cpmix = 0.0_rt;
+   eos.TY2Cp(T(i,j,k), y, cpmix);
+   lambda(i,j,k) = mu_cgs * PrInv * cpmix * 1.0e-5_rt;   // Constant Prandtl number
+}
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+void
 getTransportCoeff(int i, int j, int k,
                   amrex::Array4<const amrex::Real> const& rhoY,
                   amrex::Array4<const amrex::Real> const& T,
@@ -750,4 +802,100 @@ getGammaInv(int i, int j, int k,
 
    return gammainv;
 }
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+getSijSij(int i, int j, int k, amrex::Array4<const amrex::Real> const& velgrad) noexcept
+{
+  // This function returns SijSij, not strain rate magnitude |S| = sqrt(2 SijSij)
+  amrex::Real SijSij = 0.0;
+  for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+    for (int jdim = 0; jdim < AMREX_SPACEDIM; ++jdim) {
+      // Sij = 0.5(dui/dxj + duj/dxi)
+      amrex::Real Sij = 0.5*(velgrad(i,j,k,idim*AMREX_SPACEDIM + jdim)
+                             + velgrad(i,j,k,jdim*AMREX_SPACEDIM + idim));
+      SijSij += Sij*Sij;
+    }
+  }
+  return SijSij;
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+getVelGradTerm(int i, int j, int k, amrex::Array4<const amrex::Real> const& velgrad) noexcept
+{
+  // Compute S^d_ij*S^d_ij
+  // S^d_ij = 0.5(g2_ij + g2_ji) - (1/3)*delta_ij*g2_kk
+  // g2_ij = du_i/dx_l * du_l/dx_j
+  // Therefore, g2_kk = du_k/dx_l * du_l/dx_k
+  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM*AMREX_SPACEDIM> g2_ij;
+  for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+    for (int jdim = 0; jdim < AMREX_SPACEDIM; ++jdim) {
+      g2_ij[idim*AMREX_SPACEDIM + jdim] = 0.0;
+      for (int ldim = 0; ldim < AMREX_SPACEDIM; ++ldim) {
+        g2_ij[idim*AMREX_SPACEDIM + jdim] += (velgrad(i,j,k,idim*AMREX_SPACEDIM + ldim)
+                                              *velgrad(i,j,k,ldim*AMREX_SPACEDIM + jdim));
+      }
+    }
+  }
+  amrex::Real g2_kk_third = (1.0/AMREX_SPACEDIM) * (AMREX_D_TERM(g2_ij[0],
+                                                                 + g2_ij[AMREX_SPACEDIM + 1],
+                                                                 + g2_ij[2*AMREX_SPACEDIM + 2]));
+
+  amrex::Real SdijSdij = 0.0;
+  for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+    for (int jdim = 0; jdim < AMREX_SPACEDIM; ++jdim) {
+      amrex::Real Sdij = (idim == jdim) ?
+        g2_ij[idim*AMREX_SPACEDIM + jdim] - g2_kk_third
+        : 0.5*(g2_ij[idim*AMREX_SPACEDIM + jdim] + g2_ij[jdim*AMREX_SPACEDIM + idim]);
+      SdijSdij += Sdij*Sdij;
+    }
+  }
+  return SdijSdij;
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+void
+getTurbViscSmagorinsky(int i, int j, int k,
+                       amrex::Real prefactor,
+                       amrex::Array4<const amrex::Real> const& velgrad,
+                       amrex::Array4<const amrex::Real> const& rho,
+                       amrex::Array4<      amrex::Real> const& mu_t) noexcept
+{
+   using namespace amrex::literals;
+
+   // mu_t = rho * Cs * Delta^2 * |S|    where |S| = sqrt(2 SijSij)
+
+   amrex::Real Smag = std::sqrt(2.0 * getSijSij(i,j,k,velgrad));
+   mu_t(i,j,k) = prefactor * rho(i,j,k) * Smag;
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+void
+getTurbViscWALE(int i, int j, int k,
+                amrex::Real prefactor,
+                amrex::Array4<const amrex::Real> const& velgrad,
+                amrex::Array4<const amrex::Real> const& rho,
+                amrex::Array4<      amrex::Real> const& mu_t) noexcept
+{
+   using namespace amrex::literals;
+
+   // From Ducros, Nicoud, and Poinsot 1999
+   // mu_t = rho * Cs * Delta^2 * (S^d_ijS^d_ij)^(3/2)
+   //        / (SijSij^(5/2) + (S^d_ijS^d_ij)^(5/4) + smallnum)
+   // smallnum included to make sure denom is nonzero
+
+   amrex::Real SijSij = getSijSij(i,j,k,velgrad);
+   amrex::Real Sterm52 = std::pow(SijSij, 2.5);
+   amrex::Real Sdterm = getVelGradTerm(i,j,k,velgrad); // (S^d_ijS^d_ij)
+   amrex::Real Sdterm14 = std::pow(Sdterm, 0.25);
+   amrex::Real Sdterm54 = Sdterm*Sdterm14;
+   amrex::Real Sdterm32 = Sdterm54*Sdterm14;
+   mu_t(i,j,k) = prefactor * rho(i,j,k) * Sdterm32 / (Sterm52 + Sdterm54 + 1.0e-12);
+}
+
 #endif


### PR DESCRIPTION
This PR enables LES transport models for scalars and momentum in PeleLMeX. The turbulent viscosity is computed either using constant coefficient Smagorinsky or WALE. Turbulent transport for species and enthalpy are applied using this turbulent viscosity and constant assumed turbulent Schmidt and Prandtl numbers.

A few notes on the implementation:

- Turbulent viscosity is computed based on the velocity field at the old timestep (N). Because the velocity field is not updated until the very end of the timestep, this means that when diffusion terms at N+1 are computed, the turbulent part fo the diffusion coefficient is still based on data for timestep N. This limitation would also be present for the IAMR implementation.
- Turbulent viscosity is now computed at faces (based on velocity gradients from an AMReX TensorOp) and added to the face viscosity in the getDiffusivity function, just before applying zeroVisc function. 
- The TensorOp function doesn't support EB yet, so that capability will need to be added later
- This PR also pulls in the unity Lewis number diffusion feature from LM, as that may often be desired for LES.
- Documentation included, a suitable regtest will be added in a later PR
- This PR replaces https://github.com/AMReX-Combustion/PeleLMeX/pull/126