### PR TITLE
New Options for Chi Correction in MAC Projections

### DIFF
--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -123,7 +123,7 @@ IO parameters
     amr.initDataPlt      = plt01000        # [OPT, DEF=""] Provide a plotfile from which to extract initial data
     amr.regrid_on_restart = 1              # [OPT, DEF="0"] Trigger a regrid after the data from checkpoint are loaded
     amr.n_files          = 64              # [OPT, DEF="min(256,NProcs)"] Number of files to write per level
-    
+
 Refinement controls
 -------------------
 
@@ -234,27 +234,28 @@ PeleLMeX algorithm
 ::
 
     #-----------------------PELE CONTROL-----------------------
-    peleLM.v = 1                           # [OPT, DEF=0] Verbose
-    peleLM.run_mode = normal               # [OPT, DEF=normal] Switch between time-advance mode (normal) or UnitTest (evaluate)
-    peleLM.use_wbar = 1                    # [OPT, DEF=1] Enable Wbar correction in diffusion fluxes
-    peleLM.sdc_iterMax = 2                 # [OPT, DEF=1] Number of SDC iterations
-    peleLM.num_init_iter = 2               # [OPT, DEF=3] Number of iterations to get initial pressure
-    peleLM.num_divu_iter = 1               # [OPT, DEF=1] Number of divU iterations to get initial dt estimate
-    peleLM.do_init_proj = 1                # [OPT, DEF=1] Control over initial projection
-    peleLM.advection_scheme = Godunov_BDS  # [OPT, DEF=Godunov_PLM] Advection scheme: Godunov_PLM, Godunov_PPM or Godunov_BDS
-    peleLM.incompressible = 0              # [OPT, DEF=0] Enable to run fully incompressible, scalar advance is bypassed
-    peleLM.m_rho = 1.17                    # [OPT, DEF=-1] If incompressible, density value [MKS]
-    peleLM.m_mu = 1.8e-5                   # [OPT, DEF=-1] If incompressible, kinematic visc. value [MKS]
-    peleLM.gravity = 0.0 0.0 -9.81         # [OPT, DEF=Vec{0.0}] Gravity vector [MKS]
-    peleLM.gradP0 = 0.0 0.0 10.0           # [OPT, DEF=Vec{0.0}] Average background pressure gradient [Pa/m]
-    peleLM.do_periodic_channel = 0         # [OPT, DEF= 0] Add an automatic pressure gradient to maintain initial condition mass flow rate in periodic channel
-    peleLM.periodic_channel_dir = 2        # [OPT, DEF= -1] Required if do_periodic_channel != 0. Direction to apply pressure gradient.
-    peleLM.closed_chamber = 0              # [OPT] Override the automatic detection of closed chamber (based on Outflow(s))
-    peleLM.floor_species = 0               # [OPT, DEF=0] Crudely enforce mass fraction positivity
-    peleLM.deltaT_verbose = 0              # [OPT, DEF=0] Verbose of the deltaT iterative solve algorithm
-    peleLM.deltaT_iterMax = 5              # [OPT, DEF=10] Maximum number of deltaT iterations
-    peleLM.deltaT_tol = 1e-10              # [OPT, DEF=1.e-10] Tolerance of the deltaT solve
-    peleLM.evaluate_vars =...              # [OPT, DEF=""] In evaluate mode, list unitTest: diffTerm, divU, instRR, transportCC
+    peleLM.v = 1                                # [OPT, DEF=0] Verbose
+    peleLM.run_mode = normal                    # [OPT, DEF=normal] Switch between time-advance mode (normal) or UnitTest (evaluate)
+    peleLM.use_wbar = 1                         # [OPT, DEF=1] Enable Wbar correction in diffusion fluxes
+    peleLM.sdc_iterMax = 2                      # [OPT, DEF=1] Number of SDC iterations
+    peleLM.num_init_iter = 2                    # [OPT, DEF=3] Number of iterations to get initial pressure
+    peleLM.num_divu_iter = 1                    # [OPT, DEF=1] Number of divU iterations to get initial dt estimate
+    peleLM.do_init_proj = 1                     # [OPT, DEF=1] Control over initial projection
+    peleLM.advection_scheme = Godunov_BDS       # [OPT, DEF=Godunov_PLM] Advection scheme: Godunov_PLM, Godunov_PPM or Godunov_BDS
+    peleLM.chi_convergence_type = DivuFirstIter # [OPT, DEF=DivuEveryIter] When to compute divu for MAC proj divu constraint [DivuEveryIter, DivuFirstIter, NoDivu]
+    peleLM.incompressible = 0                   # [OPT, DEF=0] Enable to run fully incompressible, scalar advance is bypassed
+    peleLM.m_rho = 1.17                         # [OPT, DEF=-1] If incompressible, density value [MKS]
+    peleLM.m_mu = 1.8e-5                        # [OPT, DEF=-1] If incompressible, kinematic visc. value [MKS]
+    peleLM.gravity = 0.0 0.0 -9.81              # [OPT, DEF=Vec{0.0}] Gravity vector [MKS]
+    peleLM.gradP0 = 0.0 0.0 10.0                # [OPT, DEF=Vec{0.0}] Average background pressure gradient [Pa/m]
+    peleLM.do_periodic_channel = 0              # [OPT, DEF= 0] Add an automatic pressure gradient to maintain initial condition mass flow rate in periodic channel
+    peleLM.periodic_channel_dir = 2             # [OPT, DEF= -1] Required if do_periodic_channel != 0. Direction to apply pressure gradient.
+    peleLM.closed_chamber = 0                   # [OPT] Override the automatic detection of closed chamber (based on Outflow(s))
+    peleLM.floor_species = 0                    # [OPT, DEF=0] Crudely enforce mass fraction positivity
+    peleLM.deltaT_verbose = 0                   # [OPT, DEF=0] Verbose of the deltaT iterative solve algorithm
+    peleLM.deltaT_iterMax = 5                   # [OPT, DEF=10] Maximum number of deltaT iterations
+    peleLM.deltaT_tol = 1e-10                   # [OPT, DEF=1.e-10] Tolerance of the deltaT solve
+    peleLM.evaluate_vars =...                   # [OPT, DEF=""] In evaluate mode, list unitTest: diffTerm, divU, instRR, transportCC
 
 Transport coefficients and LES
 ------------------------------
