### PR TITLE
Add option to plot external sources

### DIFF
--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -120,6 +120,7 @@ IO parameters
     amr.file_stepDigits  = 6               # [OPT, DEF=5] Number of digits when adding nsteps to plt and chk names
     amr.derive_plot_vars = avg_pressure ...# [OPT, DEF=""] List of derived variable included in the plot files
     amr.plot_speciesState = 0              # [OPT, DEF=0] Force adding state rhoYs to the plot files
+    peleLM.plot_extSource = false          # [OPT, DEF=false] Force adding state external sources to the plot files
 
     amr.restart          = chk00100        # [OPT, DEF=""] Checkpoint from which to restart the simulation
     amr.initDataPlt      = plt01000        # [OPT, DEF=""] Provide a plotfile from which to extract initial data
@@ -229,8 +230,9 @@ The following list of derived variables are available in PeleLMeX:
 
 Note that `mixture_fraction` and `progress_variable` requires additional inputs from the users as described below.
 The `derUserDefined` allow the user to define its own derived variable which can comprise several components. To do
-so, the user need to copy the Source/DeriveUserDefined.cpp file into his run folder and update the file. The number of
-components is defined based on the size of the vector returned by pelelmex_setuserderives().
+so, the user need to copy the Source/DeriveUserDefined.cpp file into their run folder and update the file. The number of
+components is defined based on the size of the vector returned by `pelelmex_setuserderives()`.  Be sure to add the 
+user derived variables to the input file via `amr.derive_plot_vars`.  
 
 PeleLMeX algorithm
 ------------------

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -888,6 +888,7 @@ public:
   //-----------------------------------------------------------------------------
   // External Sources
   bool m_user_defined_ext_sources;
+  bool m_plot_extSource;
   bool m_ext_sources_SDC;
   void getExternalSources(
     int is_initIter,

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -165,6 +165,11 @@ PeleLM::WritePlotFile()
     ncomp += 1;
   }
 
+  if (m_plot_extSource) {
+    // Plot state
+    ncomp += NVAR;
+  }
+
   //----------------------------------------------------------------
   // Plot MultiFabs
   Vector<MultiFab> mf_plt(finest_level + 1);
@@ -287,6 +292,13 @@ PeleLM::WritePlotFile()
     plt_VarsName.push_back(m_ode_names[n]);
   }
 #endif
+
+  // External source terms
+  if (m_plot_extSource) {
+    for (int ivar = 0; ivar < NVAR; ++ivar) {
+      plt_VarsName.push_back("extsource_" + stateVariableName(ivar));
+    }
+  }
 
   //----------------------------------------------------------------
   // Fill the plot MultiFabs
@@ -436,6 +448,12 @@ PeleLM::WritePlotFile()
               +mut_arr_z[box_no](i, j, k) + mut_arr_z[box_no](i, j, k + 1)));
         });
       Gpu::streamSynchronize();
+    }
+
+    cnt += 1;
+
+    if (m_plot_extSource) {
+      MultiFab::Copy(mf_plt[lev], *m_extSource[lev], 0, cnt, NVAR, 0);
     }
 
 #ifdef AMREX_USE_EB

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -756,7 +756,9 @@ PeleLM::readParameters()
   // -----------------------------------------
   m_user_defined_ext_sources = false;
   m_ext_sources_SDC = false; // TODO: add capability to update ext_srcs in SDC
+  m_plot_extSource = false;
   pp.query("user_defined_ext_sources", m_user_defined_ext_sources);
+  pp.query("plot_extSource", m_plot_extSource);
 }
 
 void


### PR DESCRIPTION
This PR includes a runtime option `peleLM.plot_extSource` for adding external sources to the plot files.  