### PR TITLE
Feature overwrite plt file

### DIFF
--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -109,10 +109,12 @@ IO parameters
 
     #--------------------------IO CONTROL--------------------------
     amr.plot_int         = 20              # [OPT, DEF=-1] Frequency (as step #) for writing plot file
+    amr.plot_overwrite   = false           # [OPT, DEF=false] Overwrite plot files with same name if present
     amr.plot_per         = 0.002           # [OPT, DEF=-1] Period (time in s) for writing plot file
     amr.plot_per_exact   = 1               # [OPT, DEF=0] Flag to enforce exactly plt_per by shortening dt
     amr.plot_file        = "plt_"          # [OPT, DEF="plt_"] Plot file prefix
     amr.check_int        = 100             # [OPT, DEF=-1] Frequency (as step #) for writing checkpoint file
+    amr.check_overwrite  = false           # [OPT, DEF=false] Overwrite checkpoint files with same name if present
     amr.check_per        = 0.05            # [OPT, DEF=-1] Period (time in s) for writing checkpoint file
     amr.check_file       = "chk"           # [OPT, DEF="chk"] Checkpoint file prefix
     amr.file_stepDigits  = 6               # [OPT, DEF=5] Number of digits when adding nsteps to plt and chk names

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1774,6 +1774,7 @@ public:
   int m_plotHeatRelease = 0;
   int m_plotStateSpec = 0;
   int m_plot_int = 0;
+  bool m_plot_overwrite = false;
   int m_plot_zeroEBcovered = 1;
   amrex::Real m_plot_per_approx = -1.;
   amrex::Real m_plot_per_exact = -1.;

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1779,6 +1779,7 @@ public:
   amrex::Real m_plot_per_approx = -1.;
   amrex::Real m_plot_per_exact = -1.;
   int m_check_int = 0;
+  bool m_check_overwrite = false;
   amrex::Real m_check_per = -1.;
   int m_message_int = 10;
   int m_evaluatePlotVarCount = 0;

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -535,6 +535,16 @@ PeleLM::WriteCheckPointFile()
     amrex::Print() << "\n Writing checkpoint file: " << checkpointname << "\n";
   }
 
+  //----------------------------------------------------------------
+  // Delete checkfiles if present and requested (and have same name)
+  if (m_check_overwrite) {
+    if (amrex::ParallelContext::IOProcessorSub()) {
+      if (amrex::FileExists(checkpointname)) {
+        amrex::FileSystem::RemoveAll(checkpointname);
+      }
+    }
+  }
+
   VisMF::SetNOutFiles(m_nfiles);
 
   amrex::PreBuildDirectorHierarchy(

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -71,6 +71,16 @@ PeleLM::WritePlotFile()
     amrex::Print() << "\n Writing plotfile: " << plotfilename << "\n";
   }
 
+  //----------------------------------------------------------------
+  // Delete plotfiles if present and requested (and have same name)
+  if (m_plot_overwrite) {
+    if (amrex::ParallelContext::IOProcessorSub()) {
+      if (amrex::FileExists(plotfilename)) {
+        amrex::FileSystem::RemoveAll(plotfilename);
+      }
+    }
+  }
+
   VisMF::SetNOutFiles(m_nfiles);
 
   //----------------------------------------------------------------

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -674,6 +674,7 @@ PeleLM::readIOParameters()
 
   pp.query("check_file", m_check_file);
   pp.query("check_int", m_check_int);
+  pp.query("check_overwrite", m_check_overwrite);
   pp.query("check_per", m_check_per);
   pp.query("restart", m_restart_chkfile);
   pp.query("initDataPlt", m_restart_pltfile);

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -680,6 +680,7 @@ PeleLM::readIOParameters()
   pp.query("initDataPltSource", pltfileSource);
   pp.query("plot_file", m_plot_file);
   pp.query("plot_int", m_plot_int);
+  pp.query("plot_overwrite", m_plot_overwrite);
   if (pp.contains("plot_per")) {
     int do_exact = 0;
     pp.query("plot_per_exact", do_exact);


### PR DESCRIPTION
This PR adds the option to overwrite plot and checkpoint files instead of duplicating them with the `old.******` extension. Default option is FALSE. The doc has also been updated. 