@@ -452,41 +453,41 @@ to activate `temporal` diagnostics performing these reductions at given interval
     peleLM.do_species_balance = 1               # [OPT, DEF=0] Compute species mass balance, if temporals activated
     peleLM.do_patch_mfr=1                       # [OPT, DEF=0] Activate patch based species flux diagbostics
     peleLM.bpatch.patchnames= <patch_name1 patch_name2 ..> # List of patchnames
-    
-    bpatch.patch_name1.patchtype=full-boundary             # patchtype one of "full-boundary", "circle, "rectangle", "circle-annular" or "rectangle-annular"	 
-    bpatch.patch_name1.boundary_direction=2                # patch normal direction 
-    bpatch.patch_name1.boundary_lo_or_hi=0                 # patch in low or high side of boundary    
+
+    bpatch.patch_name1.patchtype=full-boundary             # patchtype one of "full-boundary", "circle, "rectangle", "circle-annular" or "rectangle-annular"
+    bpatch.patch_name1.boundary_direction=2                # patch normal direction
+    bpatch.patch_name1.boundary_lo_or_hi=0                 # patch in low or high side of boundary
     bpatch.patch_name1.species= O2 N2                      # list of species names
-    
-    bpatch.patch_name2.patchtype=circle                    # patchtype one of "full-boundary", "circle, "rectangle", "circle-annular" or "rectangle-annular"	 
-    bpatch.patch_name2.boundary_direction=2                # patch normal direction 
-    bpatch.patch_name2.boundary_lo_or_hi=0                 # patch in low or high side of boundary   
+
+    bpatch.patch_name2.patchtype=circle                    # patchtype one of "full-boundary", "circle, "rectangle", "circle-annular" or "rectangle-annular"
+    bpatch.patch_name2.boundary_direction=2                # patch normal direction
+    bpatch.patch_name2.boundary_lo_or_hi=0                 # patch in low or high side of boundary
     bpatch.patch_name2.patch_circle_radius=0.1             # radius of the patch
