### PR TITLE
Fix no EB production cases

### DIFF
--- a/Exec/Production/CounterFlow/GNUmakefile
+++ b/Exec/Production/CounterFlow/GNUmakefile
@@ -2,7 +2,7 @@
 DIM = 2
 COMP = gnu
 PRECISION = DOUBLE
-USE_EB = TRUE
+USE_EB = FALSE
 USE_HYPRE = FALSE
 
 # Profiling

--- a/Exec/Production/CounterFlowSpray/GNUmakefile
+++ b/Exec/Production/CounterFlowSpray/GNUmakefile
@@ -2,7 +2,7 @@
 DIM = 2
 COMP = gnu
 PRECISION = DOUBLE
-USE_EB = TRUE
+USE_EB = FALSE
 USE_HYPRE = FALSE
 
 # Profiling

--- a/Exec/Production/DiffBunsen2D/GNUmakefile
+++ b/Exec/Production/DiffBunsen2D/GNUmakefile
@@ -2,7 +2,7 @@
 DIM = 2
 COMP = gnu
 PRECISION = DOUBLE
-USE_EB = TRUE
+USE_EB = FALSE
 USE_HYPRE = FALSE
 
 # Profiling

--- a/Exec/Production/JetInCrossflow/GNUmakefile
+++ b/Exec/Production/JetInCrossflow/GNUmakefile
@@ -2,7 +2,7 @@
 DIM = 3
 COMP = gnu
 PRECISION = DOUBLE
-USE_EB = TRUE
+USE_EB = FALSE
 USE_HYPRE = FALSE
 
 # Profiling

--- a/Exec/Production/NormalJet_OpenDomain/GNUmakefile
+++ b/Exec/Production/NormalJet_OpenDomain/GNUmakefile
@@ -2,7 +2,7 @@
 DIM = 3
 COMP = gnu
 PRECISION = DOUBLE
-USE_EB = TRUE
+USE_EB = FALSE
 USE_HYPRE = FALSE
 
 # Profiling

--- a/Exec/Production/NormalJet_OpenDomain/pelelmex_prob.H
+++ b/Exec/Production/NormalJet_OpenDomain/pelelmex_prob.H
@@ -3,13 +3,12 @@
 
 #include <AMReX_Geometry.H>
 #include <AMReX_FArrayBox.H>
-#include <AMReX_ParmParse.H>
 #include <AMReX_SPACE.H>
 
 #include <PeleLMeX_Index.H>
 #include <pelelmex_prob_parm.H>
 #include <PMFData.H>
-#include <PelePhysics.H>
+#include <mechanism.H>
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
@@ -115,7 +114,7 @@ bcnormal(
     }
     enthalpy = eta * prob_parm.H_fuel + (1.0 - eta) * prob_parm.H_ox;
 
-    GET_T_GIVEN_HY(&enthalpy, massfrac, &s_ext[TEMP], &ierr);
+    GET_T_GIVEN_HY(enthalpy, massfrac, s_ext[TEMP], ierr);
 
     amrex::Real rho_cgs, P_cgs, RhoH_temp;
     P_cgs = prob_parm.P_mean * 10.0;

--- a/Exec/Production/NormalJet_OpenDomain/pelelmex_prob.cpp
+++ b/Exec/Production/NormalJet_OpenDomain/pelelmex_prob.cpp
@@ -56,8 +56,8 @@ PeleLM::readProbParm()
       prob_parm->Z * Y_pure_fuel[n] + (1. - prob_parm->Z) * prob_parm->Y_ox[n];
   }
 
-  CKHBMS(&prob_parm->T_fu, prob_parm->Y_fuel, &prob_parm->H_fuel);
-  CKHBMS(&prob_parm->T_ox, prob_parm->Y_ox, &prob_parm->H_ox);
+  CKHBMS(prob_parm->T_fu, prob_parm->Y_fuel, prob_parm->H_fuel);
+  CKHBMS(prob_parm->T_ox, prob_parm->Y_ox, prob_parm->H_ox);
 
   auto problo = geom[0].ProbLo();
   auto probhi = geom[0].ProbHi();

--- a/Exec/Production/NormalJet_OpenDomain/pelelmex_prob_parm.H
+++ b/Exec/Production/NormalJet_OpenDomain/pelelmex_prob_parm.H
@@ -3,6 +3,7 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuMemory.H>
+#include <PelePhysics.H>
 
 using namespace amrex::literals;
 

--- a/Exec/Production/PremBunsen2D/GNUmakefile
+++ b/Exec/Production/PremBunsen2D/GNUmakefile
@@ -2,7 +2,7 @@
 DIM = 2
 COMP = gnu
 PRECISION = DOUBLE
-USE_EB = TRUE
+USE_EB = FALSE
 USE_HYPRE = FALSE
 
 # Profiling

--- a/Exec/Production/PremBunsen3D/GNUmakefile
+++ b/Exec/Production/PremBunsen3D/GNUmakefile
@@ -2,7 +2,7 @@
 DIM = 3
 COMP = gnu
 PRECISION = DOUBLE
-USE_EB = TRUE
+USE_EB = FALSE
 USE_HYPRE = FALSE
 
 # Profiling


### PR DESCRIPTION
Don't compile with EB for Production cases that don't need it. Alternatively, we could still compile with EB but set `eb2.geom_type = all_regular` in the input files.

Closes #311 