### PR TITLE
DivU constraint with arbitrary sources

### DIFF
--- a/Docs/sphinx/manual/Model.rst
+++ b/Docs/sphinx/manual/Model.rst
@@ -107,9 +107,9 @@ and observe that if the initial conditions satisfy the constraint, an evolution 
 .. math::
 
     \nabla \cdot \boldsymbol{u} = \frac{1}{T}\frac{DT}{Dt}
-    + W \sum_m \frac{1}{W_m} \frac{DY_m}{Dt} + \frac{1}{\rho}S_{\text{ext},\rho} = S
+    + W \sum_m \frac{1}{W_m} \frac{DY_m}{Dt} + \frac{1}{\rho}S_{\text{ext},\rho} = S.
 
-The constraint here take the form of a condition on the divergence of the flow.  Note that the actual expressions to use here will depend upon the chosen models for evaluating the transport fluxes.
+The constraint here takes the form of a condition on the divergence of the flow.  Note that the actual expressions to use here will depend upon the chosen models for evaluating the transport fluxes.
 
 For the standard ideal gas EOS, 
 
@@ -125,6 +125,24 @@ Therefore, the divergence constraint on velocity becomes:
     \nabla \cdot \boldsymbol{u} &= \frac{1}{\rho c_p T} \left(-\nabla \cdot \boldsymbol{Q} + S_{\text{ext},\rho h} - h S_{\text{ext},\rho} \right) 
     - \sum_m \frac{h_m}{\rho c_p T} \left( - \nabla \cdot \boldsymbol{\mathcal{F}}_m + \rho \dot \omega_m + S_{\text{ext},Y_m} - Y_m S_{\text{ext},\rho}\right) \\
     &\;\;\;+ \frac{1}{\rho} \sum_m \frac{W}{W_m} \left( - \nabla \cdot \boldsymbol{\mathcal{F}}_m + \rho \dot \omega_m + S_{\text{ext},Y_m} - Y_m S_{\text{ext},\rho}\right) + \frac{1}{\rho}S_{\text{ext},\rho}\equiv S .
+
+However, it can be shown that 
+
+.. math::
+    \sum_m h_m Y_m S_{\text{ext},\rho} = h S_{\text{ext},\rho}
+
+and 
+
+.. math::
+
+    \sum_m \frac{W}{\rho W_m} Y_m S_{\text{ext},\rho} = \frac{1}{\rho}S_{\text{ext},\rho}. 
+
+Thus, the terms containing :math:`S_{\text{ext},\rho}` cancel and the divergence constraint for the standard ideal gas EOS simplifies to 
+
+.. math::
+
+    \nabla \cdot \boldsymbol{u} = \frac{1}{\rho c_p T} \Big(-\nabla \cdot \boldsymbol{Q} + S_{\text{ext},\rho h} \Big) 
+    +  \sum_m \bigg( \frac{W}{\rho W_m} -  \frac{h_m}{\rho c_p T}\bigg)\bigg( - \nabla \cdot \boldsymbol{\mathcal{F}}_m + \rho \dot \omega_m + S_{\text{ext},Y_m} \bigg) \equiv S .
 
 Confined domain ambient pressure
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -147,7 +165,7 @@ where :math:`\overline \theta` and :math:`\overline S` are the mean values of :m
 
     \int_V \nabla \cdot \boldsymbol{u} dV + \int_V (\overline \theta + \delta \theta)\frac{dp_0}{dt} dV = \int_V (\overline S + \delta S) dV
 
-Since the perturbations integrate to zero over the domain volume, the mean values are constants, and :math:`p_0` is only a function of time, the above simplifies to:
+Since the perturbations integrate to zero over the domain volume, the mean values are constants, and :math:`p_0` is only a function of time, the above simplifies:
 
 .. math::
 

--- a/Docs/sphinx/manual/Model.rst
+++ b/Docs/sphinx/manual/Model.rst
@@ -165,7 +165,7 @@ where :math:`\overline \theta` and :math:`\overline S` are the mean values of :m
 
     \int_V \nabla \cdot \boldsymbol{u} dV + \int_V (\overline \theta + \delta \theta)\frac{dp_0}{dt} dV = \int_V (\overline S + \delta S) dV
 
