### PR TITLE
update GNUmake paths

### DIFF
--- a/Exec/Cases/ChallengeProblem/GNUmakefile
+++ b/Exec/Cases/ChallengeProblem/GNUmakefile
@@ -1,10 +1,9 @@
-TOP = ../../../..
-AMREX_HOME         ?= ${TOP}/amrex
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
-PELE_PHYSICS_HOME  ?= ${TOP}/PelePhysics
-AMREX_HYDRO_HOME   ?= ${TOP}/AMReX-Hydro
+TOP = ../../..
+PELELMEX_HOME      ?= ${TOP}
+AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
+PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
+AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro
 HYPRE_HOME         = /ccs/home/lesclapez/hypre/install-2807
-
 
 # AMReX
 DIM             = 3

--- a/Exec/Cases/CounterFlow/GNUmakefile
+++ b/Exec/Cases/CounterFlow/GNUmakefile
@@ -1,9 +1,8 @@
-TOP = ../../../..
-AMREX_HOME         ?= ${TOP}/amrex
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
-PELE_PHYSICS_HOME  ?= ${TOP}/PelePhysics
-AMREX_HYDRO_HOME   ?= ${TOP}/AMReX-Hydro
-
+TOP = ../../..
+PELELMEX_HOME      ?= ${TOP}
+AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
+PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
+AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro
 
 # AMReX
 DIM             = 2

--- a/Exec/Cases/CounterFlowSpray/GNUmakefile
+++ b/Exec/Cases/CounterFlowSpray/GNUmakefile
@@ -1,10 +1,9 @@
-TOP = ../../../..
-AMREX_HOME         ?= ${TOP}/amrex
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
-PELE_PHYSICS_HOME  ?= ${TOP}/PelePhysics
-AMREX_HYDRO_HOME   ?= ${TOP}/AMReX-Hydro
-PELEMP_HOME        ?= ${TOP}/PeleMP
-
+TOP = ../../..
+PELELMEX_HOME      ?= ${TOP}
+AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
+PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
+AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro
+PELEMP_HOME        ?= ${PELELMEX_HOME}/Submodules/PeleMP
 
 # AMReX
 DIM             = 2

--- a/Exec/Cases/DiffBunsen2D/GNUmakefile
+++ b/Exec/Cases/DiffBunsen2D/GNUmakefile
@@ -1,9 +1,8 @@
-TOP = ../../../
-AMREX_HOME         ?= ${TOP}/amrex
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
-PELE_PHYSICS_HOME  ?= ${TOP}/PelePhysics
-AMREX_HYDRO_HOME   ?= ${TOP}/AMReX-Hydro
-
+TOP = ../../..
+PELELMEX_HOME      ?= ${TOP}
+AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
+PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
+AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro
 
 # AMReX
 DIM             = 2

--- a/Exec/Cases/JetInCrossflow/GNUmakefile
+++ b/Exec/Cases/JetInCrossflow/GNUmakefile
@@ -1,9 +1,8 @@
-TOP = ../../../..
-AMREX_HOME         ?= ${TOP}/amrex
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
-PELE_PHYSICS_HOME  ?= ${TOP}/PelePhysics
-AMREX_HYDRO_HOME   ?= ${TOP}/AMReX-Hydro
-
+TOP = ../../..
+PELELMEX_HOME      ?= ${TOP}
+AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
+PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
+AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro
 
 # AMReX
 DIM             = 3

--- a/Exec/Cases/NormalJet_OpenDomain/GNUmakefile
+++ b/Exec/Cases/NormalJet_OpenDomain/GNUmakefile
@@ -1,9 +1,8 @@
-TOP = ../../../..
-AMREX_HOME         ?= ${TOP}/amrex
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
-PELE_PHYSICS_HOME  ?= ${TOP}/PelePhysics
-AMREX_HYDRO_HOME   ?= ${TOP}/AMReX-Hydro
-
+TOP = ../../..
+PELELMEX_HOME      ?= ${TOP}
+AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
+PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
+AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro
 
 # AMReX
 DIM             = 3

