### PR TITLE
Documentation updates/fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,21 +4,21 @@ New contributions to *PeleLMeX* are welcome !
 
 The *PeleLMeX* contributions workflow follows these steps:
 1. Fork the main repository
-2. Create an `AmazingNewFeature` branch implementing your changes 
+2. Create an `AmazingNewFeature` branch implementing your changes
 3. Open a Pull Request (PR) from `AmazingNewFeature` on your fork to branch `development` of the main *PeleLMeX* repository
 
-Follow [GitHub directions](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) 
+Follow [GitHub directions](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo)
 to fork *PeleLMeX* main repo on your GitHub account, and use a recursive `git clone` to get your fork of *PeleLMeX* and its dependencies.
 
 Then step into the *PeleLMeX* folder and add the main *PeleLMeX* repository as the `upstream` remote in order to keep track of the main repo :
 
        git add remote upstream https://github.com/AMReX-Combustion/PeleLMeX
 
-At any point, you can update the `development` branch of your local repository with changes implemented in the main *PeleLMeX* repo by pulling from `upstream` : 
+At any point, you can update the `development` branch of your local repository with changes implemented in the main *PeleLMeX* repo by pulling from `upstream` :
 
         git checkout development
         git pull upstream development
-        
+
 We recommend setting your development branch to track the upstream one instead of your fork:
 
         git branch -u upstream/development
@@ -27,16 +27,16 @@ You are now free to modify your own fork of *PeleLMeX*. To add a new feature to 
 
 1. Create a branch for the new feature from the `development` branch (locally) :
 
-        git checkout development 
+        git checkout development
         git checkout -b AmazingNewFeature
 
-2. and commit your changes to your local repo : 
+2. and commit your changes to your local repo :
 
         git commit -m "Developed AmazingNewFeature"
 
 3. Alongside your development, regularly merge changes from the main repo `development` branch into your `AmazingNewFeature` branch,
 fix any conflicts, and push your changes to your GitHub fork :
-   
+
         git push -u origin AmazingNewFeature
 
 4. When you are ready to propose your new feature/improvement/bug fix to the main *PeleLMeX* repo, reiterate Step 3 and submit a PR through the GitHub page from your fork onto the `development` branch of the main repo:
@@ -55,5 +55,11 @@ If you want to fix a bug, make a small pull request that only fixes a bug.
 
 ## PeleLMeX Coding Style Guide
 