-Since the perturbations integrate to zero over the domain volume, the mean values are constants, and :math:`p_0` is only a function of time, the above simplifies:
+Since the perturbations integrate to zero over the domain volume, the mean values are constants, and :math:`p_0` is only a function of time, the above simplifies to:
 
 .. math::
 

--- a/Docs/sphinx/manual/Model.rst
+++ b/Docs/sphinx/manual/Model.rst
@@ -115,34 +115,33 @@ For the standard ideal gas EOS,
 
 .. math::
 
-    \frac{DT}{Dt} &= \frac{1}{\rho}\left[ - \nabla \cdot \boldsymbol{Q} + S_{\text{ext},\rho h} - h S_{\text{ext},\rho}\right] - \sum_m \frac{h_m}{ c_p} \frac{DY_m}{Dt}, \\
-    \frac{DY_m}{Dt} &= \frac{1}{\rho}\left[ - \nabla \cdot \boldsymbol{\mathcal{F_m}} + \rho \dot \omega_m + S_{\text{ext},\rho Y_m} - Y_m S_{\text{ext},\rho}\right].
+    \frac{DT}{Dt} &= \frac{1}{\rho}\Big[ - \nabla \cdot \boldsymbol{Q} + S_{\text{ext},\rho h} - h S_{\text{ext},\rho}\Big] - \sum_m \frac{h_m}{ c_p} \frac{DY_m}{Dt}, \\
+    \frac{DY_m}{Dt} &= \frac{1}{\rho}\Big[ - \nabla \cdot \boldsymbol{\mathcal{F_m}} + \rho \dot \omega_m + S_{\text{ext},\rho Y_m} - Y_m S_{\text{ext},\rho}\Big].
 
 Therefore, the divergence constraint on velocity becomes:
 
 .. math::
 
-    \nabla \cdot \boldsymbol{u} &= \frac{1}{\rho c_p T} \left(-\nabla \cdot \boldsymbol{Q} + S_{\text{ext},\rho h} - h S_{\text{ext},\rho} \right) 
-    - \sum_m \frac{h_m}{\rho c_p T} \left( - \nabla \cdot \boldsymbol{\mathcal{F}}_m + \rho \dot \omega_m + S_{\text{ext},Y_m} - Y_m S_{\text{ext},\rho}\right) \\
-    &\;\;\;+ \frac{1}{\rho} \sum_m \frac{W}{W_m} \left( - \nabla \cdot \boldsymbol{\mathcal{F}}_m + \rho \dot \omega_m + S_{\text{ext},Y_m} - Y_m S_{\text{ext},\rho}\right) + \frac{1}{\rho}S_{\text{ext},\rho}\equiv S .
+    \nabla \cdot \boldsymbol{u} &= \frac{1}{\rho c_p T} \Big(-\nabla \cdot \boldsymbol{Q} + S_{\text{ext},\rho h} - h S_{\text{ext},\rho}\Big) \\
+    &\;\;\;\; +  \sum_m \bigg( \frac{W}{\rho W_m} -  \frac{h_m}{\rho c_p T}\bigg)\bigg( - \nabla \cdot \boldsymbol{\mathcal{F}}_m + \rho \dot \omega_m + S_{\text{ext},\rho Y_m} - Y_m S_{\text{ext},\rho}\bigg) + \frac{1}{\rho} S_{\text{ext},\rho}\equiv S .
 
 However, it can be shown that 
 
 .. math::
-    \sum_m h_m Y_m S_{\text{ext},\rho} = h S_{\text{ext},\rho}
+
+    \sum_m \frac{W}{\rho W_m} Y_m S_{\text{ext},\rho} = \frac{1}{\rho}S_{\text{ext},\rho}
 
 and 
 
 .. math::
+    \sum_m h_m Y_m S_{\text{ext},\rho} = h S_{\text{ext},\rho}.
 