--- a/Exec/Cases/PremBunsen2D/GNUmakefile
+++ b/Exec/Cases/PremBunsen2D/GNUmakefile
@@ -1,9 +1,8 @@
-TOP = ../../../..
-AMREX_HOME         ?= ${TOP}/amrex
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
-PELE_PHYSICS_HOME  ?= ${TOP}/PelePhysics
-AMREX_HYDRO_HOME   ?= ${TOP}/AMReX-Hydro
-
+TOP = ../../..
+PELELMEX_HOME      ?= ${TOP}
+AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
+PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
+AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro
 
 # AMReX
 DIM             = 2

--- a/Exec/Cases/PremBunsen3D/GNUmakefile
+++ b/Exec/Cases/PremBunsen3D/GNUmakefile
@@ -1,9 +1,8 @@
-TOP = ../../../..
-AMREX_HOME         ?= ${TOP}/amrex
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
-PELE_PHYSICS_HOME  ?= ${TOP}/PelePhysics
-AMREX_HYDRO_HOME   ?= ${TOP}/AMReX-Hydro
-
+TOP = ../../..
+PELELMEX_HOME      ?= ${TOP}
+AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
+PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
+AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro
 
 # AMReX
 DIM             = 3

--- a/Exec/Cases/SwirlFlowWallInteractions/GNUmakefile
+++ b/Exec/Cases/SwirlFlowWallInteractions/GNUmakefile
@@ -1,9 +1,8 @@
-TOP = ../../../..
-AMREX_HOME         ?= ${TOP}/amrex
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
-PELE_PHYSICS_HOME  ?= ${TOP}/PelePhysics
-AMREX_HYDRO_HOME   ?= ${TOP}/AMReX-Hydro
-
+TOP = ../../..
+PELELMEX_HOME      ?= ${TOP}
+AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
+PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
+AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro
 
 # AMReX
 DIM             = 3

--- a/Exec/Cases/TripleFlame/GNUmakefile
+++ b/Exec/Cases/TripleFlame/GNUmakefile
@@ -1,8 +1,8 @@
-TOP = ../../../..
-AMREX_HOME         ?= ${TOP}/amrex
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
-PELE_PHYSICS_HOME  ?= ${TOP}/PelePhysics
-
+TOP = ../../..
+PELELMEX_HOME      ?= ${TOP}
+AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
+PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
+AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro
 
 # AMReX
 DIM             = 2

--- a/Exec/RegTests/EB_EnclosedFlame/GNUmakefile
+++ b/Exec/RegTests/EB_EnclosedFlame/GNUmakefile
@@ -1,5 +1,5 @@
 TOP = ../../..
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
+PELELMEX_HOME      ?= ${TOP}
 AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
 PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
 AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro

--- a/Exec/RegTests/EB_EnclosedVortex/GNUmakefile
+++ b/Exec/RegTests/EB_EnclosedVortex/GNUmakefile
@@ -1,5 +1,5 @@
 TOP = ../../..
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
+PELELMEX_HOME      ?= ${TOP}
 AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
 PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
 AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro

--- a/Exec/RegTests/EB_FlowPastCylinder/GNUmakefile
+++ b/Exec/RegTests/EB_FlowPastCylinder/GNUmakefile
@@ -1,5 +1,5 @@
 TOP = ../../..
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
+PELELMEX_HOME      ?= ${TOP}
 AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
 PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
 AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro

--- a/Exec/RegTests/EB_PipeFlow/GNUmakefile
+++ b/Exec/RegTests/EB_PipeFlow/GNUmakefile
@@ -1,5 +1,5 @@
 TOP = ../../..
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
+PELELMEX_HOME      ?= ${TOP}
 AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
 PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
 AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro

--- a/Exec/RegTests/EnclosedFlame/GNUmakefile
+++ b/Exec/RegTests/EnclosedFlame/GNUmakefile
@@ -1,5 +1,5 @@
 TOP = ../../..
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
+PELELMEX_HOME      ?= ${TOP}
 AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
 PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
 AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro

--- a/Exec/RegTests/EnclosedInjection/GNUmakefile
+++ b/Exec/RegTests/EnclosedInjection/GNUmakefile
@@ -1,5 +1,5 @@
 TOP = ../../..
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
+PELELMEX_HOME      ?= ${TOP}
 AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
 PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
 AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro

