### PR TITLE
Eosparm support in PeleLMeX

### DIFF
--- a/Exec/RegTests/FlameSheet/pelelmex_prob.H
+++ b/Exec/RegTests/FlameSheet/pelelmex_prob.H
@@ -38,7 +38,7 @@ pelelmex_initdata(
 
   constexpr amrex::Real Pi = 3.14159265358979323846264338327950288;
 
-  auto eos = pele::physics::PhysicsType::eos();
+  auto eos = pele::physics::PhysicsType::eos(prob_parm.eosparm);
   amrex::GpuArray<amrex::Real, NUM_SPECIES + 4> pmf_vals = {0.0};
   amrex::Real molefrac[NUM_SPECIES] = {0.0};
   amrex::Real massfrac[NUM_SPECIES] = {0.0};
@@ -140,7 +140,7 @@ bcnormal(
   amrex::Real molefrac[NUM_SPECIES] = {0.0};
   amrex::Real massfrac[NUM_SPECIES] = {0.0};
 
-  auto eos = pele::physics::PhysicsType::eos();
+  auto eos = pele::physics::PhysicsType::eos(prob_parm.eosparm);
   if (sgn == 1) {
     pele::physics::PMF::pmf(pmf_data, prob_lo[idir], prob_lo[idir], pmf_vals);
 

--- a/Exec/RegTests/FlameSheet/pelelmex_prob.cpp
+++ b/Exec/RegTests/FlameSheet/pelelmex_prob.cpp
@@ -12,5 +12,6 @@ PeleLM::readProbParm()
   pp.query("pertmag", PeleLM::prob_parm->pertmag);
   pp.query("pertlength", PeleLM::prob_parm->pertlength);
 
+  PeleLM::prob_parm->eosparm = PeleLM::eos_parms.device_parm();
   PeleLM::pmf_data.initialize();
 }

--- a/Exec/RegTests/FlameSheet/pelelmex_prob_parm.H
+++ b/Exec/RegTests/FlameSheet/pelelmex_prob_parm.H
@@ -3,6 +3,7 @@
 
 #include <AMReX_REAL.H>
 #include <AMReX_GpuMemory.H>
+#include <PelePhysics.H>
 
 using namespace amrex::literals;
 
@@ -13,5 +14,7 @@ struct ProbParm
   amrex::Real pertmag = 0.0004_rt;
   amrex::Real pertlength = 0.008_rt;
   int meanFlowDir = 1;
+  pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type> const*
+    eosparm;
 };
 #endif

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -606,6 +606,7 @@ public:
    * velocity, ensuring they sum up to zero. \param a_fluxes diffusion fluxes to
    * be updated \param a_spec species rhoYs state data on all levels
    */
+  template <typename EOSType>
   void adjustSpeciesFluxes(
     const amrex::Vector<amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM>>&
       a_spfluxes,
@@ -1752,6 +1753,11 @@ public:
     pele::physics::PhysicsType::eos_type,
     pele::physics::PhysicsType::transport_type>>
     trans_parms;
+
+  // EOS pointer
+  static pele::physics::PeleParams<
+    pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type>>
+    eos_parms;
 
   // Reactor pointer
   std::string m_chem_integrator;

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -606,7 +606,6 @@ public:
    * velocity, ensuring they sum up to zero. \param a_fluxes diffusion fluxes to
    * be updated \param a_spec species rhoYs state data on all levels
    */
-  template <typename EOSType>
   void adjustSpeciesFluxes(
     const amrex::Vector<amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM>>&
       a_spfluxes,

--- a/Source/PeleLMeX.cpp
+++ b/Source/PeleLMeX.cpp
@@ -12,12 +12,17 @@ pele::physics::PeleParams<pele::physics::transport::TransParm<
   pele::physics::PhysicsType::transport_type>>
   PeleLM::trans_parms;
 
+pele::physics::PeleParams<
+  pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type>>
+  PeleLM::eos_parms;
+
 PeleLM::PeleLM() = default;
 
 PeleLM::~PeleLM()
 {
   if (m_incompressible == 0) {
     trans_parms.deallocate();
+    eos_parms.deallocate();
     m_reactor->close();
   }
 

--- a/Source/PeleLMeX_DeriveFunc.cpp
+++ b/Source/PeleLMeX_DeriveFunc.cpp
@@ -75,8 +75,9 @@ pelelmex_derheatrelease(
   auto const react = reactfab.const_array(0);
   auto const& Hi = EnthFab.array();
   auto HRR = derfab.array(dcomp);
+  auto const* leosparm = a_pelelm->eos_parms.device_parm();
   amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-    getHGivenT(i, j, k, temp, Hi);
+    getHGivenT(i, j, k, temp, Hi, leosparm);
     HRR(i, j, k) = 0.0;
     for (int n = 0; n < NUM_SPECIES; n++) {
       HRR(i, j, k) -= Hi(i, j, k, n) * react(i, j, k, n);
@@ -1371,17 +1372,18 @@ pelelmex_derdiffc(
   auto lambda = dummies.array(0);
   auto mu = dummies.array(1);
   auto const* ltransparm = a_pelelm->trans_parms.device_parm();
+  auto const* leosparm = a_pelelm->eos_parms.device_parm();
   auto rhotheta = do_soret ? derfab.array(dcomp + NUM_SPECIES)
                            : dummies.array(2); // dummy for no soret
   amrex::Real LeInv = a_pelelm->m_Lewis_inv;
   amrex::Real PrInv = a_pelelm->m_Prandtl_inv;
   amrex::ParallelFor(
-    bx,
-    [do_fixed_Le, do_fixed_Pr, do_soret, LeInv, PrInv, rhoY, T, rhoD, rhotheta,
-     lambda, mu, ltransparm] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+    bx, [do_fixed_Le, do_fixed_Pr, do_soret, LeInv, PrInv, rhoY, T, rhoD,
+         rhotheta, lambda, mu, ltransparm,
+         leosparm] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
       getTransportCoeff(
         i, j, k, do_fixed_Le, do_fixed_Pr, do_soret, LeInv, PrInv, rhoY, T,
-        rhoD, rhotheta, lambda, mu, ltransparm);
+        rhoD, rhotheta, lambda, mu, ltransparm, leosparm);
     });
 }
 
@@ -1418,15 +1420,16 @@ pelelmex_derlambda(
   auto mu = dummies.array(0);
   auto rhotheta = dummies.array(NUM_SPECIES + 1);
   auto const* ltransparm = a_pelelm->trans_parms.device_parm();
+  auto const* leosparm = a_pelelm->eos_parms.device_parm();
   amrex::Real LeInv = a_pelelm->m_Lewis_inv;
   amrex::Real PrInv = a_pelelm->m_Prandtl_inv;
   amrex::ParallelFor(
-    bx,
-    [do_fixed_Le, do_fixed_Pr, do_soret, LeInv, PrInv, rhoY, T, rhoD, rhotheta,
-     lambda, mu, ltransparm] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+    bx, [do_fixed_Le, do_fixed_Pr, do_soret, LeInv, PrInv, rhoY, T, rhoD,
+         rhotheta, lambda, mu, ltransparm,
+         leosparm] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
       getTransportCoeff(
         i, j, k, do_fixed_Le, do_fixed_Pr, do_soret, LeInv, PrInv, rhoY, T,
-        rhoD, rhotheta, lambda, mu, ltransparm);
+        rhoD, rhotheta, lambda, mu, ltransparm, leosparm);
     });
 }
 

--- a/Source/PeleLMeX_DeriveFunc.cpp
+++ b/Source/PeleLMeX_DeriveFunc.cpp
@@ -147,6 +147,7 @@ pelelmex_dermolefrac(
   AMREX_ASSERT(!a_pelelm->m_incompressible);
   auto const in_dat = statefab.array();
   auto der = derfab.array(dcomp);
+  auto const* leosparm = a_pelelm->eos_parms.device_parm();
   amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
     amrex::Real Yt[NUM_SPECIES] = {0.0};
     amrex::Real Xt[NUM_SPECIES] = {0.0};
@@ -154,7 +155,7 @@ pelelmex_dermolefrac(
     for (int n = 0; n < NUM_SPECIES; n++) {
       Yt[n] = in_dat(i, j, k, FIRSTSPEC + n) * rhoinv;
     }
-    auto eos = pele::physics::PhysicsType::eos();
+    auto eos = pele::physics::PhysicsType::eos(leosparm);
     eos.Y2X(Yt, Xt);
     for (int n = 0; n < NUM_SPECIES; n++) {
       der(i, j, k, n) = Xt[n];

--- a/Source/PeleLMeX_Diffusion.cpp
+++ b/Source/PeleLMeX_Diffusion.cpp
@@ -204,126 +204,6 @@ PeleLM::computeDifferentialDiffusionTerms(
 #endif
 }
 
-template <typename EOSType>
-void
-PeleLM::adjustSpeciesFluxes(
-  const Vector<Array<MultiFab*, AMREX_SPACEDIM>>& a_spfluxes,
-  Vector<MultiFab const*> const& a_spec)
-{
-
-  BL_PROFILE("PeleLMeX::adjustSpeciesFluxes()");
-
-  // Get the species BCRec
-  auto bcRecSpec = fetchBCRecArray(FIRSTSPEC, NUM_SPECIES);
-
-  for (int lev = 0; lev <= finest_level; ++lev) {
-
-    const Box& domain = geom[lev].Domain();
-
-#ifdef AMREX_USE_EB
-    //------------------------------------------------------------------------
-    // Get the edge species state needed for EB
-    int nGrow = 1;
-    const auto& ba = a_spec[lev]->boxArray();
-    const auto& dm = a_spec[lev]->DistributionMap();
-    const auto& ebfact = EBFactory(lev);
-    Array<MultiFab, AMREX_SPACEDIM> edgstate{AMREX_D_DECL(
-      MultiFab(
-        amrex::convert(ba, IntVect::TheDimensionVector(0)), dm, NUM_SPECIES,
-        nGrow, MFInfo(), ebfact),
-      MultiFab(
-        amrex::convert(ba, IntVect::TheDimensionVector(1)), dm, NUM_SPECIES,
-        nGrow, MFInfo(), ebfact),
-      MultiFab(
-        amrex::convert(ba, IntVect::TheDimensionVector(2)), dm, NUM_SPECIES,
-        nGrow, MFInfo(), ebfact))};
-    EB_interp_CellCentroid_to_FaceCentroid(
-      *a_spec[lev], GetArrOfPtrs(edgstate), 0, 0, NUM_SPECIES, geom[lev],
-      bcRecSpec);
-    auto const& areafrac = ebfact.getAreaFrac();
-#endif
-
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
-    for (MFIter mfi(*a_spec[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-      for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        const Box& ebx = mfi.nodaltilebox(idim);
-        const Box& edomain = amrex::surroundingNodes(domain, idim);
-        auto const& rhoY = a_spec[lev]->const_array(mfi);
-        auto const& flux_dir = a_spfluxes[lev][idim]->array(mfi);
-
-        const auto bc_lo = bcRecSpec[0].lo(idim);
-        const auto bc_hi = bcRecSpec[0].hi(idim);
-
-#ifdef AMREX_USE_EB
-        auto const& flagfab = ebfact.getMultiEBCellFlagFab()[mfi];
-
-        if (flagfab.getType(amrex::grow(ebx, 0)) != FabType::covered) {
-          // No cut cells in tile + nghost-cell width halo -> use non-eb routine
-          if (flagfab.getType(amrex::grow(ebx, nGrow)) == FabType::regular) {
-            amrex::ParallelFor(
-              ebx, [idim, rhoY, flux_dir, edomain, bc_lo,
-                    bc_hi] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                int idx[3] = {i, j, k};
-                bool on_lo =
-                  ((bc_lo == amrex::BCType::ext_dir) &&
-                   (idx[idim] <= edomain.smallEnd(idim)));
-                bool on_hi =
-                  ((bc_hi == amrex::BCType::ext_dir) &&
-                   (idx[idim] >= edomain.bigEnd(idim)));
-                repair_flux(i, j, k, idim, on_lo, on_hi, rhoY, flux_dir);
-              });
-          } else {
-            auto const& rhoYed_ar = edgstate[idim].const_array(mfi);
-            auto const& areafrac_ar = areafrac[idim]->const_array(mfi);
-            amrex::ParallelFor(
-              ebx,
-              [idim, rhoY, flux_dir, rhoYed_ar, areafrac_ar, edomain, bc_lo,
-               bc_hi] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                int idx[3] = {i, j, k};
-                bool on_lo =
-                  ((bc_lo == amrex::BCType::ext_dir) &&
-                   (idx[idim] <= edomain.smallEnd(idim)));
-                bool on_hi =
-                  ((bc_hi == amrex::BCType::ext_dir) &&
-                   (idx[idim] >= edomain.bigEnd(idim)));
-                repair_flux_eb(
-                  i, j, k, idim, on_lo, on_hi, rhoY, rhoYed_ar, areafrac_ar,
-                  flux_dir);
-              });
-          }
-        }
-#else
-        amrex::ParallelFor(
-          ebx, [idim, rhoY, flux_dir, edomain, bc_lo,
-                bc_hi] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-            int idx[3] = {i, j, k};
-            bool on_lo =
-              ((bc_lo == amrex::BCType::ext_dir) &&
-               (idx[idim] <= edomain.smallEnd(idim)));
-            bool on_hi =
-              ((bc_hi == amrex::BCType::ext_dir) &&
-               (idx[idim] >= edomain.bigEnd(idim)));
-            repair_flux(i, j, k, idim, on_lo, on_hi, rhoY, flux_dir);
-          });
-#endif
-      }
-    }
-  }
-}
-
-template <>
-void
-PeleLM::adjustSpeciesFluxes<pele::physics::eos::Manifold>(
-  const Vector<Array<MultiFab*, AMREX_SPACEDIM>>& /*a_spfluxes*/,
-  Vector<MultiFab const*> const& /*a_spec*/)
-{
-  // Manifold Model: "Species" don't sum to unity, so no need to adjust the
-  // fluxes
-  BL_PROFILE("PeleLM::adjustSpeciesFluxes()");
-}
-
 void
 PeleLM::computeDifferentialDiffusionFluxes(
   const TimeStamp& a_time,
@@ -410,8 +290,7 @@ PeleLM::computeDifferentialDiffusionFluxes(
   }
 
   // Adjust species diffusion fluxes to ensure their sum is zero
-  adjustSpeciesFluxes<pele::physics::PhysicsType::eos_type>(
-    a_fluxes, GetVecOfConstPtrs(getSpeciesVect(a_time)));
+  adjustSpeciesFluxes(a_fluxes, GetVecOfConstPtrs(getSpeciesVect(a_time)));
   //----------------------------------------------------------------
 
   //----------------------------------------------------------------
@@ -761,6 +640,114 @@ PeleLM::addSoretTerm(
 }
 
 void
+PeleLM::adjustSpeciesFluxes(
+  const Vector<Array<MultiFab*, AMREX_SPACEDIM>>& a_spfluxes,
+  Vector<MultiFab const*> const& a_spec)
+{
+
+  BL_PROFILE("PeleLMeX::adjustSpeciesFluxes()");
+
+  // Get the species BCRec
+  auto bcRecSpec = fetchBCRecArray(FIRSTSPEC, NUM_SPECIES);
+
+  for (int lev = 0; lev <= finest_level; ++lev) {
+
+    const Box& domain = geom[lev].Domain();
+
+#ifdef AMREX_USE_EB
+    //------------------------------------------------------------------------
+    // Get the edge species state needed for EB
+    int nGrow = 1;
+    const auto& ba = a_spec[lev]->boxArray();
+    const auto& dm = a_spec[lev]->DistributionMap();
+    const auto& ebfact = EBFactory(lev);
+    Array<MultiFab, AMREX_SPACEDIM> edgstate{AMREX_D_DECL(
+      MultiFab(
+        amrex::convert(ba, IntVect::TheDimensionVector(0)), dm, NUM_SPECIES,
+        nGrow, MFInfo(), ebfact),
+      MultiFab(
+        amrex::convert(ba, IntVect::TheDimensionVector(1)), dm, NUM_SPECIES,
+        nGrow, MFInfo(), ebfact),
+      MultiFab(
+        amrex::convert(ba, IntVect::TheDimensionVector(2)), dm, NUM_SPECIES,
+        nGrow, MFInfo(), ebfact))};
+    EB_interp_CellCentroid_to_FaceCentroid(
+      *a_spec[lev], GetArrOfPtrs(edgstate), 0, 0, NUM_SPECIES, geom[lev],
+      bcRecSpec);
+    auto const& areafrac = ebfact.getAreaFrac();
+#endif
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(*a_spec[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+      for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        const Box& ebx = mfi.nodaltilebox(idim);
+        const Box& edomain = amrex::surroundingNodes(domain, idim);
+        auto const& rhoY = a_spec[lev]->const_array(mfi);
+        auto const& flux_dir = a_spfluxes[lev][idim]->array(mfi);
+
+        const auto bc_lo = bcRecSpec[0].lo(idim);
+        const auto bc_hi = bcRecSpec[0].hi(idim);
+
+#ifdef AMREX_USE_EB
+        auto const& flagfab = ebfact.getMultiEBCellFlagFab()[mfi];
+
+        if (flagfab.getType(amrex::grow(ebx, 0)) != FabType::covered) {
+          // No cut cells in tile + nghost-cell width halo -> use non-eb routine
+          if (flagfab.getType(amrex::grow(ebx, nGrow)) == FabType::regular) {
+            amrex::ParallelFor(
+              ebx, [idim, rhoY, flux_dir, edomain, bc_lo,
+                    bc_hi] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                int idx[3] = {i, j, k};
+                bool on_lo =
+                  ((bc_lo == amrex::BCType::ext_dir) &&
+                   (idx[idim] <= edomain.smallEnd(idim)));
+                bool on_hi =
+                  ((bc_hi == amrex::BCType::ext_dir) &&
+                   (idx[idim] >= edomain.bigEnd(idim)));
+                repair_flux(i, j, k, idim, on_lo, on_hi, rhoY, flux_dir);
+              });
+          } else {
+            auto const& rhoYed_ar = edgstate[idim].const_array(mfi);
+            auto const& areafrac_ar = areafrac[idim]->const_array(mfi);
+            amrex::ParallelFor(
+              ebx,
+              [idim, rhoY, flux_dir, rhoYed_ar, areafrac_ar, edomain, bc_lo,
+               bc_hi] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                int idx[3] = {i, j, k};
+                bool on_lo =
+                  ((bc_lo == amrex::BCType::ext_dir) &&
+                   (idx[idim] <= edomain.smallEnd(idim)));
+                bool on_hi =
+                  ((bc_hi == amrex::BCType::ext_dir) &&
+                   (idx[idim] >= edomain.bigEnd(idim)));
+                repair_flux_eb(
+                  i, j, k, idim, on_lo, on_hi, rhoY, rhoYed_ar, areafrac_ar,
+                  flux_dir);
+              });
+          }
+        }
+#else
+        amrex::ParallelFor(
+          ebx, [idim, rhoY, flux_dir, edomain, bc_lo,
+                bc_hi] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            int idx[3] = {i, j, k};
+            bool on_lo =
+              ((bc_lo == amrex::BCType::ext_dir) &&
+               (idx[idim] <= edomain.smallEnd(idim)));
+            bool on_hi =
+              ((bc_hi == amrex::BCType::ext_dir) &&
+               (idx[idim] >= edomain.bigEnd(idim)));
+            repair_flux(i, j, k, idim, on_lo, on_hi, rhoY, flux_dir);
+          });
+#endif
+      }
+    }
+  }
+}
+
+void
 PeleLM::computeSpeciesEnthalpyFlux(
   const Vector<Array<MultiFab*, AMREX_SPACEDIM>>& a_fluxes,
   Vector<MultiFab const*> const& a_temp)
@@ -1020,7 +1007,7 @@ PeleLM::differentialDiffusionUpdate(
   fillPatchSpecies(AmrNewTime);
 
   // Adjust species diffusion fluxes to ensure their sum is zero
-  adjustSpeciesFluxes<pele::physics::PhysicsType::eos_type>(
+  adjustSpeciesFluxes(
     GetVecOfArrOfPtrs(fluxes), GetVecOfConstPtrs(getSpeciesVect(AmrNewTime)));
 
   // Average down fluxes^{np1,kp1}

--- a/Source/PeleLMeX_Diffusion.cpp
+++ b/Source/PeleLMeX_Diffusion.cpp
@@ -204,6 +204,126 @@ PeleLM::computeDifferentialDiffusionTerms(
 #endif
 }
 
+template <typename EOSType>
+void
+PeleLM::adjustSpeciesFluxes(
+  const Vector<Array<MultiFab*, AMREX_SPACEDIM>>& a_spfluxes,
+  Vector<MultiFab const*> const& a_spec)
+{
+
+  BL_PROFILE("PeleLMeX::adjustSpeciesFluxes()");
+
+  // Get the species BCRec
+  auto bcRecSpec = fetchBCRecArray(FIRSTSPEC, NUM_SPECIES);
+
+  for (int lev = 0; lev <= finest_level; ++lev) {
+
+    const Box& domain = geom[lev].Domain();
+
+#ifdef AMREX_USE_EB
+    //------------------------------------------------------------------------
+    // Get the edge species state needed for EB
+    int nGrow = 1;
+    const auto& ba = a_spec[lev]->boxArray();
+    const auto& dm = a_spec[lev]->DistributionMap();
+    const auto& ebfact = EBFactory(lev);
+    Array<MultiFab, AMREX_SPACEDIM> edgstate{AMREX_D_DECL(
+      MultiFab(
+        amrex::convert(ba, IntVect::TheDimensionVector(0)), dm, NUM_SPECIES,
+        nGrow, MFInfo(), ebfact),
+      MultiFab(
+        amrex::convert(ba, IntVect::TheDimensionVector(1)), dm, NUM_SPECIES,
+        nGrow, MFInfo(), ebfact),
+      MultiFab(
+        amrex::convert(ba, IntVect::TheDimensionVector(2)), dm, NUM_SPECIES,
+        nGrow, MFInfo(), ebfact))};
+    EB_interp_CellCentroid_to_FaceCentroid(
+      *a_spec[lev], GetArrOfPtrs(edgstate), 0, 0, NUM_SPECIES, geom[lev],
+      bcRecSpec);
+    auto const& areafrac = ebfact.getAreaFrac();
+#endif
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(*a_spec[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+      for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        const Box& ebx = mfi.nodaltilebox(idim);
+        const Box& edomain = amrex::surroundingNodes(domain, idim);
+        auto const& rhoY = a_spec[lev]->const_array(mfi);
+        auto const& flux_dir = a_spfluxes[lev][idim]->array(mfi);
+
+        const auto bc_lo = bcRecSpec[0].lo(idim);
+        const auto bc_hi = bcRecSpec[0].hi(idim);
+
+#ifdef AMREX_USE_EB
+        auto const& flagfab = ebfact.getMultiEBCellFlagFab()[mfi];
+
+        if (flagfab.getType(amrex::grow(ebx, 0)) != FabType::covered) {
+          // No cut cells in tile + nghost-cell width halo -> use non-eb routine
+          if (flagfab.getType(amrex::grow(ebx, nGrow)) == FabType::regular) {
+            amrex::ParallelFor(
+              ebx, [idim, rhoY, flux_dir, edomain, bc_lo,
+                    bc_hi] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                int idx[3] = {i, j, k};
+                bool on_lo =
+                  ((bc_lo == amrex::BCType::ext_dir) &&
+                   (idx[idim] <= edomain.smallEnd(idim)));
+                bool on_hi =
+                  ((bc_hi == amrex::BCType::ext_dir) &&
+                   (idx[idim] >= edomain.bigEnd(idim)));
+                repair_flux(i, j, k, idim, on_lo, on_hi, rhoY, flux_dir);
+              });
+          } else {
+            auto const& rhoYed_ar = edgstate[idim].const_array(mfi);
+            auto const& areafrac_ar = areafrac[idim]->const_array(mfi);
+            amrex::ParallelFor(
+              ebx,
+              [idim, rhoY, flux_dir, rhoYed_ar, areafrac_ar, edomain, bc_lo,
+               bc_hi] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                int idx[3] = {i, j, k};
+                bool on_lo =
+                  ((bc_lo == amrex::BCType::ext_dir) &&
+                   (idx[idim] <= edomain.smallEnd(idim)));
+                bool on_hi =
+                  ((bc_hi == amrex::BCType::ext_dir) &&
+                   (idx[idim] >= edomain.bigEnd(idim)));
+                repair_flux_eb(
+                  i, j, k, idim, on_lo, on_hi, rhoY, rhoYed_ar, areafrac_ar,
+                  flux_dir);
+              });
+          }
+        }
+#else
+        amrex::ParallelFor(
+          ebx, [idim, rhoY, flux_dir, edomain, bc_lo,
+                bc_hi] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            int idx[3] = {i, j, k};
+            bool on_lo =
+              ((bc_lo == amrex::BCType::ext_dir) &&
+               (idx[idim] <= edomain.smallEnd(idim)));
+            bool on_hi =
+              ((bc_hi == amrex::BCType::ext_dir) &&
+               (idx[idim] >= edomain.bigEnd(idim)));
+            repair_flux(i, j, k, idim, on_lo, on_hi, rhoY, flux_dir);
+          });
+#endif
+      }
+    }
+  }
+}
+
+template <>
+void
+PeleLM::adjustSpeciesFluxes<pele::physics::eos::Manifold>(
+  const Vector<Array<MultiFab*, AMREX_SPACEDIM>>& /*a_spfluxes*/,
+  Vector<MultiFab const*> const& /*a_spec*/)
+{
+  // Manifold Model: "Species" don't sum to unity, so no need to adjust the
+  // fluxes
+  BL_PROFILE("PeleLM::adjustSpeciesFluxes()");
+}
+
 void
 PeleLM::computeDifferentialDiffusionFluxes(
   const TimeStamp& a_time,
@@ -638,126 +758,6 @@ PeleLM::addSoretTerm(
       }
     }
   }
