### PR TITLE
fix RY2R calc in regrid for manifold

### DIFF
--- a/Source/PeleLMeX_Eos.cpp
+++ b/Source/PeleLMeX_Eos.cpp
@@ -194,10 +194,9 @@ PeleLM::setRhoToSumRhoY(int lev, const TimeStamp& a_time)
   amrex::ParallelFor(
     ldata_p->state,
     [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) noexcept {
-      sma[box_no](i, j, k, DENSITY) = 0.0;
-      for (int n = 0; n < NUM_SPECIES; n++) {
-        sma[box_no](i, j, k, DENSITY) += sma[box_no](i, j, k, FIRSTSPEC + n);
-      }
+      pele::physics::PhysicsType::eos_type::RY2R(
+        sma[box_no].cellData(i, j, k), sma[box_no](i, j, k, DENSITY),
+        FIRSTSPEC);
     });
   Gpu::streamSynchronize();
 }


### PR DESCRIPTION
This should correct the errors when regriding while running with manifold models.