-    \sum_m \frac{W}{\rho W_m} Y_m S_{\text{ext},\rho} = \frac{1}{\rho}S_{\text{ext},\rho}. 
-
-Thus, the terms containing :math:`S_{\text{ext},\rho}` cancel and the divergence constraint for the standard ideal gas EOS simplifies to 
+Thus, the terms containing :math:`S_{\text{ext},\rho}` cancel and the divergence constraint for the standard ideal gas EOS simplifies to: 
 
 .. math::
 
     \nabla \cdot \boldsymbol{u} = \frac{1}{\rho c_p T} \Big(-\nabla \cdot \boldsymbol{Q} + S_{\text{ext},\rho h} \Big) 
-    +  \sum_m \bigg( \frac{W}{\rho W_m} -  \frac{h_m}{\rho c_p T}\bigg)\bigg( - \nabla \cdot \boldsymbol{\mathcal{F}}_m + \rho \dot \omega_m + S_{\text{ext},Y_m} \bigg) \equiv S .
+    +  \sum_m \bigg( \frac{W}{\rho W_m} -  \frac{h_m}{\rho c_p T}\bigg)\bigg( - \nabla \cdot \boldsymbol{\mathcal{F}}_m + \rho \dot \omega_m + S_{\text{ext},\rho Y_m} \bigg) \equiv S .
 
 Confined domain ambient pressure
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Source/PeleLMeX_Eos.cpp
+++ b/Source/PeleLMeX_Eos.cpp
@@ -135,27 +135,27 @@ PeleLM::calcDivU(
       } else if (flagfab.getType(bx) != FabType::regular) { // EB containing
                                                             // boxes
         amrex::ParallelFor(
-          bx, [rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho, extRhoY, extRhoH, divu,
-               use_react, flag,
+          bx, [rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho, extRhoY,
+               extRhoH, divu, use_react, flag,
                leosparm] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             if (flag(i, j, k).isCovered()) {
               divu(i, j, k) = 0.0;
             } else {
               compute_divu(
-                i, j, k, rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho, extRhoY, extRhoH,
-                divu, use_react, leosparm);
+                i, j, k, rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho,
+                extRhoY, extRhoH, divu, use_react, leosparm);
             }
           });
       } else
 #endif
       {
         amrex::ParallelFor(
-          bx,
-          [rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho, extRhoY, extRhoH, divu,
-           use_react, leosparm] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+          bx, [rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho, extRhoY,
+               extRhoH, divu, use_react,
+               leosparm] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             compute_divu(
-              i, j, k, rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho, extRhoY, extRhoH,
-              divu, use_react, leosparm);
+              i, j, k, rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho,
+              extRhoY, extRhoH, divu, use_react, leosparm);
           });
       }
     }