-As much as possible, `PeleLMeX` adhere to [AMReX Coding Style](https://github.com/AMReX-Codes/amrex/blob/development/CONTRIBUTING.md#amrex-coding-style-guide)
+Source code files can be automatically formatted to adhere to the appropriate formatting rules using ``clang-format``. To format all files, use the command:
+
+        find Source Exec \( -name "*.cpp" -o -name "*.H" \) -exec clang-format -i {} +
+
+from within the PeleLMeX base directory. You can also format files individually using ``clang-format -i /path/to/file``. Adherence to this format is checked for all PRs.
+
+Beyond that, as much as possible, `PeleLMeX` adheres to [AMReX Coding Style](https://github.com/AMReX-Codes/amrex/blob/development/CONTRIBUTING.md#amrex-coding-style-guide)
 and we are encouraging contributors to follow those guidelines.

--- a/Docs/sphinx/landing/index.html
+++ b/Docs/sphinx/landing/index.html
@@ -25,7 +25,7 @@
     </noscript>
   </head>
   <body class="landing">
-    
+
     <!-- Header -->
     <header id="header">
       <nav id="nav">
@@ -67,13 +67,13 @@
 	    <pre>
               git clone --recursive https://github.com/AMReX-Combustion/PeleLMeX.git
               cd Exec/RegTests/FlameSheet/
-              make -j 12
+              make TPL && make -j 12
               mpiexec -np 8 ./PeleLMeX2d.gnu.MPI.ex input.2d-regt
             </pre>
             <p>
               The <a href="manual/html/index.html">PeleLMeX Documentation</a>
               continues to be the best place to learn more about the code.
-              You can also ask for help by opening up an issue on the 
+              You can also ask for help by opening up an issue on the
               <a href="https://github.com/AMReX-Combustion/PeleLMeX">PeleLMeX GitHub webpage</a>.
             </p>
 	    </li>

--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -164,7 +164,7 @@ The following list of derived variables are available in PeleLMeX:
     * - `mole_fractions`
       - NUM_SPECIES
       - Species mole fractions
-    * - `diffcoeffs`
+    * - `diffcoeff`
       - NUM_SPECIES
       - Species mixture-averaged diffusion coefficients
     * - `lambda`
@@ -527,4 +527,3 @@ frequency using:
 ::
 
     amr.message_int      = 20                # [OPT, DEF=10] Frequency for checking the presence of trigger files
-

--- a/Docs/sphinx/manual/Tutorials_BFSFlame.rst
+++ b/Docs/sphinx/manual/Tutorials_BFSFlame.rst
@@ -19,42 +19,7 @@ well as embedded boundaries.
 
 ..  _sec:TUTO_BFS::PrepStep:
 
-Setting-up your environment
----------------------------
-
-Getting a functioning environment in which to compile and run `PeleLMeX` is the first step of this tutorial.
-Follow the steps listed below to get to this point:
-
-#. The first step is to get `PeleLMeX` and its dependencies. To do so, use a recursive *git clone*: ::
-
-    git clone --recursive https://github.com/AMReX-Combustion/PeleLMeX.git
-
-#. Move into the Exec folder containing the ``EB_BackwardStepFlame``. To do so: ::
-
-    cd PeleLMeX/Exec/RegTests/EB_BackwardStepFlame
-
-Note that the makefile system is set up such that default paths are automatically set to the
-submodules obtained with the recursive *git clone*, however the user can set their own dependencies
-in the `GNUmakefile` by updating the top-most lines as follows: ::
-
-       PELELMEX_HOME     = <path_to_PeleLMeX>
-       AMREX_HOME        = <path_to_MyAMReX>
-       AMREX_HYDRO_HOME  = <path_to_MyAMReXHydro>
-       PELE_PHYSICS_HOME = <path_to_MyPelePhysics>
-       SUNDIALS_HOME     = <path_to_MySUNDIALS>
-
-or directly through shell environment variables (using *bash* for instance): ::
-
-       export PELELMEX_HOME=<path_to_PeleLMeX>
-       export AMREX_HOME=<path_to_MyAMReX>
-       export AMREX_HYDRO_HOME=<path_to_MyAMReXHydro>
-       export PELE_PHYSICS_HOME=<path_to_MyPelePhysics>
-       export SUNDIALS_HOME=<path_to_MySUNDIALS>
-
-Note that using the first option will overwrite any
-environment variables you might have previously defined when using this `GNUmakefile`.
-
-You're good to go !
+.. include:: Tutorials_SettingUp.rst
 
 Case setup
 ----------

--- a/Docs/sphinx/manual/Tutorials_BFSFlame.rst
+++ b/Docs/sphinx/manual/Tutorials_BFSFlame.rst
@@ -11,14 +11,13 @@ Introduction
 ------------
 
 The primary objective of `PeleLMeX` is to enable simulations of reactive flows on platforms ranging
-from small personal computers to Exascale supercomputers. This tutorial describes the case
+from small personal computers to Exascale supercomputers. This ``EB_BackwardStepFlame`` tutorial describes the case
 of a 2D laminar premixed methane/air flame anchored behind a backward facing step.
 
 The goal of this tutorial is to introduce `PeleLMeX` users to more advanced reactive simulation setup as
 well as embedded boundaries.
 
-..  _sec:TUTO_BFS::PrepStep:
-
+.. _sec:TUTO_BFS::PrepStep:
 .. include:: Tutorials_SettingUp.rst
 
 Case setup

--- a/Docs/sphinx/manual/Tutorials_FlameSheet.rst
+++ b/Docs/sphinx/manual/Tutorials_FlameSheet.rst
@@ -10,7 +10,7 @@ Premixed flame sheet with harmonic perturbations
 Introduction
 ------------
 `PeleLMeX` primary objective is to enable simulation of reactive flows on platforms ranging
-from small personal computer to Exascale supercomputer. This short tutorial describes
+from small personal computer to Exascale supercomputer. This short ``FlameSheet`` tutorial describes
 the case of a 2D laminar methane/hydrogen/air premixed flame, perturbed using harmonic fluctuations
 on the initial conditions.
 
@@ -19,45 +19,7 @@ This document provides step by step instructions reviewing how to set-up the dom
 and how to construct an initial solution.
 
 ..  _sec:TUTO_FS::PrepStep:
-
-Setting-up your environment
----------------------------
-
-Getting a functioning environment in which to compile and run `PeleLMeX` is the first step of this tutorial.
-Please review the requirements listed on the `PeleLMeX README <https://github.com/AMReX-Combustion/PeleLMeX/blob/development/README.md>`_ to ensure
-you have a suitable compiler suite to build `PeleLMeX`.
-Follow the steps listed below to get the source code and its dependent libraries:
-
-#. The first step consist in getting `PeleLMeX` and its dependencies. To do so, use a recursive *git clone*: ::
-
-    git clone --recursive https://github.com/AMReX-Combustion/PeleLMeX.git
-
-#. Move into the Exec folder containing the ``FlameSheet``. To do so: ::
-
-    cd PeleLMeX/Exec/RegTests/FlameSheet
-
-Note that the makefile system is set up such that default paths are automatically set to the
-submodules obtained with the recursive *git clone*, however the user can set their own dependencies
-in the `GNUmakefile` by updating the top-most lines as follows: ::
-
-       PELELMEX_HOME     = <path_to_PeleLMeX>
-       AMREX_HOME        = <path_to_MyAMReX>
-       AMREX_HYDRO_HOME  = <path_to_MyAMReXHydro>
-       PELE_PHYSICS_HOME = <path_to_MyPelePhysics>
-       SUNDIALS_HOME     = <path_to_MySUNDIALS>
-
-or directly through shell environment variables (using *bash* for instance): ::
-
-       export PELELMEX_HOME=<path_to_PeleLMeX>
-       export AMREX_HOME=<path_to_MyAMReX>
-       export AMREX_HYDRO_HOME=<path_to_MyAMReXHydro>
-       export PELE_PHYSICS_HOME=<path_to_MyPelePhysics>
-       export SUNDIALS_HOME=<path_to_MySUNDIALS>
-
-Note that using the first option will overwrite any
-environment variables you might have previously defined when using this `GNUmakefile`.
-
-You're good to go !
+.. include:: Tutorials_SettingUp.rst
 
 Case setup
 ----------

--- a/Docs/sphinx/manual/Tutorials_FlowPastCyl.rst
+++ b/Docs/sphinx/manual/Tutorials_FlowPastCyl.rst
@@ -15,48 +15,12 @@ geometries using an embedded boundary (EB) method. This method relies on interse
 arbitrary surface with the Cartesian matrix of uniform cells, and modifies the numerical stencils
 near cells that are cut by the EB.
 
-The goal of this tutorial is to setup a simple 2-dimentional flow past cylinder case in `PeleLMeX`.
+The goal of this ``EB_FlowPastCylinder`` tutorial is to setup a simple 2-dimentional flow past cylinder case in `PeleLMeX`.
 This document provides step by step instructions to properly set-up the domain and boundary conditions,
 construct an initial solution.
 
 ..  _sec:TUTO_FPC::PrepStep:
-
-Setting-up your environment
----------------------------
-
-Getting a functioning environment in which to compile and run `PeleLMeX` is the first step of this tutorial.
-Follow the steps listed below to get to this point:
-
-#. The first step consist in getting `PeleLMeX` and its dependencies. To do so, use a recursive *git clone*: ::
-
-    git clone --recursive https://github.com/AMReX-Combustion/PeleLMeX.git
-
-#. Move into the Exec folder containing the ``FlowPastCylinder``. To do so: ::
-
-    cd PeleLMeX/Exec/RegTests/EB_FlowPastCylinder
-
-Note that the makefile system is set up such that default paths are automatically set to the
-submodules obtained with the recursive *git clone*, however the user can set their own dependencies
-in the `GNUmakefile` by updating the top-most lines as follows: ::
-
-       PELELMEX_HOME     = <path_to_PeleLMeX>
-       AMREX_HOME        = <path_to_MyAMReX>
-       AMREX_HYDRO_HOME  = <path_to_MyAMReXHydro>
-       PELE_PHYSICS_HOME = <path_to_MyPelePhysics>
-       SUNDIALS_HOME     = <path_to_MySUNDIALS>
-
-or directly through shell environment variables (using *bash* for instance): ::
-
-       export PELELMEX_HOME=<path_to_PeleLMeX>
-       export AMREX_HOME=<path_to_MyAMReX>
-       export AMREX_HYDRO_HOME=<path_to_MyAMReXHydro>
-       export PELE_PHYSICS_HOME=<path_to_MyPelePhysics>
-       export SUNDIALS_HOME=<path_to_MySUNDIALS>
-
-Note that using the first option will overwrite any
-environment variables you might have previously defined when using this `GNUmakefile`.
-
-You're good to go !
+.. include:: Tutorials_SettingUp.rst
 
 Numerical setup
 ---------------

--- a/Docs/sphinx/manual/Tutorials_HotBubble.rst
+++ b/Docs/sphinx/manual/Tutorials_HotBubble.rst
@@ -11,48 +11,12 @@ Introduction
 ------------
 
 At the core of `PeleLMeX` algorithm is a variable-density, low Mach number Navier-Stokes solver based
-on a fractional step approach. This short tutorial presents the case of a rising light bubble under
+on a fractional step approach. This short ``HotBubble`` tutorial presents the case of a rising light bubble under
 the influence of a gravity field, which exercice this algorithm without the added complexity
 of chemical reactions or embedded boundaries.
 
 ..  _sec:TUTO_HB::PrepStep:
-
-Setting-up your environment
----------------------------
-
-Getting a functioning environment in which to compile and run `PeleLMeX` is the first step of this tutorial.
-Follow the steps listed below to get to this point:
-
-#. The first step is to get `PeleLMeX` and its dependencies. To do so, use a recursive *git clone*: ::
-
-    git clone --recursive https://github.com/AMReX-Combustion/PeleLMeX.git
-
-#. Move into the Exec folder containing the ``HotBubble``. To do so: ::
-
-    cd PeleLMeX/Exec/RegTests/HotBubble
-
-Note that the makefile system is set up such that default paths are automatically set to the
-submodules obtained with the recursive *git clone*, however the user can set their own dependencies
-in the `GNUmakefile` by updating the top-most lines as follows: ::
-
-       PELELMEX_HOME     = <path_to_PeleLMeX>
-       AMREX_HOME        = <path_to_MyAMReX>
-       AMREX_HYDRO_HOME  = <path_to_MyAMReXHydro>
-       PELE_PHYSICS_HOME = <path_to_MyPelePhysics>
-       SUNDIALS_HOME     = <path_to_MySUNDIALS>
-
-or directly through shell environment variables (using *bash* for instance): ::
-
-       export PELELMEX_HOME=<path_to_PeleLMeX>
-       export AMREX_HOME=<path_to_MyAMReX>
-       export AMREX_HYDRO_HOME=<path_to_MyAMReXHydro>
-       export PELE_PHYSICS_HOME=<path_to_MyPelePhysics>
-       export SUNDIALS_HOME=<path_to_MySUNDIALS>
-
-Note that using the first option will overwrite any
-environment variables you might have previously defined when using this `GNUmakefile`.
-
-You're good to go !
+.. include:: Tutorials_SettingUp.rst
 
 Case setup
 ----------

--- a/Docs/sphinx/manual/Tutorials_SettingUp.rst
+++ b/Docs/sphinx/manual/Tutorials_SettingUp.rst
@@ -12,7 +12,7 @@ Follow the steps listed below to get to this point:
    substantially reduce the size of the download by skipping extraneous parts of the git history.
    Developers may wish to omit these flags in order download the complete git history of PeleLMeX
    and its submodules, though standard ``git`` commands may also be used after a shallow clone to
-   optain the skipped portions if needed.
+   obtain the skipped portions if needed.
 
 #. Move into the Exec folder containing your tutorial. To do so: ::
 
@@ -26,7 +26,7 @@ You're good to go!
 .. Note::
 
    The makefile system is set up such that default paths are automatically set to the
-   submodules obtained with the recursive *git clone*, however the user can set their own dependencies
+   submodules obtained with the recursive *git clone*, however advanced users can set their own dependencies
    in the `GNUmakefile` for each case by updating the top-most lines as follows: ::
 
        PELELMEX_HOME     = <path_to_PeleLMeX>

--- a/Docs/sphinx/manual/Tutorials_SettingUp.rst
+++ b/Docs/sphinx/manual/Tutorials_SettingUp.rst
@@ -1,0 +1,36 @@
+Setting-up your environment
+---------------------------
+
+Getting a functioning environment in which to compile and run `PeleLMeX` is the first step of this tutorial.
+Follow the steps listed below to get to this point:
+
+#. The first step is to get `PeleLMeX` and its dependencies. To do so, use a recursive *git clone*: ::
+
+    git clone --recursive https://github.com/AMReX-Combustion/PeleLMeX.git
+
+#. Move into the Exec folder containing the ``EB_BackwardStepFlame``. To do so: ::
+
+    cd PeleLMeX/Exec/RegTests/EB_BackwardStepFlame
+
+Note that the makefile system is set up such that default paths are automatically set to the
+submodules obtained with the recursive *git clone*, however the user can set their own dependencies
+in the `GNUmakefile` by updating the top-most lines as follows: ::
+
+       PELELMEX_HOME     = <path_to_PeleLMeX>
+       AMREX_HOME        = <path_to_MyAMReX>
+       AMREX_HYDRO_HOME  = <path_to_MyAMReXHydro>
+       PELE_PHYSICS_HOME = <path_to_MyPelePhysics>
+       SUNDIALS_HOME     = <path_to_MySUNDIALS>
+
+or directly through shell environment variables (using *bash* for instance): ::
+
+       export PELELMEX_HOME=<path_to_PeleLMeX>
+       export AMREX_HOME=<path_to_MyAMReX>
+       export AMREX_HYDRO_HOME=<path_to_MyAMReXHydro>
+       export PELE_PHYSICS_HOME=<path_to_MyPelePhysics>
+       export SUNDIALS_HOME=<path_to_MySUNDIALS>
+
+Note that using the first option will overwrite any
+environment variables you might have previously defined when using this `GNUmakefile`.
+
+You're good to go !

--- a/Docs/sphinx/manual/Tutorials_SettingUp.rst
+++ b/Docs/sphinx/manual/Tutorials_SettingUp.rst
@@ -6,15 +6,28 @@ Follow the steps listed below to get to this point:
 
 #. The first step is to get `PeleLMeX` and its dependencies. To do so, use a recursive *git clone*: ::
 
-    git clone --recursive https://github.com/AMReX-Combustion/PeleLMeX.git
+    git clone --recursive --shallow-submodules --single-branch https://github.com/AMReX-Combustion/PeleLMeX.git
 
-#. Move into the Exec folder containing the ``EB_BackwardStepFlame``. To do so: ::
+   The ``--shallow-submodules`` and ``--single-branch`` flags are recommended for most users as they
+   substantially reduce the size of the download by skipping extraneous parts of the git history.
+   Developers may wish to omit these flags in order download the complete git history of PeleLMeX
+   and its submodules, though standard ``git`` commands may also be used after a shallow clone to
+   optain the skipped portions if needed.
 
-    cd PeleLMeX/Exec/RegTests/EB_BackwardStepFlame
+#. Move into the Exec folder containing your tutorial. To do so: ::
 
-Note that the makefile system is set up such that default paths are automatically set to the
-submodules obtained with the recursive *git clone*, however the user can set their own dependencies
-in the `GNUmakefile` by updating the top-most lines as follows: ::
+    cd PeleLMeX/Exec/RegTests/<CaseName>
+
+   where <CaseName> is the name of your tutorial, e.g. ``HotBubble``, ``FlameSheet``,
+   ``EB_BackwardStepFlame``, ``EB_FlowPastCylinder``, or ``TripleFlame``.
+
+You're good to go!
+
+.. Note::
+
+   The makefile system is set up such that default paths are automatically set to the
+   submodules obtained with the recursive *git clone*, however the user can set their own dependencies
+   in the `GNUmakefile` for each case by updating the top-most lines as follows: ::
 
        PELELMEX_HOME     = <path_to_PeleLMeX>
        AMREX_HOME        = <path_to_MyAMReX>
@@ -22,7 +35,7 @@ in the `GNUmakefile` by updating the top-most lines as follows: ::
        PELE_PHYSICS_HOME = <path_to_MyPelePhysics>
        SUNDIALS_HOME     = <path_to_MySUNDIALS>
 
-or directly through shell environment variables (using *bash* for instance): ::
+   or directly through shell environment variables (using *bash* for instance): ::
 
        export PELELMEX_HOME=<path_to_PeleLMeX>
        export AMREX_HOME=<path_to_MyAMReX>
@@ -30,7 +43,5 @@ or directly through shell environment variables (using *bash* for instance): ::
        export PELE_PHYSICS_HOME=<path_to_MyPelePhysics>
        export SUNDIALS_HOME=<path_to_MySUNDIALS>
 
-Note that using the first option will overwrite any
-environment variables you might have previously defined when using this `GNUmakefile`.
-
-You're good to go !
+   Note that using the first option will overwrite any
+   environment variables you might have previously defined when using this `GNUmakefile`.

--- a/Docs/sphinx/manual/Tutorials_TripleFlame.rst
+++ b/Docs/sphinx/manual/Tutorials_TripleFlame.rst
@@ -16,7 +16,7 @@ They also aid in our understanding of the more complex turbulent flames.
 Depending on the fuel involved and the flow configuration, the laminar flames can take on a number of interesting geometries.
 For example, as practical combustion systems often operate in partially premixed mode,
 with one or more fuel injections, a wide range of fresh gas compositions can be observed;
-and these conditions favor the appearance of edge flames, see Fig. :numref:`TripleFlameIntro`.
+and these conditions favor the appearance of edge flames, see :numref:`TripleFlameIntro`.
 
 .. figure:: images/tutorials/TF_Intro.png
    :name: TripleFlameIntro
@@ -31,54 +31,13 @@ an important role in flame stabilization, re-ignition and propagation.
 Simple fuels can exhibit up to three burning branches while diesel fuel, with a low temperature combustion mode,
 can exhibit up to 5 branches.
 
-The goal of this tutorial is to setup a simple 2D laminar triple edge flame configuration with `PeleLMeX`.
+The goal of this ``TripleFlame`` tutorial is to setup a simple 2D laminar triple edge flame configuration with `PeleLMeX`.
 This document provides step by step instructions to properly set-up the domain and boundary conditions,
 construct an initial solution, and provides guidance on how to monitor and influence the initial transient to reach
 a final steady-state solution.
 
 ..  _sec:TUTO_TF::PrepStep:
-
-Setting-up your environment
----------------------------
-
-Getting a functioning environment in which to compile and run `PeleLMeX` is the first step of this tutorial.
-Follow the steps listed below to get to this point:
-
-#. The first step is to get `PeleLMeX` and its dependencies. To do so, use a recursive *git clone*: ::
-
-    git clone --recursive https://github.com/AMReX-Combustion/PeleLMeX.git
-
-#. Move into the Exec folder containing the ``TripleFLame``. To do so: ::
-
-    cd PeleLMeX/Exec/RegTests/TripleFLame
-
-Note that the makefile system is set up such that default paths are automatically set to the
-submodules obtained with the recursive *git clone*, however the user can set their own dependencies
-in the `GNUmakefile` by updating the top-most lines as follows: ::
-
-       PELELMEX_HOME     = <path_to_PeleLMeX>
-       AMREX_HOME        = <path_to_MyAMReX>
-       AMREX_HYDRO_HOME  = <path_to_MyAMReXHydro>
-       PELE_PHYSICS_HOME = <path_to_MyPelePhysics>
-       SUNDIALS_HOME     = <path_to_MySUNDIALS>
-
-or directly through shell environment variables (using *bash* for instance): ::
-
-       export PELELMEX_HOME=<path_to_PeleLMeX>
-       export AMREX_HOME=<path_to_MyAMReX>
-       export AMREX_HYDRO_HOME=<path_to_MyAMReXHydro>
-       export PELE_PHYSICS_HOME=<path_to_MyPelePhysics>
-       export SUNDIALS_HOME=<path_to_MySUNDIALS>
-
-Note that using the first option will overwrite any
-environment variables you might have previously defined when using this `GNUmakefile`.
-
-You're good to go !
-
-Numerical setup
----------------
-
-In this section we review the content of the various input files for the Triple Flame test case. To get additional information about the keywords discussed, the user is referred to :doc:`LMeXControls`.
+.. include:: Tutorials_SettingUp.rst
 
 Test case and boundary conditions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.md
+++ b/README.md
@@ -69,8 +69,11 @@ The preferred method consists of cloning *PeleLMeX* and its submodules
 ([amrex](https://github.com/AMReX-Codes/amrex), [AMReX-Hydro](https://github.com/AMReX-Fluids/AMReX-Hydro), [PelePhysics](https://github.com/AMReX-Combustion/PelePhysics), [PeleMP](https://github.com/AMReX-Combustion/PeleMP)), and [SUNDIALS](https://github.com/LLNL/sundials) using a recursive `git clone`:
 
 ```
-git clone --recursive https://github.com/AMReX-Combustion/PeleLMeX.git
+git clone --recursive --shallow-submodules --single-branch https://github.com/AMReX-Combustion/PeleLMeX.git
 ```
+
+The `--shallow-submodules` and `--single-branch` commands are recommended for most users as they substantially reduce the size of the download by
+skipping extraneous parts of the git history.   
 
 Alternatively, you can use a separate `git clone` of each of the submodules.
 The default location for *PeleLMeX* dependencies is the `Submodules` folder but you optionally

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ git clone --recursive --shallow-submodules --single-branch https://github.com/AM
 
 The `--shallow-submodules` and `--single-branch` flags are recommended for most users as they substantially reduce the size of the download by
 skipping extraneous parts of the git history. Developers may wish to omit these flags in order download the complete git history of PeleLMeX
-and its submodules, though standard `git` commands may also be used after a shallow clone to optain the skipped portions if needed.
+and its submodules, though standard `git` commands may also be used after a shallow clone to obtain the skipped portions if needed.
 
 Alternatively, you can use a separate `git clone` of each of the submodules.
 The default location for *PeleLMeX* dependencies is the `Submodules` folder but you optionally

--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ The preferred method consists of cloning *PeleLMeX* and its submodules
 git clone --recursive --shallow-submodules --single-branch https://github.com/AMReX-Combustion/PeleLMeX.git
 ```
 
-The `--shallow-submodules` and `--single-branch` commands are recommended for most users as they substantially reduce the size of the download by
-skipping extraneous parts of the git history.   
+The `--shallow-submodules` and `--single-branch` flags are recommended for most users as they substantially reduce the size of the download by
+skipping extraneous parts of the git history. Developers may wish to omit these flags in order download the complete git history of PeleLMeX
+and its submodules, though standard `git` commands may also be used after a shallow clone to optain the skipped portions if needed.
 
 Alternatively, you can use a separate `git clone` of each of the submodules.
 The default location for *PeleLMeX* dependencies is the `Submodules` folder but you optionally


### PR DESCRIPTION
- Adds some instructions for using `clang_format`
- Fixes a typo to close #310 
- Consolidates redundant boilerplate on cloning at the beginning of each tutorial
- Instructs users to use `git clone --recursive --shallow-submodules --single-branch` in order to reduce the size of the cloned submodules (particularly PelePhysics, which has a hefty history from reformatting large mechanisms) and avoid cloning unnecessary branches (relates to #307)