### PR TITLE
Fix BC Types due to breaking AMReX change

### DIFF
--- a/Exec/RegTests/TurbInflow/TurbFileHIT/main.cpp
+++ b/Exec/RegTests/TurbInflow/TurbFileHIT/main.cpp
@@ -161,11 +161,12 @@ main(int argc, char* argv[])
     Real xhi = data.d_xarray[ncell - 1];
 
     Box box_turb(
-      IntVect(D_DECL(0, 0, 0)),
-      IntVect(D_DECL(ncell - 1, ncell - 1, ncell - 1)));
-    RealBox rb_turb({D_DECL(xlo, xlo, xlo)}, {D_DECL(xhi, xhi, xhi)});
+      IntVect(AMREX_D_DECL(0, 0, 0)),
+      IntVect(AMREX_D_DECL(ncell - 1, ncell - 1, ncell - 1)));
+    RealBox rb_turb(
+      {AMREX_D_DECL(xlo, xlo, xlo)}, {AMREX_D_DECL(xhi, xhi, xhi)});
     int coord_turb(0);
-    Array<int, AMREX_SPACEDIM> per_turb = {D_DECL(1, 1, 1)};
+    Array<int, AMREX_SPACEDIM> per_turb = {AMREX_D_DECL(1, 1, 1)};
     Geometry geom_turb(box_turb, rb_turb, coord_turb, per_turb);
     const Real* dx_turb = geom_turb.CellSize();
 