-}
-
-template <typename EOSType>
-void
-PeleLM::adjustSpeciesFluxes(
-  const Vector<Array<MultiFab*, AMREX_SPACEDIM>>& a_spfluxes,
-  Vector<MultiFab const*> const& a_spec)
-{
-
-  BL_PROFILE("PeleLMeX::adjustSpeciesFluxes()");
-
-  // Get the species BCRec
-  auto bcRecSpec = fetchBCRecArray(FIRSTSPEC, NUM_SPECIES);
-
-  for (int lev = 0; lev <= finest_level; ++lev) {
-
-    const Box& domain = geom[lev].Domain();
-
-#ifdef AMREX_USE_EB
-    //------------------------------------------------------------------------
-    // Get the edge species state needed for EB
-    int nGrow = 1;
-    const auto& ba = a_spec[lev]->boxArray();
-    const auto& dm = a_spec[lev]->DistributionMap();
-    const auto& ebfact = EBFactory(lev);
-    Array<MultiFab, AMREX_SPACEDIM> edgstate{AMREX_D_DECL(
-      MultiFab(
-        amrex::convert(ba, IntVect::TheDimensionVector(0)), dm, NUM_SPECIES,
-        nGrow, MFInfo(), ebfact),
-      MultiFab(
-        amrex::convert(ba, IntVect::TheDimensionVector(1)), dm, NUM_SPECIES,
-        nGrow, MFInfo(), ebfact),
-      MultiFab(
-        amrex::convert(ba, IntVect::TheDimensionVector(2)), dm, NUM_SPECIES,
-        nGrow, MFInfo(), ebfact))};
-    EB_interp_CellCentroid_to_FaceCentroid(
-      *a_spec[lev], GetArrOfPtrs(edgstate), 0, 0, NUM_SPECIES, geom[lev],
-      bcRecSpec);
-    auto const& areafrac = ebfact.getAreaFrac();
-#endif
-
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
-    for (MFIter mfi(*a_spec[lev], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-      for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        const Box& ebx = mfi.nodaltilebox(idim);
-        const Box& edomain = amrex::surroundingNodes(domain, idim);
-        auto const& rhoY = a_spec[lev]->const_array(mfi);
-        auto const& flux_dir = a_spfluxes[lev][idim]->array(mfi);
-
-        const auto bc_lo = bcRecSpec[0].lo(idim);
-        const auto bc_hi = bcRecSpec[0].hi(idim);
-
-#ifdef AMREX_USE_EB
-        auto const& flagfab = ebfact.getMultiEBCellFlagFab()[mfi];
-
-        if (flagfab.getType(amrex::grow(ebx, 0)) != FabType::covered) {
-          // No cut cells in tile + nghost-cell width halo -> use non-eb routine
-          if (flagfab.getType(amrex::grow(ebx, nGrow)) == FabType::regular) {
-            amrex::ParallelFor(
-              ebx, [idim, rhoY, flux_dir, edomain, bc_lo,
-                    bc_hi] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                int idx[3] = {i, j, k};
-                bool on_lo =
-                  ((bc_lo == amrex::BCType::ext_dir) &&
-                   (idx[idim] <= edomain.smallEnd(idim)));
-                bool on_hi =
-                  ((bc_hi == amrex::BCType::ext_dir) &&
-                   (idx[idim] >= edomain.bigEnd(idim)));
-                repair_flux(i, j, k, idim, on_lo, on_hi, rhoY, flux_dir);
-              });
-          } else {
-            auto const& rhoYed_ar = edgstate[idim].const_array(mfi);
-            auto const& areafrac_ar = areafrac[idim]->const_array(mfi);
-            amrex::ParallelFor(
-              ebx,
-              [idim, rhoY, flux_dir, rhoYed_ar, areafrac_ar, edomain, bc_lo,
-               bc_hi] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                int idx[3] = {i, j, k};
-                bool on_lo =
-                  ((bc_lo == amrex::BCType::ext_dir) &&
-                   (idx[idim] <= edomain.smallEnd(idim)));
-                bool on_hi =
-                  ((bc_hi == amrex::BCType::ext_dir) &&
-                   (idx[idim] >= edomain.bigEnd(idim)));
-                repair_flux_eb(
-                  i, j, k, idim, on_lo, on_hi, rhoY, rhoYed_ar, areafrac_ar,
-                  flux_dir);
-              });
-          }
-        }
-#else
-        amrex::ParallelFor(
-          ebx, [idim, rhoY, flux_dir, edomain, bc_lo,
-                bc_hi] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-            int idx[3] = {i, j, k};
-            bool on_lo =
-              ((bc_lo == amrex::BCType::ext_dir) &&
-               (idx[idim] <= edomain.smallEnd(idim)));
-            bool on_hi =
-              ((bc_hi == amrex::BCType::ext_dir) &&
-               (idx[idim] >= edomain.bigEnd(idim)));
-            repair_flux(i, j, k, idim, on_lo, on_hi, rhoY, flux_dir);
-          });
-#endif
-      }
-    }
-  }
-}
-
-template <>
-void
-PeleLM::adjustSpeciesFluxes<pele::physics::eos::Manifold>(
-  const Vector<Array<MultiFab*, AMREX_SPACEDIM>>& /*a_spfluxes*/,
-  Vector<MultiFab const*> const& /*a_spec*/)
-{
-  // Manifold Model: "Species" don't sum to unity, so no need to adjust the
-  // fluxes
-  BL_PROFILE("PeleLM::adjustSpeciesFluxes()");
 }
 
 void