-    bpatch.patch_name2.patch_circle_center=0.0 0.0 0.0     # coordinates of patch center 
+    bpatch.patch_name2.patch_circle_center=0.0 0.0 0.0     # coordinates of patch center
     bpatch.patch_name2.species= O2 N2                      # list of species names
-    
-    bpatch.patch_name3.patchtype=rectangle      	 
-    bpatch.patch_name3.boundary_direction=2                # patch normal direction 
-    bpatch.patch_name3.boundary_lo_or_hi=0                 # patch in low or high side of boundary   
+
+    bpatch.patch_name3.patchtype=rectangle
+    bpatch.patch_name3.boundary_direction=2                # patch normal direction
+    bpatch.patch_name3.boundary_lo_or_hi=0                 # patch in low or high side of boundary
     bpatch.patch_name3.patch_rectangle_lo=0.0 0.0 0.0      # coordinates of low corner of rectangle
     bpatch.patch_name3.patch_rectangle_hi=1.0 1.0 1.0      # coordinates of high corner of rectangle
     bpatch.patch_name3.species= O2 N2                      # list of species names
-    
-    bpatch.patch_name4.patchtype=circle-annular  	 
-    bpatch.patch_name4.boundary_direction=2                # patch normal direction 
-    bpatch.patch_name4.boundary_lo_or_hi=0                 # patch in low or high side of boundary   
+
+    bpatch.patch_name4.patchtype=circle-annular
+    bpatch.patch_name4.boundary_direction=2                # patch normal direction
+    bpatch.patch_name4.boundary_lo_or_hi=0                 # patch in low or high side of boundary
     bpatch.patch_name4.patch_circ_ann_center= 0.0 0.0 0.0  # center of annular circle
     bpatch.patch_name4.patch_circ_ann_inner_radius=0.1     # coordinates of patch center
-    bpatch.patch_name4.patch_circ_ann_outer_radius=0.2     # coordinates of patch center 
+    bpatch.patch_name4.patch_circ_ann_outer_radius=0.2     # coordinates of patch center
     bpatch.patch_name4.species= O2 N2                      # list of species names
-    
-    bpatch.patch_name5.patchtype=rectangle-annular         
-    bpatch.patch_name5.boundary_direction=2                     # patch normal direction 
-    bpatch.patch_name5.boundary_lo_or_hi=0                      # patch in low or high side of boundary   
-    bpatch.patch_name5.patch_rect_ann_outer_lo = -1.0 -1.0 -1.0 # coordinates of low corner of outer rectangle 
-    bpatch.patch_name5.patch_rect_ann_outer_hi =  1.0  1.0  1.0 # coordinates of high corner of outer rectangle  
-    bpatch.patch_name5.patch_rect_ann_inner_lo = -0.5 -0.5 -0.5 # coordinates of low corner of inner rectangle 
-    bpatch.patch_name5.patch_rect_ann_inner_hi =  0.5  0.5  0.5 # coordinates of high corner of inner rectangle 
+
+    bpatch.patch_name5.patchtype=rectangle-annular
+    bpatch.patch_name5.boundary_direction=2                     # patch normal direction
+    bpatch.patch_name5.boundary_lo_or_hi=0                      # patch in low or high side of boundary
+    bpatch.patch_name5.patch_rect_ann_outer_lo = -1.0 -1.0 -1.0 # coordinates of low corner of outer rectangle
+    bpatch.patch_name5.patch_rect_ann_outer_hi =  1.0  1.0  1.0 # coordinates of high corner of outer rectangle
+    bpatch.patch_name5.patch_rect_ann_inner_lo = -0.5 -0.5 -0.5 # coordinates of low corner of inner rectangle
+    bpatch.patch_name5.patch_rect_ann_inner_hi =  0.5  0.5  0.5 # coordinates of high corner of inner rectangle
     bpatch.patch_name5.species= O2 N2                           # list of species names
 
 The `do_temporal` flag will trigger the creation of a `temporals` folder in your run directory and the following entries
