### PR TITLE
Allow restart with fewer levels than previous checkpoint

### DIFF
--- a/Source/PeleLMPlot.cpp
+++ b/Source/PeleLMPlot.cpp
@@ -592,6 +592,13 @@ void PeleLM::ReadCheckPointFile()
        MakeNewLevelFromScratch(lev, m_cur_time, ba, dm);
    }
 
+   for(int lev = finest_level+1; lev <= chk_finest_level; ++lev)
+   {
+       // read dummy level 'lev' BoxArray if restarting with reduced levels
+       BoxArray ba;
+       ba.readFrom(is);
+   }
+
    // deal with typval and P_amb
    is >> m_pNew;
    GotoNextLine(is);


### PR DESCRIPTION
The checkpoint file reader was failing if the desired number of levels in the restarted simulation is less than the number of levels in the checkpoint file, as the pressure and typical values get read in at the wrong location in the file. This PR fixes that.