### PR TITLE
Active Control max velocity default value fix

### DIFF
--- a/Docs/source/manual/LMeXControls.rst
+++ b/Docs/source/manual/LMeXControls.rst
@@ -384,7 +384,7 @@ the user to set the inflow velocity. The following options are available when us
     active_control.height = 0.01              # [OPT, DEF=0.0] Where is the flame held ?
     active_control.v = 1                      # [OPT, DEF=0] verbose
     active_control.method = 1                 # [OPT, DEF=2] Controller: 1 - Linear, 2 - Quadratic, 3 - Weighted quadratic
-    active_control.velMax = 2.0               # [OPT, DEF=0.0] limit inlet velocity
+    active_control.velMax = 2.0               # [OPT, DEF=-1.0] limit inlet velocity, only used when positive
     active_control.changeMax = 0.1            # [OPT, DEF=1.0] limit inlet velocity changes (absolute m/s)
     active_control.flow_dir  = 1              # [OPT, DEF=AMREX_SPACEDIM-1] flame main direction
     active_control.AC_history  = AChist       # [OPT, DEF=AC_history] Control history file, read upon restart

--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -1541,7 +1541,7 @@ class PeleLM : public amrex::AmrCore {
    amrex::Real m_ctrl_scale{0.0};
    amrex::Real m_ctrl_zBase{0.0};
    amrex::Real m_ctrl_h{0.0};
-   amrex::Real m_ctrl_velMax{0.0};
+   amrex::Real m_ctrl_velMax{-1.0};
    amrex::Real m_ctrl_temperature{-1.0};
    int m_ctrl_verbose{0};
    int m_ctrl_NavgPts{3};

--- a/Source/PeleLMFlowController.cpp
+++ b/Source/PeleLMFlowController.cpp
@@ -218,7 +218,9 @@ PeleLM::activeControl(int is_restart)
     Real dVmin = m_ctrl_changeMax * std::max(1.0,m_ctrl_V_in);
     Vnew = std::max(Vnew,0.0);
     Vnew = std::min(std::max(Vnew,m_ctrl_V_in-dVmin),m_ctrl_V_in+dVmax);
-    Vnew = std::min(Vnew,m_ctrl_velMax);
+    if (m_ctrl_velMax > 0.0) { // Only limit Vnew to velMax if velMax > 0.0
+       Vnew = std::min(Vnew,m_ctrl_velMax);
+    }
 
     if (!is_restart && m_nstep > 0) {
        m_ctrl_tBase = m_cur_time;


### PR DESCRIPTION
The default value for `m_ctrl_velMax` was set to -1.0 in `PeleLM.H`

The updated velocity in `PeleLMFlowControler.cpp` is not limited by the maximum velocity parameter if the parameter value is less than zero.

This result in the `active_control.velMax` input file parameter being truly optional (see issue #232).

Active control was able to converge without setting the `active_control.velMax` parameter:

<img width="1044" alt="image" src="https://github.com/AMReX-Combustion/PeleLMeX/assets/78630053/6d16b70a-38a5-475b-ac49-701a7a2daba8">