--- a/Source/PeleLMeX_Diffusion.cpp
+++ b/Source/PeleLMeX_Diffusion.cpp
@@ -290,7 +290,8 @@ PeleLM::computeDifferentialDiffusionFluxes(
   }
 
   // Adjust species diffusion fluxes to ensure their sum is zero
-  adjustSpeciesFluxes(a_fluxes, GetVecOfConstPtrs(getSpeciesVect(a_time)));
+  adjustSpeciesFluxes<pele::physics::PhysicsType::eos_type>(
+    a_fluxes, GetVecOfConstPtrs(getSpeciesVect(a_time)));
   //----------------------------------------------------------------
 
   //----------------------------------------------------------------
@@ -637,6 +638,7 @@ PeleLM::addSoretTerm(
   }
 }
 
+template <typename EOSType>
 void
 PeleLM::adjustSpeciesFluxes(
   const Vector<Array<MultiFab*, AMREX_SPACEDIM>>& a_spfluxes,
@@ -743,6 +745,17 @@ PeleLM::adjustSpeciesFluxes(
       }
     }
   }
+}
+
+template <>
+void
+PeleLM::adjustSpeciesFluxes<pele::physics::eos::Manifold>(
+  const Vector<Array<MultiFab*, AMREX_SPACEDIM>>& /*a_spfluxes*/,
+  Vector<MultiFab const*> const& /*a_spec*/)
+{
+  // Manifold Model: "Species" don't sum to unity, so no need to adjust the
+  // fluxes
+  BL_PROFILE("PeleLM::adjustSpeciesFluxes()");
 }
 
 void