@@ -498,8 +499,8 @@ the balance (dMdt - sum of fluxes), and species balance (stored in `temporals/te
 advective \& diffusive fluxes across the domain boundaries, consumption rate integral and the error (dMdt - sum of fluxes - reaction).
 Users can also monitor species advective fluxes through specific regions of the domain boundaries (called as boundary patches).
 Patches can be defined on the low or high sides of non-embedded boundaries through the use of pre-defined shapes such as `circle`,
-`rectangle`,`circle-annular`, `rectangle-annular` and `full-boundary`. The zero AMR level, advective fluxes of each of the user-specified species will be 
-reported in the ASCII `temppatchmfr` file in the temporals folder. 
+`rectangle`,`circle-annular`, `rectangle-annular` and `full-boundary`. The zero AMR level, advective fluxes of each of the user-specified species will be
+reported in the ASCII `temppatchmfr` file in the temporals folder.
 
 Combustion diagnostics often involve the use of a mixture fraction and/or a progress variable, both of which can be defined
 at run time and added to the derived variables included in the plotfile. If `mixture_fraction` or `progress_variable` is

--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -242,7 +242,8 @@ PeleLMeX algorithm
     peleLM.num_divu_iter = 1                    # [OPT, DEF=1] Number of divU iterations to get initial dt estimate
     peleLM.do_init_proj = 1                     # [OPT, DEF=1] Control over initial projection
     peleLM.advection_scheme = Godunov_BDS       # [OPT, DEF=Godunov_PLM] Advection scheme: Godunov_PLM, Godunov_PPM or Godunov_BDS
-    peleLM.chi_convergence_type = DivuFirstIter # [OPT, DEF=DivuEveryIter] When to compute divu for MAC proj divu constraint [DivuEveryIter, DivuFirstIter, NoDivu]
+    peleLM.chi_correction_type = DivuFirstIter  # [OPT, DEF=DivuEveryIter] When to compute divu for MAC proj divu constraint [DivuEveryIter, DivuFirstIter, NoDivu]
+    peleLM.print_chi_convergence = 1            # [OPT, DEF=(peleLM.v > 1)] Boolean flag on whether to print size of chi correction on each SDC iter
     peleLM.incompressible = 0                   # [OPT, DEF=0] Enable to run fully incompressible, scalar advance is bypassed
     peleLM.m_rho = 1.17                         # [OPT, DEF=-1] If incompressible, density value [MKS]
     peleLM.m_mu = 1.8e-5                        # [OPT, DEF=-1] If incompressible, kinematic visc. value [MKS]

--- a/Docs/sphinx/manual/Model.rst
+++ b/Docs/sphinx/manual/Model.rst
@@ -237,6 +237,7 @@ the time-explicit advective fluxes for :math:`U`, :math:`\rho h`, and :math:`\rh
 
         S^{MAC} = \frac{1}{2}(\widehat S^n + \widehat S^{n+1,(k)}) + \sum_{i=0}^k \frac{1}{p_{therm}^{n+1,(i)}}\frac{p_{therm}^{n+1,(i)}-p_0}{\Delta t}
 
+     In this update, it is optional whether to update the :math:`\widehat S^{n+1}` term on every SDC iteration, or to simply compute it for :math:`k = 0` and then hold it constant, with the :math:`\chi` correction iterations accounting for changes during the SDC iterations. The latter strategy has been observed to improve convergence in some cases.
 
   #. Perform **Step 1** to obtain the time-centered, staggered :math:`U^{ADV}`
 

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1891,6 +1891,8 @@ public:
   // SDC
   int m_nSDCmax = 1;
   int m_sdcIter = 0;
+  bool m_print_chi_convergence = false;
+  int m_chi_correction_type{ChiCorrectionType::DivuEveryIter};
 
   // DeltaT iterations
   int m_deltaT_verbose = 0;

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -424,6 +424,9 @@ PeleLM::readParameters()
   // advance
   // -----------------------------------------
   pp.query("sdc_iterMax", m_nSDCmax);
+  m_print_chi_convergence = m_verbose > 1;
+  pp.query("print_chi_convergence", m_print_chi_convergence);
+  parseUserKey(pp, "chi_correction_type", chicorr, m_chi_correction_type);
   pp.query("floor_species", m_floor_species);
   pp.query("dPdt_factor", m_dpdtFactor);
   pp.query("memory_checks", m_checkMem);

--- a/Source/PeleLMeX_UMac.cpp
+++ b/Source/PeleLMeX_UMac.cpp
@@ -114,17 +114,46 @@ PeleLM::addChiIncrement(
       auto const& chiInc_ar = chiIncr[lev].const_array(mfi);
       auto const& chi_ar = advData->chi[lev].array(mfi);
       auto const& mac_divu_ar = advData->mac_divu[lev].array(mfi);
-      amrex::ParallelFor(
-        gbx, [chi_ar, chiInc_ar, mac_divu_ar,
-              a_sdcIter] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-          if (a_sdcIter == 1) {
-            chi_ar(i, j, k) = chiInc_ar(i, j, k);
-          } else {
-            chi_ar(i, j, k) += chiInc_ar(i, j, k);
-          }
-          mac_divu_ar(i, j, k) += chi_ar(i, j, k);
-        });
+      if (m_chi_correction_type == ChiCorrectionType::DivuFirstIter) {
+          amrex::ParallelFor(gbx, [chi_ar, chiInc_ar, mac_divu_ar, a_sdcIter]
+                             AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+          {
+              if ( a_sdcIter == 1 ) {
+                  chi_ar(i,j,k) = chiInc_ar(i,j,k) + mac_divu_ar(i,j,k);
+              } else {
+                  chi_ar(i,j,k) += chiInc_ar(i,j,k);
+              }
+              mac_divu_ar(i,j,k) = chi_ar(i,j,k);
+          });
+      } else if (m_chi_correction_type == ChiCorrectionType::NoDivu) {
+          amrex::ParallelFor(gbx, [chi_ar, chiInc_ar, mac_divu_ar, a_sdcIter]
+                             AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+          {
+              if ( a_sdcIter == 1 ) {
+                  chi_ar(i,j,k) = chiInc_ar(i,j,k);
+              } else {
+                  chi_ar(i,j,k) += chiInc_ar(i,j,k);
+              }
+              mac_divu_ar(i,j,k) = chi_ar(i,j,k);
+          });
+      } else { // Default: use updated divu every iteration
+          amrex::ParallelFor(gbx, [chi_ar, chiInc_ar, mac_divu_ar, a_sdcIter]
+                             AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+          {
+              if ( a_sdcIter == 1 ) {
+                  chi_ar(i,j,k) = chiInc_ar(i,j,k);
+              } else {
+                  chi_ar(i,j,k) += chiInc_ar(i,j,k);
+              }
+              mac_divu_ar(i,j,k) += chi_ar(i,j,k);
+          });
+      }
     }