--- a/Source/Efield/LinOps/PrecondOp.cpp
+++ b/Source/Efield/LinOps/PrecondOp.cpp
@@ -207,12 +207,14 @@ PrecondOp::getOpBC(Orientation::Side a_side, const BCRec& a_bc)
     } else {
       auto amrexbc =
         (a_side == Orientation::low) ? a_bc.lo(idim) : a_bc.hi(idim);
-      if (amrexbc == EXT_DIR) {
+      if (amrexbc == amrex::BCType::ext_dir) {
         r[idim] = LinOpBCType::Dirichlet;
       } else if (
-        amrexbc == FOEXTRAP || amrexbc == HOEXTRAP || amrexbc == REFLECT_EVEN) {
+        amrexbc == amrex::BCType::foextrap ||
+        amrexbc == amrex::BCType::hoextrap ||
+        amrexbc == amrex::BCType::reflect_even) {
         r[idim] = LinOpBCType::Neumann;
-      } else if (amrexbc == REFLECT_ODD) {
+      } else if (amrexbc == amrex::BCType::reflect_odd) {
         r[idim] = LinOpBCType::reflect_odd;
       } else {
         r[idim] = LinOpBCType::bogus;

--- a/Source/PeleLMeX_BC.cpp
+++ b/Source/PeleLMeX_BC.cpp
@@ -10,26 +10,40 @@
 // Components are  Interior, Inflow, Outflow, Symmetry, &
 // SlipWallAdiab, NoSlipWallAdiab, SlipWallIsoTherm, NoSlipWallIsoTherm.
 
-int norm_vel_bc[] = {INT_DIR, EXT_DIR, FOEXTRAP, REFLECT_ODD,
-                     EXT_DIR, EXT_DIR, EXT_DIR,  EXT_DIR};
+int norm_vel_bc[] = {amrex::BCType::int_dir,  amrex::BCType::ext_dir,
+                     amrex::BCType::foextrap, amrex::BCType::reflect_odd,
+                     amrex::BCType::ext_dir,  amrex::BCType::ext_dir,
+                     amrex::BCType::ext_dir,  amrex::BCType::ext_dir};
 
-int tang_vel_bc[] = {INT_DIR,  EXT_DIR, FOEXTRAP, REFLECT_EVEN,
-                     HOEXTRAP, EXT_DIR, HOEXTRAP, EXT_DIR};
+int tang_vel_bc[] = {amrex::BCType::int_dir,  amrex::BCType::ext_dir,
+                     amrex::BCType::foextrap, amrex::BCType::reflect_even,
+                     amrex::BCType::hoextrap, amrex::BCType::ext_dir,
+                     amrex::BCType::hoextrap, amrex::BCType::ext_dir};
 
-int density_bc[] = {INT_DIR,  EXT_DIR,  FOEXTRAP, REFLECT_EVEN,
-                    FOEXTRAP, FOEXTRAP, FOEXTRAP, FOEXTRAP};
+int density_bc[] = {amrex::BCType::int_dir,  amrex::BCType::ext_dir,
+                    amrex::BCType::foextrap, amrex::BCType::reflect_even,
+                    amrex::BCType::foextrap, amrex::BCType::foextrap,
+                    amrex::BCType::foextrap, amrex::BCType::foextrap};
 
-int species_bc[] = {INT_DIR,  EXT_DIR,  FOEXTRAP, REFLECT_EVEN,
-                    FOEXTRAP, FOEXTRAP, EXT_DIR,  EXT_DIR};
+int species_bc[] = {amrex::BCType::int_dir,  amrex::BCType::ext_dir,
+                    amrex::BCType::foextrap, amrex::BCType::reflect_even,
+                    amrex::BCType::foextrap, amrex::BCType::foextrap,
+                    amrex::BCType::ext_dir,  amrex::BCType::ext_dir};
 
-int rhoh_bc[] = {INT_DIR,  EXT_DIR,  FOEXTRAP, REFLECT_EVEN,
-                 FOEXTRAP, FOEXTRAP, EXT_DIR,  EXT_DIR};
+int rhoh_bc[] = {amrex::BCType::int_dir,  amrex::BCType::ext_dir,
+                 amrex::BCType::foextrap, amrex::BCType::reflect_even,
+                 amrex::BCType::foextrap, amrex::BCType::foextrap,
+                 amrex::BCType::ext_dir,  amrex::BCType::ext_dir};
 
-int temp_bc[] = {INT_DIR,  EXT_DIR,  FOEXTRAP, REFLECT_EVEN,
-                 FOEXTRAP, FOEXTRAP, EXT_DIR,  EXT_DIR};
+int temp_bc[] = {amrex::BCType::int_dir,  amrex::BCType::ext_dir,
+                 amrex::BCType::foextrap, amrex::BCType::reflect_even,
+                 amrex::BCType::foextrap, amrex::BCType::foextrap,
+                 amrex::BCType::ext_dir,  amrex::BCType::ext_dir};
 
-int divu_bc[] = {INT_DIR,      REFLECT_EVEN, REFLECT_EVEN, REFLECT_EVEN,
-                 REFLECT_EVEN, REFLECT_EVEN, REFLECT_EVEN, REFLECT_EVEN};
+int divu_bc[] = {amrex::BCType::int_dir,      amrex::BCType::reflect_even,
+                 amrex::BCType::reflect_even, amrex::BCType::reflect_even,
+                 amrex::BCType::reflect_even, amrex::BCType::reflect_even,
+                 amrex::BCType::reflect_even, amrex::BCType::reflect_even};
 
 // Following incflo rather than IAMR here
 int force_bc[] = {BCType::int_dir,  BCType::foextrap, BCType::foextrap,
@@ -37,15 +51,20 @@ int force_bc[] = {BCType::int_dir,  BCType::foextrap, BCType::foextrap,
                   BCType::foextrap, BCType::foextrap};
 
 #ifdef PELE_USE_EFIELD
-int nE_bc[] = {INT_DIR,      EXT_DIR,      FOEXTRAP, REFLECT_EVEN,
-               REFLECT_EVEN, REFLECT_EVEN, EXT_DIR,  EXT_DIR};
+int nE_bc[] = {amrex::BCType::int_dir,      amrex::BCType::ext_dir,
+               amrex::BCType::foextrap,     amrex::BCType::reflect_even,
+               amrex::BCType::reflect_even, amrex::BCType::reflect_even,
+               amrex::BCType::ext_dir,      amrex::BCType::ext_dir};
 
-int phiV_bc[] = {INT_DIR, EXT_DIR, REFLECT_EVEN};
+int phiV_bc[] = {
+  amrex::BCType::int_dir, amrex::BCType::ext_dir, amrex::BCType::reflect_even};
 #endif
 
 #ifdef PELE_USE_SOOT
-int soot_bc[] = {INT_DIR,      EXT_DIR,      FOEXTRAP, REFLECT_EVEN,
-                 REFLECT_EVEN, REFLECT_EVEN, EXT_DIR,  EXT_DIR};
+int soot_bc[] = {amrex::BCType::int_dir,      amrex::BCType::ext_dir,
+                 amrex::BCType::foextrap,     amrex::BCType::reflect_even,
+                 amrex::BCType::reflect_even, amrex::BCType::reflect_even,
+                 amrex::BCType::ext_dir,      amrex::BCType::ext_dir};
 #endif
 
 InterpBase*
@@ -903,7 +922,8 @@ PeleLM::fillTurbInflow(
 
         auto bndryBoxLO =
           amrex::Box(amrex::adjCellLo(geom[lev].Domain(), dir, 4) & bx);
-        if (velBCRec[0].lo()[dir] == EXT_DIR && bndryBoxLO.ok()) {
+        if (
+          velBCRec[0].lo()[dir] == amrex::BCType::ext_dir && bndryBoxLO.ok()) {
           // Create box with ghost cells and set them to zero
           amrex::IntVect growVect(amrex::IntVect::TheUnitVector());
           int Grow = 4; // Being conservative
@@ -925,7 +945,8 @@ PeleLM::fillTurbInflow(
 
         auto bndryBoxHI =
           amrex::Box(amrex::adjCellHi(geom[lev].Domain(), dir, 4) & bx);
-        if (velBCRec[0].hi()[dir] == EXT_DIR && bndryBoxHI.ok()) {
+        if (
+          velBCRec[0].hi()[dir] == amrex::BCType::ext_dir && bndryBoxHI.ok()) {
           // Create box with ghost cells and set them to zero
           amrex::IntVect growVect(amrex::IntVect::TheUnitVector());
           int Grow = 4;

--- a/Source/PeleLMeX_BCfill.H
+++ b/Source/PeleLMeX_BCfill.H
@@ -569,8 +569,8 @@ struct PeleLMCCFillExtDirDummy
 //
 // A dummy function because FillPatch requires something to exist for filling
 // dirichlet boundary conditions, even if we know we cannot have an ext_dir BC.
-// u_mac BCs are only either periodic (INT_DIR) or first order extrapolation
-// (FOEXTRAP).
+// u_mac BCs are only either periodic (amrex::BCType::int_dir) or first order
+// extrapolation (amrex::BCType::foextrap).
 //
 struct umacFill
 {

--- a/Source/PeleLMeX_Diffusion.cpp
+++ b/Source/PeleLMeX_Diffusion.cpp
@@ -1510,12 +1510,14 @@ PeleLM::getDiffusionLinOpBC(Orientation::Side a_side, const BCRec& a_bc)
     } else {
       auto amrexbc =
         (a_side == Orientation::low) ? a_bc.lo(idim) : a_bc.hi(idim);
-      if (amrexbc == EXT_DIR) {
+      if (amrexbc == amrex::BCType::ext_dir) {
         r[idim] = LinOpBCType::Dirichlet;
       } else if (
-        amrexbc == FOEXTRAP || amrexbc == HOEXTRAP || amrexbc == REFLECT_EVEN) {
+        amrexbc == amrex::BCType::foextrap ||
+        amrexbc == amrex::BCType::hoextrap ||
+        amrexbc == amrex::BCType::reflect_even) {
         r[idim] = LinOpBCType::Neumann;
-      } else if (amrexbc == REFLECT_ODD) {
+      } else if (amrexbc == amrex::BCType::reflect_odd) {
         r[idim] = LinOpBCType::reflect_odd;
       } else {
         r[idim] = LinOpBCType::bogus;
@@ -1540,13 +1542,14 @@ PeleLM::getDiffusionTensorOpBC(
       for (int dir = 0; dir < AMREX_SPACEDIM; dir++) {
         auto amrexbc = (a_side == Orientation::low) ? a_bc[dir].lo(idim)
                                                     : a_bc[dir].hi(idim);
-        if (amrexbc == EXT_DIR) {
+        if (amrexbc == amrex::BCType::ext_dir) {
           r[dir][idim] = LinOpBCType::Dirichlet;
         } else if (
-          amrexbc == FOEXTRAP || amrexbc == HOEXTRAP ||
-          amrexbc == REFLECT_EVEN) {
+          amrexbc == amrex::BCType::foextrap ||
+          amrexbc == amrex::BCType::hoextrap ||
+          amrexbc == amrex::BCType::reflect_even) {
           r[dir][idim] = LinOpBCType::Neumann;
-        } else if (amrexbc == REFLECT_ODD) {
+        } else if (amrexbc == amrex::BCType::reflect_odd) {
           r[dir][idim] = LinOpBCType::reflect_odd;
         } else {
           r[dir][idim] = LinOpBCType::bogus;

--- a/Source/PeleLMeX_Projection.cpp
+++ b/Source/PeleLMeX_Projection.cpp
@@ -396,7 +396,7 @@ PeleLM::doNodalProject(
     if (Geom(0).isPeriodic(idim)) {
       lobc[idim] = hibc[idim] = LinOpBCType::Periodic;
     } else {
-        if (m_phys_bc.lo(idim) == amrex::PhysBCType::outflow) {
+      if (m_phys_bc.lo(idim) == amrex::PhysBCType::outflow) {
         lobc[idim] = LinOpBCType::Dirichlet;
       } else if (m_phys_bc.lo(idim) == amrex::PhysBCType::inflow) {
         lobc[idim] = LinOpBCType::inflow;

--- a/Source/PeleLMeX_Projection.cpp
+++ b/Source/PeleLMeX_Projection.cpp
@@ -396,16 +396,16 @@ PeleLM::doNodalProject(
     if (Geom(0).isPeriodic(idim)) {
       lobc[idim] = hibc[idim] = LinOpBCType::Periodic;
     } else {
-      if (m_phys_bc.lo(idim) == Outflow) {
+        if (m_phys_bc.lo(idim) == amrex::PhysBCType::outflow) {
         lobc[idim] = LinOpBCType::Dirichlet;
-      } else if (m_phys_bc.lo(idim) == Inflow) {
+      } else if (m_phys_bc.lo(idim) == amrex::PhysBCType::inflow) {
         lobc[idim] = LinOpBCType::inflow;
       } else {
         lobc[idim] = LinOpBCType::Neumann;
       }
-      if (m_phys_bc.hi(idim) == Outflow) {
+      if (m_phys_bc.hi(idim) == amrex::PhysBCType::outflow) {
         hibc[idim] = LinOpBCType::Dirichlet;
-      } else if (m_phys_bc.hi(idim) == Inflow) {
+      } else if (m_phys_bc.hi(idim) == amrex::PhysBCType::inflow) {
         hibc[idim] = LinOpBCType::inflow;
       } else {
         hibc[idim] = LinOpBCType::Neumann;

--- a/Source/PeleLMeX_UMac.cpp
+++ b/Source/PeleLMeX_UMac.cpp
@@ -435,7 +435,7 @@ PeleLM::getMACProjectionBC(Orientation::Side a_side)
     } else {
       auto physbc =
         (a_side == Orientation::low) ? m_phys_bc.lo(idim) : m_phys_bc.hi(idim);
-      if (physbc == Outflow) {
+      if (physbc == amrex::PhysBCType::outflow) {
         r[idim] = LinOpBCType::Dirichlet;
       } else {
         r[idim] = LinOpBCType::Neumann;


### PR DESCRIPTION
https://github.com/AMReX-Codes/amrex/pull/3713 eliminates macros defining BC types and requires use of the enums instead, causing the PeleLMeX nightly test to fail. This makes the required changes, which are better anyway. Same changes will be required in PeleC.