--- a/Exec/RegTests/EnclosedInjection/pelelm_prob.cpp
+++ b/Exec/RegTests/EnclosedInjection/pelelm_prob.cpp
@@ -1,6 +1,5 @@
 #include <PeleLM.H>
 #include <AMReX_ParmParse.H>
-#include <pmf.H>
 
 void PeleLM::readProbParm()
 {

--- a/Exec/RegTests/FlameSheet/GNUmakefile
+++ b/Exec/RegTests/FlameSheet/GNUmakefile
@@ -1,5 +1,5 @@
 TOP = ../../..
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
+PELELMEX_HOME      ?= ${TOP}
 AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
 PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
 AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro

--- a/Exec/RegTests/HITDecay/GNUmakefile
+++ b/Exec/RegTests/HITDecay/GNUmakefile
@@ -1,5 +1,5 @@
 TOP = ../../..
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
+PELELMEX_HOME      ?= ${TOP}
 AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
 PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
 AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro

--- a/Exec/RegTests/HotBubble/GNUmakefile
+++ b/Exec/RegTests/HotBubble/GNUmakefile
@@ -1,5 +1,5 @@
 TOP = ../../..
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
+PELELMEX_HOME      ?= ${TOP}
 AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
 PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
 AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro

--- a/Exec/RegTests/PeriodicCases/GNUmakefile
+++ b/Exec/RegTests/PeriodicCases/GNUmakefile
@@ -1,5 +1,5 @@
 TOP = ../../..
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
+PELELMEX_HOME      ?= ${TOP}
 AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
 PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
 AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro

--- a/Exec/RegTests/SprayTest/GNUmakefile
+++ b/Exec/RegTests/SprayTest/GNUmakefile
@@ -1,5 +1,5 @@
 TOP = ../../..
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
+PELELMEX_HOME      ?= ${TOP}
 AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
 PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
 AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro

--- a/Exec/RegTests/TaylorGreen/GNUmakefile
+++ b/Exec/RegTests/TaylorGreen/GNUmakefile
@@ -1,5 +1,5 @@
 TOP = ../../..
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
+PELELMEX_HOME      ?= ${TOP}
 AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
 PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
 AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro

--- a/Exec/RegTests/TurbInflow/GNUmakefile
+++ b/Exec/RegTests/TurbInflow/GNUmakefile
@@ -1,5 +1,5 @@
 TOP = ../../..
-PELELMEX_HOME      ?= ${TOP}/PeleLMeX
+PELELMEX_HOME      ?= ${TOP}
 AMREX_HOME         ?= ${PELELMEX_HOME}/Submodules/amrex
 PELE_PHYSICS_HOME  ?= ${PELELMEX_HOME}/Submodules/PelePhysics
 AMREX_HYDRO_HOME   ?= ${PELELMEX_HOME}/Submodules/AMReX-Hydro

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can clone the PeleLMeX and tested versions of its submodules
 git clone --recursive https://github.com/AMReX-Combustion/PeleLMeX.git
 ```
 
-and setup the following environment variables (e.g. using bash):
+You can optionally setup the following environment variables (e.g. using bash):
 
 ```
 export PELELMEX_HOME=<path_to_PeleLMeX>
@@ -50,7 +50,9 @@ export AMREX_HYDRO_HOME=${PELELMEX_HOME}/Submodules/AMReX-Hydro
 export PELE_PHYSICS_HOME=${PELELMEX_HOME}/Submodules/PelePhysics
 ```
 
-Then, move into one of the available example, such as `HotBubble`:
+If you do not set these paths as environment variables, they will be assumed as specified in the `GNUmakefile` for the case you are compiling. If compiling in the default location for each case, no modifications are necessary.
+
+Then, move into one of the available examples, such as `HotBubble`:
 
 ```
 cd PeleLMeX/Exec/RegTest/HotBubble


### PR DESCRIPTION
Should enable compiling with the submodules obtained when using `git clone --recursive` without needing to edit the GNUmakefile or export any paths.