### PR TITLE
add error check on pressure matching for Manifold EOS

### DIFF
--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -316,6 +316,7 @@ public:
    * parameters.
    */
   void checkRunParams();
+  void checkSetupParams();
 
   //-----------------------------------------------------------------------------
   // REGRID / LOAD BALANCE


### PR DESCRIPTION
In the Manifold EOS, the nominal pressure for the manifold model must be specified. This pressure should match the Pmean specified for PeleLMeX in the prob structure, although one is in cgs units and the other is in mks units. 