+  }
+  if (m_print_chi_convergence) {
+      amrex::Real max_corr = MLNorm0(GetVecOfConstPtrs(chiIncr)) * m_dt/m_dpdtFactor;
+      amrex::Print() << "      Before SDC " << a_sdcIter
+                     << ": max relative P mismatch is " << max_corr << std::endl;
   }
 }
 

--- a/Source/PeleLMeX_UMac.cpp
+++ b/Source/PeleLMeX_UMac.cpp
@@ -115,45 +115,46 @@ PeleLM::addChiIncrement(
       auto const& chi_ar = advData->chi[lev].array(mfi);
       auto const& mac_divu_ar = advData->mac_divu[lev].array(mfi);
       if (m_chi_correction_type == ChiCorrectionType::DivuFirstIter) {
-          amrex::ParallelFor(gbx, [chi_ar, chiInc_ar, mac_divu_ar, a_sdcIter]
-                             AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-          {
-              if ( a_sdcIter == 1 ) {
-                  chi_ar(i,j,k) = chiInc_ar(i,j,k) + mac_divu_ar(i,j,k);
-              } else {
-                  chi_ar(i,j,k) += chiInc_ar(i,j,k);
-              }
-              mac_divu_ar(i,j,k) = chi_ar(i,j,k);
+        amrex::ParallelFor(
+          gbx, [chi_ar, chiInc_ar, mac_divu_ar,
+                a_sdcIter] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            if (a_sdcIter == 1) {
+              chi_ar(i, j, k) = chiInc_ar(i, j, k) + mac_divu_ar(i, j, k);
+            } else {
+              chi_ar(i, j, k) += chiInc_ar(i, j, k);
+            }
+            mac_divu_ar(i, j, k) = chi_ar(i, j, k);
           });
       } else if (m_chi_correction_type == ChiCorrectionType::NoDivu) {
-          amrex::ParallelFor(gbx, [chi_ar, chiInc_ar, mac_divu_ar, a_sdcIter]
-                             AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-          {
-              if ( a_sdcIter == 1 ) {
-                  chi_ar(i,j,k) = chiInc_ar(i,j,k);
-              } else {
-                  chi_ar(i,j,k) += chiInc_ar(i,j,k);
-              }
-              mac_divu_ar(i,j,k) = chi_ar(i,j,k);
+        amrex::ParallelFor(
+          gbx, [chi_ar, chiInc_ar, mac_divu_ar,
+                a_sdcIter] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            if (a_sdcIter == 1) {
+              chi_ar(i, j, k) = chiInc_ar(i, j, k);
+            } else {
+              chi_ar(i, j, k) += chiInc_ar(i, j, k);
+            }
+            mac_divu_ar(i, j, k) = chi_ar(i, j, k);
           });
       } else { // Default: use updated divu every iteration
-          amrex::ParallelFor(gbx, [chi_ar, chiInc_ar, mac_divu_ar, a_sdcIter]
-                             AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-          {
-              if ( a_sdcIter == 1 ) {
-                  chi_ar(i,j,k) = chiInc_ar(i,j,k);
-              } else {
-                  chi_ar(i,j,k) += chiInc_ar(i,j,k);
-              }
-              mac_divu_ar(i,j,k) += chi_ar(i,j,k);
+        amrex::ParallelFor(
+          gbx, [chi_ar, chiInc_ar, mac_divu_ar,
+                a_sdcIter] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            if (a_sdcIter == 1) {
+              chi_ar(i, j, k) = chiInc_ar(i, j, k);
+            } else {
+              chi_ar(i, j, k) += chiInc_ar(i, j, k);
+            }
+            mac_divu_ar(i, j, k) += chi_ar(i, j, k);
           });
       }
     }
   }
   if (m_print_chi_convergence) {
-      amrex::Real max_corr = MLNorm0(GetVecOfConstPtrs(chiIncr)) * m_dt/m_dpdtFactor;
-      amrex::Print() << "      Before SDC " << a_sdcIter
-                     << ": max relative P mismatch is " << max_corr << std::endl;
+    amrex::Real max_corr =
+      MLNorm0(GetVecOfConstPtrs(chiIncr)) * m_dt / m_dpdtFactor;
+    amrex::Print() << "      Before SDC " << a_sdcIter
+                   << ": max relative P mismatch is " << max_corr << std::endl;
   }
 }
 

--- a/Source/PeleLMeX_UserKeys.H
+++ b/Source/PeleLMeX_UserKeys.H
@@ -160,4 +160,23 @@ struct LoadBalanceMethod
     "load_balancing_method", "chem_load_balancing_method"};
 };
 const LoadBalanceMethod lbmethod;
