### PR TITLE
Print temporals in CSV format

### DIFF
--- a/Source/Efield/PeleLMeX_EFUtils.cpp
+++ b/Source/Efield/PeleLMeX_EFUtils.cpp
@@ -362,9 +362,9 @@ PeleLM::ionsBalance()
     }
   }
 
-  tmpIonsFile << m_nstep << " " << m_cur_time; // Time info
+  tmpIonsFile << m_nstep << "," << m_cur_time; // Time info
   for (int i = 0; i < 2 * AMREX_SPACEDIM; i++) {
-    tmpIonsFile << " " << ionsCurrent[i]; // ions current as xlo, xhi, ylo, ...
+    tmpIonsFile << "," << ionsCurrent[i]; // ions current as xlo, xhi, ylo, ...
   }
   tmpIonsFile << "\n";
   tmpIonsFile.flush();

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1307,6 +1307,7 @@ public:
   bool isReactVariable(std::string_view a_name);
   int stateVariableIndex(std::string_view a_name);
   int reactVariableIndex(std::string_view a_name);
+  std::string stateVariableName(int a_index);
 
   // Typical values
   void setTypicalValues(const PeleLM::TimeStamp& a_time, int is_init = 0);

--- a/Source/PeleLMeX_Utils.cpp
+++ b/Source/PeleLMeX_Utils.cpp
@@ -1205,6 +1205,24 @@ PeleLM::stateVariableIndex(std::string_view a_name)
   return idx;
 }
 
+std::string
+PeleLM::stateVariableName(int a_index)
+{
+  if (a_index < 0 || a_index >= NVAR) {
+    amrex::Error(
+      "PeleLM::stateVariableName(): invalod state index: " +
+      std::to_string(a_index));
+  }
+
+  std::string var_name = "";
+  for (const auto& stateComponent : stateComponents) {
+    if (std::get<0>(stateComponent) == a_index) {
+      var_name = std::get<1>(stateComponent);
+    }
+  }
+  return var_name;
+}
+
 int
 PeleLM::reactVariableIndex(std::string_view a_name)
 {

--- a/Source/PeleLMeX_Utils.cpp
+++ b/Source/PeleLMeX_Utils.cpp
@@ -1214,7 +1214,7 @@ PeleLM::stateVariableName(int a_index)
       std::to_string(a_index));
   }
 
-  std::string var_name = "";
+  std::string var_name;
   for (const auto& stateComponent : stateComponents) {
     if (std::get<0>(stateComponent) == a_index) {
       var_name = std::get<1>(stateComponent);

--- a/Source/PeleLMeX_Utils.cpp
+++ b/Source/PeleLMeX_Utils.cpp
@@ -1210,7 +1210,7 @@ PeleLM::stateVariableName(int a_index)
 {
   if (a_index < 0 || a_index >= NVAR) {
     amrex::Error(
-      "PeleLM::stateVariableName(): invalod state index: " +
+      "PeleLM::stateVariableName(): invalid state index: " +
       std::to_string(a_index));
   }
 


### PR DESCRIPTION
Add headers with variable names to temporals and convert to comma separated rather than space separated format for easier processing.

Add a function to easily get the state variable name from its index.