### PR TITLE
do proper shallow submodule update in clonedeps

### DIFF
--- a/Utils/CloneDeps.sh
+++ b/Utils/CloneDeps.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 echo "Getting PeleLMeX dependencies - tests ... "
-git submodule update --init --recursive --recommend-shallow
+git submodule update --init --recursive --depth=1


### PR DESCRIPTION
`--recommend-shallow` doesn't really do anything in `git submodule --init`, use `depth=1` instead which does.