+
+/**
+  * \brief struct holding PeleLMeX DivU/chi constraint options
+           default is DivuEveryIter
+  */
+struct ChiCorrectionType
+{
+    ChiCorrectionType() = default;
+    enum {DivuEveryIter = 0, DivuFirstIter, NoDivu};
+    const std::map<const std::string, int> str2int = {
+        {"divueveryiter", DivuEveryIter},
+        {"divufirstiter", DivuFirstIter},
+        {"nodivu", NoDivu},
+        {"default", DivuEveryIter}
+    };
+    const amrex::Array<std::string, 1> searchKey{"chi_correction_type"};
+};
+const ChiCorrectionType chicorr;
+
 #endif

--- a/Source/PeleLMeX_UserKeys.H
+++ b/Source/PeleLMeX_UserKeys.H
@@ -167,15 +167,14 @@ const LoadBalanceMethod lbmethod;
   */
 struct ChiCorrectionType
 {
-    ChiCorrectionType() = default;
-    enum {DivuEveryIter = 0, DivuFirstIter, NoDivu};
-    const std::map<const std::string, int> str2int = {
-        {"divueveryiter", DivuEveryIter},
-        {"divufirstiter", DivuFirstIter},
-        {"nodivu", NoDivu},
-        {"default", DivuEveryIter}
-    };
-    const amrex::Array<std::string, 1> searchKey{"chi_correction_type"};
+  ChiCorrectionType() = default;
+  enum { DivuEveryIter = 0, DivuFirstIter, NoDivu };
+  const std::map<const std::string, int> str2int = {
+    {"divueveryiter", DivuEveryIter},
+    {"divufirstiter", DivuFirstIter},
+    {"nodivu", NoDivu},
+    {"default", DivuEveryIter}};
+  const amrex::Array<std::string, 1> searchKey{"chi_correction_type"};
 };
 const ChiCorrectionType chicorr;
 