--- a/Source/PeleLMeX_Eos.cpp
+++ b/Source/PeleLMeX_Eos.cpp
@@ -102,6 +102,7 @@ PeleLM::calcDivU(
 #endif
 
       auto const& rhoY = ldata_p->state.const_array(mfi, FIRSTSPEC);
+      auto const& rhoH = ldata_p->state.const_array(mfi, RHOH);
       auto const& T = ldata_p->state.const_array(mfi, TEMP);
       auto const& SpecD = (a_time == AmrOldTime)
                             ? diffData->Dn[lev].const_array(mfi, 0)
@@ -118,6 +119,7 @@ PeleLM::calcDivU(
         ((m_do_react != 0) && (m_skipInstantRR == 0))
           ? RhoYdot.const_array(mfi)
           : ldata_p->state.const_array(mfi, FIRSTSPEC); // Dummy unused Array4
+      auto const& extRho = m_extSource[lev]->const_array(mfi, DENSITY);
       auto const& extRhoY = m_extSource[lev]->const_array(mfi, FIRSTSPEC);
       auto const& extRhoH = m_extSource[lev]->const_array(mfi, RHOH);
       auto const& divu = ldata_p->divu.array(mfi);
@@ -133,14 +135,14 @@ PeleLM::calcDivU(
       } else if (flagfab.getType(bx) != FabType::regular) { // EB containing
                                                             // boxes
         amrex::ParallelFor(
-          bx, [rhoY, T, SpecD, Fourier, DiffDiff, r, extRhoY, extRhoH, divu,
+          bx, [rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho, extRhoY, extRhoH, divu,
                use_react, flag,
                leosparm] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             if (flag(i, j, k).isCovered()) {
               divu(i, j, k) = 0.0;
             } else {
               compute_divu(
-                i, j, k, rhoY, T, SpecD, Fourier, DiffDiff, r, extRhoY, extRhoH,
+                i, j, k, rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho, extRhoY, extRhoH,
                 divu, use_react, leosparm);
             }
           });
@@ -149,10 +151,10 @@ PeleLM::calcDivU(
       {
         amrex::ParallelFor(
           bx,
-          [rhoY, T, SpecD, Fourier, DiffDiff, r, extRhoY, extRhoH, divu,
+          [rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho, extRhoY, extRhoH, divu,
            use_react, leosparm] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             compute_divu(
-              i, j, k, rhoY, T, SpecD, Fourier, DiffDiff, r, extRhoY, extRhoH,
+              i, j, k, rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho, extRhoY, extRhoH,
               divu, use_react, leosparm);
           });
       }

--- a/Source/PeleLMeX_Eos.cpp
+++ b/Source/PeleLMeX_Eos.cpp
@@ -102,7 +102,6 @@ PeleLM::calcDivU(
 #endif
 
       auto const& rhoY = ldata_p->state.const_array(mfi, FIRSTSPEC);
-      auto const& rhoH = ldata_p->state.const_array(mfi, RHOH);
       auto const& T = ldata_p->state.const_array(mfi, TEMP);
       auto const& SpecD = (a_time == AmrOldTime)
                             ? diffData->Dn[lev].const_array(mfi, 0)
@@ -119,7 +118,6 @@ PeleLM::calcDivU(
         ((m_do_react != 0) && (m_skipInstantRR == 0))
           ? RhoYdot.const_array(mfi)
           : ldata_p->state.const_array(mfi, FIRSTSPEC); // Dummy unused Array4
-      auto const& extRho = m_extSource[lev]->const_array(mfi, DENSITY);
       auto const& extRhoY = m_extSource[lev]->const_array(mfi, FIRSTSPEC);
       auto const& extRhoH = m_extSource[lev]->const_array(mfi, RHOH);
       auto const& divu = ldata_p->divu.array(mfi);
@@ -135,27 +133,27 @@ PeleLM::calcDivU(
       } else if (flagfab.getType(bx) != FabType::regular) { // EB containing
                                                             // boxes
         amrex::ParallelFor(
-          bx, [rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho, extRhoY,
-               extRhoH, divu, use_react, flag,
+          bx, [rhoY, T, SpecD, Fourier, DiffDiff, r, extRhoY, extRhoH, divu,
+               use_react, flag,
                leosparm] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             if (flag(i, j, k).isCovered()) {
               divu(i, j, k) = 0.0;
             } else {
               compute_divu(
-                i, j, k, rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho,
-                extRhoY, extRhoH, divu, use_react, leosparm);
+                i, j, k, rhoY, T, SpecD, Fourier, DiffDiff, r, extRhoY, extRhoH,
+                divu, use_react, leosparm);
             }
           });
       } else
 #endif
       {
         amrex::ParallelFor(
-          bx, [rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho, extRhoY,
-               extRhoH, divu, use_react,
-               leosparm] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+          bx,
+          [rhoY, T, SpecD, Fourier, DiffDiff, r, extRhoY, extRhoH, divu,
+           use_react, leosparm] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             compute_divu(
-              i, j, k, rhoY, rhoH, T, SpecD, Fourier, DiffDiff, r, extRho,
-              extRhoY, extRhoH, divu, use_react, leosparm);
+              i, j, k, rhoY, T, SpecD, Fourier, DiffDiff, r, extRhoY, extRhoH,
+              divu, use_react, leosparm);
           });
       }
     }

--- a/Source/PeleLMeX_K.H
+++ b/Source/PeleLMeX_K.H
@@ -199,11 +199,13 @@ compute_divu(
   int j,
   int k,
   amrex::Array4<const amrex::Real> const& rhoY,
+  amrex::Array4<const amrex::Real> const& rhoH,
   amrex::Array4<const amrex::Real> const& T,
   amrex::Array4<const amrex::Real> const& specDiff,
   amrex::Array4<const amrex::Real> const& tempDiff,
   amrex::Array4<const amrex::Real> const& specEnthDiff,
   amrex::Array4<const amrex::Real> const& rhoYdot,
+  amrex::Array4<const amrex::Real> const& extRho,
   amrex::Array4<const amrex::Real> const& extRhoY,
   amrex::Array4<const amrex::Real> const& extRhoH,
   amrex::Array4<amrex::Real> const& divu,
@@ -239,15 +241,25 @@ compute_divu(
     n *= 1.0e-4_rt; // CGS -> MKS conversion
   }
 
+  // Additional terms related to external forcing on density
+  amrex::Real hExtRho = rhoinv * rhoH(i,j,k) * extRho(i, j, k);
+  amrex::Real yExtRho[NUM_SPECIES] = {0.0};
+  for (int n = 0; n < NUM_SPECIES; n++) {
+    yExtRho[n] = y[n] * extRho(i, j, k);
+  }   
+
   amrex::Real denominv = 1.0_rt / (rho * cpmix * T(i, j, k));
   divu(i, j, k) =
-    (specEnthDiff(i, j, k) + tempDiff(i, j, k) + extRhoH(i, j, k)) * denominv;
+    denominv * (specEnthDiff(i, j, k) + tempDiff(i, j, k) 
+    + extRhoH(i, j, k) - hExtRho);
   for (int n = 0; n < NUM_SPECIES; n++) {
-    amrex::Real specTerm = specDiff(i, j, k, n) + extRhoY(i, j, k, n);
+    amrex::Real specTerm = 
+      specDiff(i, j, k, n) + extRhoY(i, j, k, n) - yExtRho[n];
     if (do_react != 0) {
       specTerm += rhoYdot(i, j, k, n);
     }
-    divu(i, j, k) += specTerm * (mwtinv[n] * Wbar * rhoinv - hi[n] * denominv);
+    divu(i, j, k) += specTerm * (mwtinv[n] * Wbar * rhoinv - hi[n] * denominv)
+                  + rhoinv * extRho(i, j, k);
   }
 }
 

--- a/Source/PeleLMeX_K.H
+++ b/Source/PeleLMeX_K.H
@@ -199,13 +199,11 @@ compute_divu(
   int j,
   int k,
   amrex::Array4<const amrex::Real> const& rhoY,
-  amrex::Array4<const amrex::Real> const& rhoH,
   amrex::Array4<const amrex::Real> const& T,
   amrex::Array4<const amrex::Real> const& specDiff,
   amrex::Array4<const amrex::Real> const& tempDiff,
   amrex::Array4<const amrex::Real> const& specEnthDiff,
   amrex::Array4<const amrex::Real> const& rhoYdot,
-  amrex::Array4<const amrex::Real> const& extRho,
   amrex::Array4<const amrex::Real> const& extRhoY,
   amrex::Array4<const amrex::Real> const& extRhoH,
   amrex::Array4<amrex::Real> const& divu,
@@ -241,25 +239,16 @@ compute_divu(
     n *= 1.0e-4_rt; // CGS -> MKS conversion
   }
 
-  // Additional terms related to external forcing on density
-  amrex::Real hExtRho = rhoinv * rhoH(i, j, k) * extRho(i, j, k);
-  amrex::Real yExtRho[NUM_SPECIES] = {0.0};
-  for (int n = 0; n < NUM_SPECIES; n++) {
-    yExtRho[n] = y[n] * extRho(i, j, k);
-  }
-
   amrex::Real denominv = 1.0_rt / (rho * cpmix * T(i, j, k));
-  divu(i, j, k) = denominv * (specEnthDiff(i, j, k) + tempDiff(i, j, k) +
-                              extRhoH(i, j, k) - hExtRho);
+  divu(i, j, k) =
+    (specEnthDiff(i, j, k) + tempDiff(i, j, k) + extRhoH(i, j, k)) * denominv;
   for (int n = 0; n < NUM_SPECIES; n++) {
-    amrex::Real specTerm =
-      specDiff(i, j, k, n) + extRhoY(i, j, k, n) - yExtRho[n];
+    amrex::Real specTerm = specDiff(i, j, k, n) + extRhoY(i, j, k, n);
     if (do_react != 0) {
       specTerm += rhoYdot(i, j, k, n);
     }
     divu(i, j, k) += specTerm * (mwtinv[n] * Wbar * rhoinv - hi[n] * denominv);
   }
-  divu(i, j, k) += rhoinv * extRho(i, j, k);
 }
 
 AMREX_GPU_DEVICE

--- a/Source/PeleLMeX_K.H
+++ b/Source/PeleLMeX_K.H
@@ -257,9 +257,9 @@ compute_divu(
     if (do_react != 0) {
       specTerm += rhoYdot(i, j, k, n);
     }
-    divu(i, j, k) += specTerm * (mwtinv[n] * Wbar * rhoinv - hi[n] * denominv) +
-                     rhoinv * extRho(i, j, k);
+    divu(i, j, k) += specTerm * (mwtinv[n] * Wbar * rhoinv - hi[n] * denominv);
   }
+  divu(i, j, k) += rhoinv * extRho(i, j, k);
 }
 
 AMREX_GPU_DEVICE

--- a/Source/PeleLMeX_K.H
+++ b/Source/PeleLMeX_K.H
@@ -242,24 +242,23 @@ compute_divu(
   }
 
   // Additional terms related to external forcing on density
-  amrex::Real hExtRho = rhoinv * rhoH(i,j,k) * extRho(i, j, k);
+  amrex::Real hExtRho = rhoinv * rhoH(i, j, k) * extRho(i, j, k);
   amrex::Real yExtRho[NUM_SPECIES] = {0.0};
   for (int n = 0; n < NUM_SPECIES; n++) {
     yExtRho[n] = y[n] * extRho(i, j, k);
-  }   
+  }
 
   amrex::Real denominv = 1.0_rt / (rho * cpmix * T(i, j, k));
