### PR TITLE
From prior commit: fix bug with indexing in plt when LES is not active 

### DIFF
--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -448,9 +448,8 @@ PeleLM::WritePlotFile()
               +mut_arr_z[box_no](i, j, k) + mut_arr_z[box_no](i, j, k + 1)));
         });
       Gpu::streamSynchronize();
+      cnt += 1;
     }
-
-    cnt += 1;
 
     if (m_plot_extSource) {
       MultiFab::Copy(mf_plt[lev], *m_extSource[lev], 0, cnt, NVAR, 0);


### PR DESCRIPTION
In the plotting routine, the counter should only increment for plotting the LES stuff when using LES.

@dmontgomeryNREL: note that this means all the source terms you've been looking at are probably off by one - it may not actually be the enthalpy source term that's going crazy in your case.