### PR DESCRIPTION
This was needed for the manifold stuff, so moving it in now to capture some progress toward fully merging that capability. Probably won't merge the rest for a while though.

This PR does two things:
- Optionally print the zero norm of the chi correction on each SDC iteration, which indicates the mismatch between the actual pressure and the prescribed pressure based on the Low Mach assumption. This can be used to assess how the SDC iterations are converging. Note that the values printed are the mismatch before the indicated iteration, so the value for the 0th iteration on one time step corresponds to the value at the end of the previous timestep. That output looks something like this:
```
   SDC iter [1] 
      Before SDC 1: max relative P mismatch is 0.0002924937001
   - oneSDC()::MACProjection()   --> Time: 0.003672
   - oneSDC()::ScalarAdvection() --> Time: 0.009108
   - oneSDC()::ScalarDiffusion() --> Time: 0.059437
   - oneSDC()::ScalarReaction()  --> Time: 0.76213
   SDC iter [2] 
   - oneSDC()::Update t^{n+1,k}  --> Time: 0.029643
      Before SDC 2: max relative P mismatch is 0.01296565691
   - oneSDC()::MACProjection()   --> Time: 0.003565
   - oneSDC()::ScalarAdvection() --> Time: 0.009067
   - oneSDC()::ScalarDiffusion() --> Time: 0.057344
   - oneSDC()::ScalarReaction()  --> Time: 0.757911
```
- Offer new strategies for how the divergence constraint on each SDC iteration is computed: 
   - `DivuEveryIter` (current, remains default), 
   - `DivuFirstIter` (the estimate of Divu computed on the 0th SDC iteration is kept constant, and only the chi correction is used to drive the solution toward convergence)
   - `NoDivu` (the Divu estimates are ignored in the MAC projection and only the chi correction is used to iteratively ensure the actual pressure (RhoRT) matches the desired value)

For the PMF case, it can be observed that the second option provides better convergence of the pressure than the first. My working hypothesis is that updating the estimated divergence constraint essentially adds noise to the iterative update of the chi correction. The converged solution with infinite SDC iterations would be the same between all methods, but the rate of convergence is not. The existing approach is left as the default because the alternative `DivuFirstIter` approach hasn't been tested for a wide range of cases yet. The `NoDivu` option should never be used and is only included for comparison. In the latter two options, some compute could be saved by not recomputing the divergence estimate at each n+1,k, but for now it is computed but then ignored.

![SDC-convergence](https://github.com/user-attachments/assets/8aa801d1-c710-4121-844d-5941bcbdf41b)