@@ -1004,7 +1017,7 @@ PeleLM::differentialDiffusionUpdate(
   fillPatchSpecies(AmrNewTime);
 
   // Adjust species diffusion fluxes to ensure their sum is zero
-  adjustSpeciesFluxes(
+  adjustSpeciesFluxes<pele::physics::PhysicsType::eos_type>(
     GetVecOfArrOfPtrs(fluxes), GetVecOfConstPtrs(getSpeciesVect(AmrNewTime)));
 
   // Average down fluxes^{np1,kp1}

--- a/Source/PeleLMeX_Diffusion.cpp
+++ b/Source/PeleLMeX_Diffusion.cpp
@@ -466,10 +466,11 @@ PeleLM::addWbarTerm(
           // Wbar flux is : - \rho Y_m / \overline{W} * D_m * \nabla
           // \overline{W} with beta_m = \rho * D_m below
           amrex::ParallelFor(
-            ebx,
-            [need_wbar_fluxes, gradWbar_ar, beta_ar, rhoY, spFlux_ar,
-             spwbarFlux_ar] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-              auto eos = pele::physics::PhysicsType::eos();
+            ebx, [need_wbar_fluxes, gradWbar_ar, beta_ar, rhoY, spFlux_ar,
+                  spwbarFlux_ar,
+                  eosparm =
+                    leosparm] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+              auto eos = pele::physics::PhysicsType::eos(eosparm);
               // Get Wbar from rhoYs
               amrex::Real rho = 0.0;
               for (int n = 0; n < NUM_SPECIES; n++) {

--- a/Source/PeleLMeX_Forces.cpp
+++ b/Source/PeleLMeX_Forces.cpp
@@ -204,15 +204,17 @@ PeleLM::addSpark(const TimeStamp& a_timestamp)
         Print() << m_spark[n] << " active" << std::endl;
       }
 
-      auto eos = pele::physics::PhysicsType::eos();
       auto statema = getLevelDataPtr(lev, a_timestamp)->state.const_arrays();
       auto extma = m_extSource[lev]->arrays();
+      auto const* leosparm = eos_parms.device_parm();
 
       amrex::ParallelFor(
         *m_extSource[lev],
         [=, spark_duration = m_spark_duration[n], spark_temp = m_spark_temp[n],
+         eosparm = leosparm,
          spark_radius = m_spark_radius
            [n]] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) noexcept {
+          auto eos = pele::physics::PhysicsType::eos(eosparm);
           Real dist_to_center = std::sqrt(AMREX_D_TERM(
             (i - spark_idx[0]) * (i - spark_idx[0]) * dx[0] * dx[0],
             +(j - spark_idx[1]) * (j - spark_idx[1]) * dx[1] * dx[1],

--- a/Source/PeleLMeX_K.H
+++ b/Source/PeleLMeX_K.H
@@ -24,11 +24,13 @@ getTransportCoeff(
   amrex::Array4<amrex::Real> const& mu,
   pele::physics::transport::TransParm<
     pele::physics::PhysicsType::eos_type,
-    pele::physics::PhysicsType::transport_type> const* trans_parm) noexcept
+    pele::physics::PhysicsType::transport_type> const* trans_parm,
+  pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type> const*
+    eosparm) noexcept
 {
   using namespace amrex::literals;
 
-  auto eos = pele::physics::PhysicsType::eos();
+  auto eos = pele::physics::PhysicsType::eos(eosparm);
   amrex::Real mwtinv[NUM_SPECIES] = {0.0};
   eos.inv_molecular_weight(mwtinv);
 
@@ -170,11 +172,13 @@ getPGivenRTY(
   amrex::Array4<const amrex::Real> const& rho,
   amrex::Array4<const amrex::Real> const& rhoY,
   amrex::Array4<const amrex::Real> const& T,
-  amrex::Array4<amrex::Real> const& P) noexcept
+  amrex::Array4<amrex::Real> const& P,
+  pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type> const*
+    eosparm) noexcept
 {
   using namespace amrex::literals;
 
-  auto eos = pele::physics::PhysicsType::eos();
+  auto eos = pele::physics::PhysicsType::eos(eosparm);
   amrex::Real rhoinv = 1.0_rt / rho(i, j, k);
   amrex::Real rho_cgs = rho(i, j, k) * 0.001_rt;
 
@@ -203,11 +207,13 @@ compute_divu(
   amrex::Array4<const amrex::Real> const& extRhoY,
   amrex::Array4<const amrex::Real> const& extRhoH,
   amrex::Array4<amrex::Real> const& divu,
-  int do_react) noexcept
+  int do_react,
+  pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type> const*
+    eosparm) noexcept
 {
   using namespace amrex::literals;
 
-  auto eos = pele::physics::PhysicsType::eos();
+  auto eos = pele::physics::PhysicsType::eos(eosparm);
   amrex::Real mwtinv[NUM_SPECIES] = {0.0};
   eos.inv_molecular_weight(mwtinv);
 
@@ -425,11 +431,13 @@ getMwmixGivenRY(
   int k,
   amrex::Array4<const amrex::Real> const& rho,
   amrex::Array4<const amrex::Real> const& rhoY,
-  amrex::Array4<amrex::Real> const& Mwmix) noexcept
+  amrex::Array4<amrex::Real> const& Mwmix,
+  pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type> const*
+    eosparm) noexcept
 {
   using namespace amrex::literals;
 
-  auto eos = pele::physics::PhysicsType::eos();
+  auto eos = pele::physics::PhysicsType::eos(eosparm);
   amrex::Real rhoinv = 1.0_rt / rho(i, j, k);
   amrex::Real y[NUM_SPECIES] = {0.0_rt};
   for (int n = 0; n < NUM_SPECIES; n++) {
@@ -591,11 +599,13 @@ getHGivenT(
   int j,
   int k,
   amrex::Array4<const amrex::Real> const& T,
-  amrex::Array4<amrex::Real> const& Hi) noexcept
+  amrex::Array4<amrex::Real> const& Hi,
+  pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type> const*
+    eosparm) noexcept
 {
   using namespace amrex::literals;
 
-  auto eos = pele::physics::PhysicsType::eos();
+  auto eos = pele::physics::PhysicsType::eos(eosparm);
   amrex::Real hi_spec[NUM_SPECIES] = {0.0_rt};
   eos.T2Hi(T(i, j, k), hi_spec);
   for (int n = 0; n < NUM_SPECIES; n++) {
@@ -665,11 +675,13 @@ getRHmixGivenTY(
   amrex::Array4<const amrex::Real> const& rho,
   amrex::Array4<const amrex::Real> const& rhoY,
   amrex::Array4<const amrex::Real> const& T,
-  amrex::Array4<amrex::Real> const& Hmix) noexcept
+  amrex::Array4<amrex::Real> const& Hmix,
+  pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type> const*
+    eosparm) noexcept
 {
   using namespace amrex::literals;
 
-  auto eos = pele::physics::PhysicsType::eos();
+  auto eos = pele::physics::PhysicsType::eos(eosparm);
   amrex::Real rhoinv = 1.0_rt / rho(i, j, k);
   amrex::Real y[NUM_SPECIES] = {0.0_rt};
   for (int n = 0; n < NUM_SPECIES; n++) {
@@ -691,11 +703,13 @@ getTfromHY(
   amrex::Array4<const amrex::Real> const& rho,
   amrex::Array4<const amrex::Real> const& rhoY,
   amrex::Array4<const amrex::Real> const& rhoH,
-  amrex::Array4<amrex::Real> const& T) noexcept
+  amrex::Array4<amrex::Real> const& T,
+  pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type> const*
+    eosparm) noexcept
 {
   using namespace amrex::literals;
 
-  auto eos = pele::physics::PhysicsType::eos();
+  auto eos = pele::physics::PhysicsType::eos(eosparm);
   amrex::Real rhoinv = 1.0_rt / rho(i, j, k);
   amrex::Real y[NUM_SPECIES] = {0.0};
   for (int n = 0; n < NUM_SPECIES; n++) {
@@ -717,11 +731,13 @@ getCpmixGivenRYT(
   amrex::Array4<const amrex::Real> const& rho,
   amrex::Array4<const amrex::Real> const& rhoY,
   amrex::Array4<const amrex::Real> const& T,
-  amrex::Array4<amrex::Real> const& cpmix) noexcept
+  amrex::Array4<amrex::Real> const& cpmix,
+  pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type> const*
+    eosparm) noexcept
 {
   using namespace amrex::literals;
 
-  auto eos = pele::physics::PhysicsType::eos();
+  auto eos = pele::physics::PhysicsType::eos(eosparm);
   amrex::Real rhoinv = 1.0_rt / rho(i, j, k);
   amrex::Real y[NUM_SPECIES] = {0.0};
   for (int n = 0; n < NUM_SPECIES; n++) {
@@ -751,11 +767,13 @@ buildAdvectionForcing(
   int const& closed_chamber,
   int do_react,
   amrex::Array4<amrex::Real> const& forceY,
-  amrex::Array4<amrex::Real> const& forceT) noexcept
+  amrex::Array4<amrex::Real> const& forceT,
+  pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type> const*
+    eosparm) noexcept
 {
   using namespace amrex::literals;
 
-  auto eos = pele::physics::PhysicsType::eos();
+  auto eos = pele::physics::PhysicsType::eos(eosparm);
   // Get species enthalpy
   amrex::Real hi_spec[NUM_SPECIES] = {0.0};
   eos.T2Hi(T(i, j, k), hi_spec);
@@ -835,11 +853,13 @@ reactionRateRhoY(
   amrex::Array4<const amrex::Real> const& rhoY,
   amrex::Array4<const amrex::Real> const& rhoH,
   amrex::Array4<const amrex::Real> const& T,
-  amrex::Array4<amrex::Real> const& rhoYdot) noexcept
+  amrex::Array4<amrex::Real> const& rhoYdot,
+  pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type> const*
+    eosparm) noexcept
 {
   using namespace amrex::literals;
 
-  auto eos = pele::physics::PhysicsType::eos();
+  auto eos = pele::physics::PhysicsType::eos(eosparm);
 
   // Get rho & Ys from rhoYs.
   amrex::Real rho = 0.0_rt;
@@ -1005,11 +1025,13 @@ getGammaInv(
   int j,
   int k,
   amrex::Array4<const amrex::Real> const& rhoY,
-  amrex::Array4<const amrex::Real> const& T) noexcept
+  amrex::Array4<const amrex::Real> const& T,
+  pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type> const*
+    eosparm) noexcept
 {
   using namespace amrex::literals;
 
-  auto eos = pele::physics::PhysicsType::eos();
+  auto eos = pele::physics::PhysicsType::eos(eosparm);
   // Get rho & Y from rhoY
   amrex::Real rho = 0.0_rt;
   for (int n = 0; n < NUM_SPECIES; n++) {

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -975,6 +975,7 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   ldata_p->gp.setVal(0.0);
 
   ProbParm const* lprobparm = prob_parm_d;
+  auto const* leosparm = eos_parms.device_parm();
 
   // If m_do_patch_flow_variables is set as true, call user-defined function to
   // patch flow variables
@@ -994,38 +995,40 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
     auto const& rhoY_arr = ldata_p->state.array(mfi, FIRSTSPEC);
     auto const& rhoH_arr = ldata_p->state.array(mfi, RHOH);
     auto const& temp_arr = ldata_p->state.array(mfi, TEMP);
-    amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-      auto eos = pele::physics::PhysicsType::eos();
-      Real massfrac[NUM_SPECIES] = {0.0};
-      Real sumYs = 0.0;
-      for (int n = 0; n < NUM_SPECIES; n++) {
-        massfrac[n] = rhoY_arr(i, j, k, n);
+    amrex::ParallelFor(
+      bx,
+      [=, eosparm = leosparm] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        auto eos = pele::physics::PhysicsType::eos(eosparm);
+        Real massfrac[NUM_SPECIES] = {0.0};
+        Real sumYs = 0.0;
+        for (int n = 0; n < NUM_SPECIES; n++) {
+          massfrac[n] = rhoY_arr(i, j, k, n);
 #ifdef N2_ID
-        if (n != N2_ID) {
-          sumYs += massfrac[n];
+          if (n != N2_ID) {
+            sumYs += massfrac[n];
+          }
+#endif
         }
-#endif
-      }
 #ifdef N2_ID
-      massfrac[N2_ID] = 1.0 - sumYs;
+        massfrac[N2_ID] = 1.0 - sumYs;
 #endif
 
-      // Get density
-      Real P_cgs = lprobparm->P_mean * 10.0;
-      Real rho_cgs = 0.0;
-      eos.PYT2R(P_cgs, massfrac, temp_arr(i, j, k), rho_cgs);
-      rho_arr(i, j, k) = rho_cgs * 1.0e3;
+        // Get density
+        Real P_cgs = lprobparm->P_mean * 10.0;
+        Real rho_cgs = 0.0;
+        eos.PYT2R(P_cgs, massfrac, temp_arr(i, j, k), rho_cgs);
+        rho_arr(i, j, k) = rho_cgs * 1.0e3;
 
-      // Get enthalpy
-      Real h_cgs = 0.0;
-      eos.TY2H(temp_arr(i, j, k), massfrac, h_cgs);
-      rhoH_arr(i, j, k) = h_cgs * 1.0e-4 * rho_arr(i, j, k);
+        // Get enthalpy
+        Real h_cgs = 0.0;
+        eos.TY2H(temp_arr(i, j, k), massfrac, h_cgs);
+        rhoH_arr(i, j, k) = h_cgs * 1.0e-4 * rho_arr(i, j, k);
 
-      // Fill rhoYs
-      for (int n = 0; n < NUM_SPECIES; n++) {
-        rhoY_arr(i, j, k, n) = massfrac[n] * rho_arr(i, j, k);
-      }
-    });
+        // Fill rhoYs
+        for (int n = 0; n < NUM_SPECIES; n++) {
+          rhoY_arr(i, j, k, n) = massfrac[n] * rho_arr(i, j, k);
+        }
+      });
   }
 
   // Initialize thermodynamic pressure

--- a/Source/PeleLMeX_Reactions.cpp
+++ b/Source/PeleLMeX_Reactions.cpp
@@ -84,7 +84,7 @@ PeleLM::advanceChemistry(int lev, const Real& a_dt, MultiFab& a_extForcing)
     auto const& FnE = a_extForcing.array(mfi, NUM_SPECIES + 1);
     auto const& rhoYe_n = ldataNew_p->state.array(mfi, FIRSTSPEC + E_ID);
     auto const& FrhoYe = a_extForcing.array(mfi, E_ID);
-    auto eos = pele::physics::PhysicsType::eos();
+    auto eos = pele::physics::PhysicsType::eos(&eos_parms.host_parm());
     Real mwt[NUM_SPECIES] = {0.0};
     eos.molecular_weight(mwt);
     ParallelFor(
@@ -245,7 +245,7 @@ PeleLM::advanceChemistryBAChem(
     auto const& FnE = chemForcing.array(mfi, NUM_SPECIES + 1);
     auto const& rhoYe_o = chemState.array(mfi, E_ID);
     auto const& FrhoYe = chemForcing.array(mfi, E_ID);
-    auto eos = pele::physics::PhysicsType::eos();
+    auto eos = pele::physics::PhysicsType::eos(&eos_parms.host_parm());
     Real mwt[NUM_SPECIES] = {0.0};
     eos.molecular_weight(mwt);
     ParallelFor(

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -105,7 +105,14 @@ PeleLM::Setup()
 
   // Initialize EOS and others
   if (m_incompressible == 0) {
+    amrex::Print() << " Initialization of Eos ... \n";
+    eos_parms.initialize();
+
     amrex::Print() << " Initialization of Transport ... \n";
+#ifdef USE_MANIFOLD_EOS
+    trans_parms.host_only_parm().manfunc_par =
+      eos_parms.host_only_parm().manfunc_par;
+#endif
     trans_parms.initialize();
     if ((m_les_verbose != 0) and m_do_les) { // Say what transport model we're
                                              // going to use
@@ -142,6 +149,7 @@ PeleLM::Setup()
       m_reactor =
         pele::physics::reactions::ReactorBase::create(m_chem_integrator);
       m_reactor->init(reactor_type, ncells_chem);
+      m_reactor->set_eos_parm(eos_parms.device_parm());
       // For ReactorNull, we need to also skip instantaneous RR used in divU
       if (m_chem_integrator == "ReactorNull") {
         m_skipInstantRR = 1;

--- a/Source/PeleLMeX_TransportProp.cpp
+++ b/Source/PeleLMeX_TransportProp.cpp
@@ -302,7 +302,7 @@ PeleLM::calcDiffusivity(const TimeStamp& a_time)
     auto const& kma = ldata_p->mob_cc.arrays();
     GpuArray<Real, NUM_SPECIES> mwt{0.0};
     {
-      auto eos = pele::physics::PhysicsType::eos();
+      auto eos = pele::physics::PhysicsType::eos(leosparm);
       eos.molecular_weight(mwt.arr);
     }
 #endif

--- a/Source/PeleLMeX_TransportProp.cpp
+++ b/Source/PeleLMeX_TransportProp.cpp
@@ -64,6 +64,7 @@ PeleLM::calcTurbViscosity(const TimeStamp& a_time)
     } else {
       // get cp_cc (valid in 1 grow cell for interpolation to FCs)
       int ngrow = 1;
+      auto const* leosparm = eos_parms.device_parm();
       cp_cc.define(ba, dm, 1, ngrow, MFInfo(), factory);
       auto const& state_arr = ldata_p->state.const_arrays();
       auto const& cp_arr = cp_cc.arrays();
@@ -74,7 +75,7 @@ PeleLM::calcTurbViscosity(const TimeStamp& a_time)
             i, j, k, Array4<Real const>(state_arr[box_no], DENSITY),
             Array4<Real const>(state_arr[box_no], FIRSTSPEC),
             Array4<Real const>(state_arr[box_no], TEMP),
-            Array4<Real>(cp_arr[box_no]));
+            Array4<Real>(cp_arr[box_no]), leosparm);
         });
       Gpu::streamSynchronize();
 
@@ -292,6 +293,7 @@ PeleLM::calcDiffusivity(const TimeStamp& a_time)
 
     // Transport data pointer
     auto const* ltransparm = trans_parms.device_parm();
+    auto const* leosparm = eos_parms.device_parm();
 
     // MultiArrays
     auto const& sma = ldata_p->state.const_arrays();
@@ -322,7 +324,7 @@ PeleLM::calcDiffusivity(const TimeStamp& a_time)
           Array4<Real const>(sma[box_no], TEMP), Array4<Real>(dma[box_no], 0),
           Array4<Real>(dma[box_no], NUM_SPECIES + 1 + soret_idx),
           Array4<Real>(dma[box_no], NUM_SPECIES),
-          Array4<Real>(dma[box_no], NUM_SPECIES + 1), ltransparm);
+          Array4<Real>(dma[box_no], NUM_SPECIES + 1), ltransparm, leosparm);
 #ifdef PELE_USE_EFIELD
         getKappaSp(
           i, j, k, mwt.arr, zk, Array4<Real const>(sma[box_no], FIRSTSPEC),

--- a/Source/PeleLMeX_Utils.cpp
+++ b/Source/PeleLMeX_Utils.cpp
@@ -658,6 +658,7 @@ PeleLM::floorSpecies(const TimeStamp& a_time)
 
     auto* ldata_p = getLevelDataPtr(lev, a_time);
     auto const& sma = ldata_p->state.arrays();
+    auto const* leosparm = eos_parms.device_parm();
 
     amrex::ParallelFor(
       ldata_p->state,
@@ -676,7 +677,7 @@ PeleLM::floorSpecies(const TimeStamp& a_time)
         }
 
         // ... as well as rhoh
-        auto eos = pele::physics::PhysicsType::eos();
+        auto eos = pele::physics::PhysicsType::eos(leosparm);
         Real massfrac[NUM_SPECIES] = {0.0};
         Real rhoinv = Real(1.0) / sma[box_no](i, j, k, DENSITY);
         for (int n = 0; n < NUM_SPECIES; n++) {
@@ -1447,7 +1448,8 @@ PeleLM::updateTypicalValuesChem()
       }
       typical_values_chem[NUM_SPECIES] = typical_values[TEMP];
 #ifdef PELE_USE_EFIELD
-      auto eos = pele::physics::PhysicsType::eos();
+      auto const* leosparm = &eos_parms.host_parm();
+      auto eos = pele::physics::PhysicsType::eos(leosparm);
       Real mwt[NUM_SPECIES] = {0.0};
       eos.molecular_weight(mwt);
       typical_values_chem[E_ID] =
@@ -1727,7 +1729,8 @@ PeleLM::initMixtureFraction()
     }
   }
 
-  auto eos = pele::physics::PhysicsType::eos();
+  auto const* leosparm = &eos_parms.host_parm();
+  auto eos = pele::physics::PhysicsType::eos(leosparm);
   // Overwrite with user-defined value if provided in input file
   ParmParse pp("peleLM");
   std::string MFformat;
@@ -1881,7 +1884,8 @@ PeleLM::parseComposition(
       massFrac[i] = compoIn[i];
     }
   } else if (compositionType == "mole") { // mole
-    auto eos = pele::physics::PhysicsType::eos();
+    auto const* leosparm = &eos_parms.host_parm();
+    auto eos = pele::physics::PhysicsType::eos(leosparm);
     eos.X2Y(compoIn, massFrac);
   } else {
     Abort("Unknown mixtureFraction.type ! Should be 'mass' or 'mole'");


### PR DESCRIPTION
Progress toward merging the manifold modeling stuff into PeleLMeX

Pass eosparm as argument into all EOS functions. Right now this is not necessary because it is only used by Manifold EOS, but this paves the way for that and should not negatively impact anything. 
- Does not yet support all Efield functions (but because eosparm is not needed for non-manofold EOS, this does not impact functionality)
- FlameSheet case shows example of how eosparm can be used in problem files for bcnormal/initdata. This will have to be added to any case to be run with manifold EOS, but is done in a way that does not break existing cases.