-  divu(i, j, k) =
-    denominv * (specEnthDiff(i, j, k) + tempDiff(i, j, k) 
-    + extRhoH(i, j, k) - hExtRho);
+  divu(i, j, k) = denominv * (specEnthDiff(i, j, k) + tempDiff(i, j, k) +
+                              extRhoH(i, j, k) - hExtRho);
   for (int n = 0; n < NUM_SPECIES; n++) {
-    amrex::Real specTerm = 
+    amrex::Real specTerm =
       specDiff(i, j, k, n) + extRhoY(i, j, k, n) - yExtRho[n];
     if (do_react != 0) {
       specTerm += rhoYdot(i, j, k, n);
     }
-    divu(i, j, k) += specTerm * (mwtinv[n] * Wbar * rhoinv - hi[n] * denominv)
-                  + rhoinv * extRho(i, j, k);
+    divu(i, j, k) += specTerm * (mwtinv[n] * Wbar * rhoinv - hi[n] * denominv) +
+                     rhoinv * extRho(i, j, k);
   }
 }
 

--- a/Source/PeleLMeX_K.H
+++ b/Source/PeleLMeX_K.H
@@ -239,6 +239,7 @@ compute_divu(
     n *= 1.0e-4_rt; // CGS -> MKS conversion
   }
 
+  // Note: divu does not depend on extRho. See docs and PR #428 for details.
   amrex::Real denominv = 1.0_rt / (rho * cpmix * T(i, j, k));
   divu(i, j, k) =
     (specEnthDiff(i, j, k) + tempDiff(i, j, k) + extRhoH(i, j, k)) * denominv;


### PR DESCRIPTION
This PR updates the divu constraint to be compatible with arbitrary source terms.  This is necessary for system closure in any model that introduces external sources on density (e.g. Spray).  This should be consistent with the user defined sources proposed in [PR #427](https://github.com/AMReX-Combustion/PeleLMeX/pull/427).