### PR TITLE
Template BCFill functions to reduce repeated code

### DIFF
--- a/Source/Efield/PeleLMeX_EFUtils.cpp
+++ b/Source/Efield/PeleLMeX_EFUtils.cpp
@@ -294,20 +294,22 @@ PeleLM::fillPatchNLnE(Real a_time, Vector<MultiFab*> const& a_nE, int a_nGrow)
 
   int lev = 0;
   {
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirnE>> bndry_func(
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<NE, 1>>> bndry_func(
       geom[lev], fetchBCRecArray(NE, 1),
-      PeleLMCCFillExtDirnE{lprobparm, lpmfdata, m_nAux});
+      PeleLMCCFillExtDirState<NE, 1>{lprobparm, lpmfdata, m_nAux});
     FillPatchSingleLevel(
       *a_nE[lev], IntVect(a_nGrow), a_time, {a_nE[lev]}, {a_time}, 0, 0, 1,
       geom[lev], bndry_func, 0);
   }
   for (lev = 1; lev <= finest_level; ++lev) {
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirnE>> crse_bndry_func(
-      geom[lev - 1], fetchBCRecArray(NE, 1),
-      PeleLMCCFillExtDirnE{lprobparm, lpmfdata, m_nAux});
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirnE>> fine_bndry_func(
-      geom[lev], fetchBCRecArray(NE, 1),
-      PeleLMCCFillExtDirnE{lprobparm, lpmfdata, m_nAux});
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<NE, 1>>>
+      crse_bndry_func(
+        geom[lev - 1], fetchBCRecArray(NE, 1),
+        PeleLMCCFillExtDirState<NE, 1>{lprobparm, lpmfdata, m_nAux});
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<NE, 1>>>
+      fine_bndry_func(
+        geom[lev], fetchBCRecArray(NE, 1),
+        PeleLMCCFillExtDirState<NE, 1>{lprobparm, lpmfdata, m_nAux});
 
     auto* mapper = getInterpolator();
     FillPatchTwoLevels(
@@ -327,20 +329,22 @@ PeleLM::fillPatchNLphiV(
 
   int lev = 0;
   {
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirPhiV>> bndry_func(
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<PHIV, 1>>> bndry_func(
       geom[lev], fetchBCRecArray(PHIV, 1),
-      PeleLMCCFillExtDirPhiV{lprobparm, lpmfdata, m_nAux});
+      PeleLMCCFillExtDirState<PHIV, 1>{lprobparm, lpmfdata, m_nAux});
     FillPatchSingleLevel(
       *a_phiV[lev], IntVect(a_nGrow), a_time, {a_phiV[lev]}, {a_time}, 0, 0, 1,
       geom[lev], bndry_func, 0);
   }
   for (lev = 1; lev <= finest_level; ++lev) {
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirPhiV>> crse_bndry_func(
-      geom[lev - 1], fetchBCRecArray(PHIV, 1),
-      PeleLMCCFillExtDirPhiV{lprobparm, lpmfdata, m_nAux});
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirPhiV>> fine_bndry_func(
-      geom[lev], fetchBCRecArray(PHIV, 1),
-      PeleLMCCFillExtDirPhiV{lprobparm, lpmfdata, m_nAux});
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<PHIV, 1>>>
+      crse_bndry_func(
+        geom[lev - 1], fetchBCRecArray(PHIV, 1),
+        PeleLMCCFillExtDirState<PHIV, 1>{lprobparm, lpmfdata, m_nAux});
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<PHIV, 1>>>
+      fine_bndry_func(
+        geom[lev], fetchBCRecArray(PHIV, 1),
+        PeleLMCCFillExtDirState<PHIV, 1>{lprobparm, lpmfdata, m_nAux});
 
     auto* mapper = getInterpolator();
     FillPatchTwoLevels(

--- a/Source/PeleLMeX_BC.cpp
+++ b/Source/PeleLMeX_BC.cpp
@@ -356,9 +356,9 @@ PeleLM::fillpatch_state(
   fillTurbInflow(a_state, VELX, lev, a_time);
 
   if (lev == 0) {
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState>> bndry_func(
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<0, NVAR>>> bndry_func(
       geom[lev], fetchBCRecArray(0, nCompState),
-      PeleLMCCFillExtDirState{
+      PeleLMCCFillExtDirState<0, NVAR>{
         lprobparm, lpmfdata, m_nAux,
         static_cast<int>(turb_inflow.is_initialized())});
     FillPatchSingleLevel(
@@ -370,16 +370,18 @@ PeleLM::fillpatch_state(
     // Interpolator
     auto* mapper = getInterpolator();
 
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState>> crse_bndry_func(
-      geom[lev - 1], fetchBCRecArray(0, nCompState),
-      PeleLMCCFillExtDirState{
-        lprobparm, lpmfdata, m_nAux,
-        static_cast<int>(turb_inflow.is_initialized())});
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState>> fine_bndry_func(
-      geom[lev], fetchBCRecArray(0, nCompState),
-      PeleLMCCFillExtDirState{
-        lprobparm, lpmfdata, m_nAux,
-        static_cast<int>(turb_inflow.is_initialized())});
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<0, NVAR>>>
+      crse_bndry_func(
+        geom[lev - 1], fetchBCRecArray(0, nCompState),
+        PeleLMCCFillExtDirState<0, NVAR>{
+          lprobparm, lpmfdata, m_nAux,
+          static_cast<int>(turb_inflow.is_initialized())});
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<0, NVAR>>>
+      fine_bndry_func(
+        geom[lev], fetchBCRecArray(0, nCompState),
+        PeleLMCCFillExtDirState<0, NVAR>{
+          lprobparm, lpmfdata, m_nAux,
+          static_cast<int>(turb_inflow.is_initialized())});
     FillPatchTwoLevels(
       a_state, IntVect(nGhost), a_time,
       {&(m_leveldata_old[lev - 1]->state), &(m_leveldata_new[lev - 1]->state)},
@@ -407,9 +409,10 @@ PeleLM::fillpatch_density(
   if (lev == 0) {
 
     // Density
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirDens>> bndry_func_rho(
-      geom[lev], fetchBCRecArray(DENSITY, 1),
-      PeleLMCCFillExtDirDens{lprobparm, lpmfdata, m_nAux});
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<DENSITY, 1>>>
+      bndry_func_rho(
+        geom[lev], fetchBCRecArray(DENSITY, 1),
+        PeleLMCCFillExtDirState<DENSITY, 1>{lprobparm, lpmfdata, m_nAux});
     FillPatchSingleLevel(
       a_density, IntVect(nGhost), a_time,
       {&(m_leveldata_old[lev]->state), &(m_leveldata_new[lev]->state)},
@@ -422,12 +425,14 @@ PeleLM::fillpatch_density(
     auto* mapper = getInterpolator();
 
     // Density
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirDens>> crse_bndry_func_rho(
-      geom[lev - 1], fetchBCRecArray(DENSITY, 1),
-      PeleLMCCFillExtDirDens{lprobparm, lpmfdata, m_nAux});
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirDens>> fine_bndry_func_rho(
-      geom[lev], fetchBCRecArray(DENSITY, 1),
-      PeleLMCCFillExtDirDens{lprobparm, lpmfdata, m_nAux});
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<DENSITY, 1>>>
+      crse_bndry_func_rho(
+        geom[lev - 1], fetchBCRecArray(DENSITY, 1),
+        PeleLMCCFillExtDirState<DENSITY, 1>{lprobparm, lpmfdata, m_nAux});
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<DENSITY, 1>>>
+      fine_bndry_func_rho(
+        geom[lev], fetchBCRecArray(DENSITY, 1),
+        PeleLMCCFillExtDirState<DENSITY, 1>{lprobparm, lpmfdata, m_nAux});
     FillPatchTwoLevels(
       a_density, IntVect(nGhost), a_time,
       {&(m_leveldata_old[lev - 1]->state), &(m_leveldata_new[lev - 1]->state)},
@@ -453,9 +458,12 @@ PeleLM::fillpatch_species(
   if (lev == 0) {
 
     // Species
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirSpec>> bndry_func(
-      geom[lev], fetchBCRecArray(FIRSTSPEC, NUM_SPECIES),
-      PeleLMCCFillExtDirSpec{lprobparm, lpmfdata, m_nAux});
+    PhysBCFunct<
+      GpuBndryFuncFab<PeleLMCCFillExtDirState<FIRSTSPEC, NUM_SPECIES>>>
+      bndry_func(
+        geom[lev], fetchBCRecArray(FIRSTSPEC, NUM_SPECIES),
+        PeleLMCCFillExtDirState<FIRSTSPEC, NUM_SPECIES>{
+          lprobparm, lpmfdata, m_nAux});
     FillPatchSingleLevel(
       a_species, IntVect(nGhost), a_time,
       {&(m_leveldata_old[lev]->state), &(m_leveldata_new[lev]->state)},
@@ -467,12 +475,18 @@ PeleLM::fillpatch_species(
     auto* mapper = getInterpolator();
 
     // Species
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirSpec>> crse_bndry_func(
-      geom[lev - 1], fetchBCRecArray(FIRSTSPEC, NUM_SPECIES),
-      PeleLMCCFillExtDirSpec{lprobparm, lpmfdata, m_nAux});
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirSpec>> fine_bndry_func(
-      geom[lev], fetchBCRecArray(FIRSTSPEC, NUM_SPECIES),
-      PeleLMCCFillExtDirSpec{lprobparm, lpmfdata, m_nAux});
+    PhysBCFunct<
+      GpuBndryFuncFab<PeleLMCCFillExtDirState<FIRSTSPEC, NUM_SPECIES>>>
+      crse_bndry_func(
+        geom[lev - 1], fetchBCRecArray(FIRSTSPEC, NUM_SPECIES),
+        PeleLMCCFillExtDirState<FIRSTSPEC, NUM_SPECIES>{
+          lprobparm, lpmfdata, m_nAux});
+    PhysBCFunct<
+      GpuBndryFuncFab<PeleLMCCFillExtDirState<FIRSTSPEC, NUM_SPECIES>>>
+      fine_bndry_func(
+        geom[lev], fetchBCRecArray(FIRSTSPEC, NUM_SPECIES),
+        PeleLMCCFillExtDirState<FIRSTSPEC, NUM_SPECIES>{
+          lprobparm, lpmfdata, m_nAux});
     FillPatchTwoLevels(
       a_species, IntVect(nGhost), a_time,
       {&(m_leveldata_old[lev - 1]->state), &(m_leveldata_new[lev - 1]->state)},
@@ -496,9 +510,9 @@ PeleLM::fillpatch_temp(
   ProbParm const* lprobparm = prob_parm_d;
   auto const* lpmfdata = pmf_data.device_parm();
   if (lev == 0) {
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirTemp>> bndry_func(
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<TEMP, 1>>> bndry_func(
       geom[lev], fetchBCRecArray(TEMP, 1),
-      PeleLMCCFillExtDirTemp{lprobparm, lpmfdata, m_nAux});
+      PeleLMCCFillExtDirState<TEMP, 1>{lprobparm, lpmfdata, m_nAux});
     FillPatchSingleLevel(
       a_temp, IntVect(nGhost), a_time,
       {&(m_leveldata_old[lev]->state), &(m_leveldata_new[lev]->state)},
@@ -509,12 +523,14 @@ PeleLM::fillpatch_temp(
     // Interpolator
     auto* mapper = getInterpolator();
 
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirTemp>> crse_bndry_func(
-      geom[lev - 1], fetchBCRecArray(TEMP, 1),
-      PeleLMCCFillExtDirTemp{lprobparm, lpmfdata, m_nAux});
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirTemp>> fine_bndry_func(
-      geom[lev], fetchBCRecArray(TEMP, 1),
-      PeleLMCCFillExtDirTemp{lprobparm, lpmfdata, m_nAux});
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<TEMP, 1>>>
+      crse_bndry_func(
+        geom[lev - 1], fetchBCRecArray(TEMP, 1),
+        PeleLMCCFillExtDirState<TEMP, 1>{lprobparm, lpmfdata, m_nAux});
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<TEMP, 1>>>
+      fine_bndry_func(
+        geom[lev], fetchBCRecArray(TEMP, 1),
+        PeleLMCCFillExtDirState<TEMP, 1>{lprobparm, lpmfdata, m_nAux});
     FillPatchTwoLevels(
       a_temp, IntVect(nGhost), a_time,
       {&(m_leveldata_old[lev - 1]->state), &(m_leveldata_new[lev - 1]->state)},
@@ -539,9 +555,9 @@ PeleLM::fillpatch_phiV(
   ProbParm const* lprobparm = prob_parm_d;
   auto const* lpmfdata = pmf_data.device_parm();
   if (lev == 0) {
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirPhiV>> bndry_func(
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<PHIV, 1>>> bndry_func(
       geom[lev], fetchBCRecArray(PHIV, 1),
-      PeleLMCCFillExtDirPhiV{lprobparm, lpmfdata, m_nAux});
+      PeleLMCCFillExtDirState<PHIV, 1>{lprobparm, lpmfdata, m_nAux});
     FillPatchSingleLevel(
       a_temp, IntVect(nGhost), a_time,
       {&(m_leveldata_old[lev]->state), &(m_leveldata_new[lev]->state)},
@@ -552,12 +568,14 @@ PeleLM::fillpatch_phiV(
     // Interpolator
     auto* mapper = getInterpolator();
 
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirPhiV>> crse_bndry_func(
-      geom[lev - 1], fetchBCRecArray(PHIV, 1),
-      PeleLMCCFillExtDirPhiV{lprobparm, lpmfdata, m_nAux});
-    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirPhiV>> fine_bndry_func(
-      geom[lev], fetchBCRecArray(PHIV, 1),
-      PeleLMCCFillExtDirPhiV{lprobparm, lpmfdata, m_nAux});
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<PHIV, 1>>>
+      crse_bndry_func(
+        geom[lev - 1], fetchBCRecArray(PHIV, 1),
+        PeleLMCCFillExtDirState<PHIV, 1>{lprobparm, lpmfdata, m_nAux});
+    PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<PHIV, 1>>>
+      fine_bndry_func(
+        geom[lev], fetchBCRecArray(PHIV, 1),
+        PeleLMCCFillExtDirState<PHIV, 1>{lprobparm, lpmfdata, m_nAux});
     FillPatchTwoLevels(
       a_temp, IntVect(nGhost), a_time,
       {&(m_leveldata_old[lev - 1]->state), &(m_leveldata_new[lev - 1]->state)},
@@ -749,16 +767,18 @@ PeleLM::fillcoarsepatch_state(
   // Interpolator
   auto* mapper = getInterpolator(m_regrid_interp_method);
 
-  PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState>> crse_bndry_func(
-    geom[lev - 1], fetchBCRecArray(0, nCompState),
-    PeleLMCCFillExtDirState{
-      lprobparm, lpmfdata, m_nAux,
-      static_cast<int>(turb_inflow.is_initialized())});
-  PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState>> fine_bndry_func(
-    geom[lev], fetchBCRecArray(0, nCompState),
-    PeleLMCCFillExtDirState{
-      lprobparm, lpmfdata, m_nAux,
-      static_cast<int>(turb_inflow.is_initialized())});
+  PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<0, NVAR>>>
+    crse_bndry_func(
+      geom[lev - 1], fetchBCRecArray(0, nCompState),
+      PeleLMCCFillExtDirState<0, NVAR>{
+        lprobparm, lpmfdata, m_nAux,
+        static_cast<int>(turb_inflow.is_initialized())});
+  PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<0, NVAR>>>
+    fine_bndry_func(
+      geom[lev], fetchBCRecArray(0, nCompState),
+      PeleLMCCFillExtDirState<0, NVAR>{
+        lprobparm, lpmfdata, m_nAux,
+        static_cast<int>(turb_inflow.is_initialized())});
   InterpFromCoarseLevel(
     a_state, IntVect(nGhost), a_time, m_leveldata_new[lev - 1]->state, 0, 0,
     nCompState, geom[lev - 1], geom[lev], crse_bndry_func, 0, fine_bndry_func,
@@ -877,9 +897,9 @@ PeleLM::setInflowBoundaryVel(MultiFab& a_vel, int lev, TimeStamp a_time)
 
   ProbParm const* lprobparm = prob_parm_d;
   auto const* lpmfdata = pmf_data.device_parm();
-  PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState>> bndry_func(
+  PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirState<0, NVAR>>> bndry_func(
     geom[lev], dummyVelBCRec,
-    PeleLMCCFillExtDirState{
+    PeleLMCCFillExtDirState<0, NVAR>{
       lprobparm, lpmfdata, m_nAux,
       static_cast<int>(turb_inflow.is_initialized())});
 

--- a/Source/PeleLMeX_BCfill.H
+++ b/Source/PeleLMeX_BCfill.H
@@ -8,6 +8,7 @@
 
 using namespace amrex;
 
+template <int start_fill, int n_fill>
 struct PeleLMCCFillExtDirState
 {
 
@@ -21,7 +22,7 @@ struct PeleLMCCFillExtDirState
     ProbParm const* a_prob_parm,
     pele::physics::PMF::PmfData::DataContainer const* a_pmf_data,
     int a_nAux,
-    int do_turbInflow)
+    int do_turbInflow = 0)
     : lprobparm(a_prob_parm),
       lpmfdata(a_pmf_data),
       m_nAux(a_nAux),
@@ -33,7 +34,7 @@ struct PeleLMCCFillExtDirState
   void operator()(
     const amrex::IntVect& iv,
     amrex::Array4<amrex::Real> const& state,
-    const int /*dcomp*/,
+    const int dcomp,
     const int numcomp,
     amrex::GeometryData const& geom,
     const amrex::Real time,
@@ -54,7 +55,7 @@ struct PeleLMCCFillExtDirState
     for (int idir = 0; idir < AMREX_SPACEDIM; idir++) {
 
       // Low
-      for (int n = 0; n < std::min(numcomp, NVAR); n++) {
+      for (int n = 0; n < std::min(numcomp, n_fill); n++) {
 
         // bcnormal handles all the state components at once
         amrex::Real s_ext[NVAR] = {0.0};
@@ -83,7 +84,7 @@ struct PeleLMCCFillExtDirState
       }
 
       // High
-      for (int n = 0; n < std::min(numcomp, NVAR); n++) {
+      for (int n = 0; n < std::min(numcomp, n_fill); n++) {
 
         // bcnormal handles all the state components at once
         amrex::Real s_ext[NVAR] = {0.0};
@@ -98,7 +99,7 @@ struct PeleLMCCFillExtDirState
           // If using TurbInflow, pass in the turbulent data. User can overwrite
           // if needed
           if (m_do_turbInflow != 0) {
-            if (n >= VELX && n < DENSITY) {
+            if (start_fill + n >= VELX && start_fill + n < DENSITY) {
               if (!isnan(
                     state(iv, VELX + n))) { // During fillcoarsepatch, get here
                                             // with nan. TODO: find a better fix
@@ -110,434 +111,12 @@ struct PeleLMCCFillExtDirState
           // /Exec
           bcnormal(
             x, m_nAux, s_ext, idir, -1, time, geom, *lprobparm, lpmfdata);
-          state(iv, n) = s_ext[n];
+          state(iv, dcomp + n) = s_ext[start_fill + n];
         }
       }
     }
   }
 };
-
-struct PeleLMCCFillExtDirSpec
-{
-
-  ProbParm const* lprobparm;
-  pele::physics::PMF::PmfData::DataContainer const* lpmfdata;
-  const int m_nAux;
-
-  AMREX_GPU_HOST
-  constexpr PeleLMCCFillExtDirSpec(
-    ProbParm const* a_prob_parm,
-    pele::physics::PMF::PmfData::DataContainer const* a_pmf_data,
-    int a_nAux)
-    : lprobparm(a_prob_parm), lpmfdata(a_pmf_data), m_nAux(a_nAux)
-  {
-  }
-
-  AMREX_GPU_DEVICE
-  void operator()(
-    const amrex::IntVect& iv,
-    amrex::Array4<amrex::Real> const& rhoY,
-    const int dcomp,
-    const int /*numcomp*/,
-    amrex::GeometryData const& geom,
-    const amrex::Real time,
-    const amrex::BCRec* bcr,
-    const int /*bcomp*/,
-    const int /*orig_comp*/) const
-  {
-
-    // Get geometry data
-    const int* domlo = geom.Domain().loVect();
-    const int* domhi = geom.Domain().hiVect();
-    const amrex::Real* prob_lo = geom.ProbLo();
-    const amrex::Real* dx = geom.CellSize();
-    const amrex::Real x[AMREX_SPACEDIM] = {AMREX_D_DECL(
-      prob_lo[0] + (iv[0] + 0.5) * dx[0], prob_lo[1] + (iv[1] + 0.5) * dx[1],
-      prob_lo[2] + (iv[2] + 0.5) * dx[2])};
-
-    for (int n = 0; n < NUM_SPECIES; n++) {
-
-      // Get the species component BC
-      const int* bc = bcr[n].data();
-
-      // bcnormal handles all the state components at once
-      amrex::Real s_ext[NVAR] = {0.0};
-
-      for (int idir = 0; idir < AMREX_SPACEDIM; idir++) {
-        // Low
-        if ((bc[idir] == amrex::BCType::ext_dir) and (iv[idir] < domlo[idir])) {
-
-          // bcnormal() is defined in pelelmex_prob.H in problem directory in
-          // /Exec
-          bcnormal(x, m_nAux, s_ext, idir, 1, time, geom, *lprobparm, lpmfdata);
-
-          rhoY(iv, dcomp + n) = s_ext[FIRSTSPEC + n];
-
-          // High
-        } else if (
-          (bc[idir + AMREX_SPACEDIM] == amrex::BCType::ext_dir) and
-          (iv[idir] > domhi[idir])) {
-
-          // bcnormal() is defined in pelelmex_prob.H in problem directory in
-          // /Exec
-          bcnormal(
-            x, m_nAux, s_ext, idir, -1, time, geom, *lprobparm, lpmfdata);
-
-          rhoY(iv, dcomp + n) = s_ext[FIRSTSPEC + n];
-        }
-      }
-    }
-  }
-};
-
-struct PeleLMCCFillExtDirDens
-{
-
-  ProbParm const* lprobparm;
-  pele::physics::PMF::PmfData::DataContainer const* lpmfdata;
-  const int m_nAux;
-
-  AMREX_GPU_HOST
-  constexpr PeleLMCCFillExtDirDens(
-    ProbParm const* a_prob_parm,
-    pele::physics::PMF::PmfData::DataContainer const* a_pmf_data,
-    int a_nAux)
-    : lprobparm(a_prob_parm), lpmfdata(a_pmf_data), m_nAux(a_nAux)
-  {
-  }
-
-  AMREX_GPU_DEVICE
-  void operator()(
-    const amrex::IntVect& iv,
-    amrex::Array4<amrex::Real> const& state,
-    const int dcomp,
-    const int /*numcomp*/,
-    amrex::GeometryData const& geom,
-    const amrex::Real time,
-    const amrex::BCRec* bcr,
-    const int /*bcomp*/,
-    const int /*orig_comp*/) const
-  {
-
-    // Get geometry data
-    const int* domlo = geom.Domain().loVect();
-    const int* domhi = geom.Domain().hiVect();
-    const amrex::Real* prob_lo = geom.ProbLo();
-    const amrex::Real* dx = geom.CellSize();
-    const amrex::Real x[AMREX_SPACEDIM] = {AMREX_D_DECL(
-      prob_lo[0] + (iv[0] + 0.5) * dx[0], prob_lo[1] + (iv[1] + 0.5) * dx[1],
-      prob_lo[2] + (iv[2] + 0.5) * dx[2])};
-
-    // Get the first species component BC
-    const int* bc = bcr->data();
-
-    // bcnormal handles all the state components at once
-    amrex::Real s_ext[NVAR] = {0.0};
-
-    for (int idir = 0; idir < AMREX_SPACEDIM; idir++) {
-      // Low
-      if ((bc[idir] == amrex::BCType::ext_dir) and (iv[idir] < domlo[idir])) {
-
-        // bcnormal() is defined in pelelmex_prob.H in problem directory in
-        // /Exec
-        bcnormal(x, m_nAux, s_ext, idir, 1, time, geom, *lprobparm, lpmfdata);
-
-        state(iv, dcomp) = s_ext[DENSITY];
-
-        // High
-      } else if (
-        (bc[idir + AMREX_SPACEDIM] == amrex::BCType::ext_dir) and
-        (iv[idir] > domhi[idir])) {
-
-        // bcnormal() is defined in pelelmex_prob.H in problem directory in
-        // /Exec
-        bcnormal(x, m_nAux, s_ext, idir, -1, time, geom, *lprobparm, lpmfdata);
-
-        state(iv, dcomp) = s_ext[DENSITY];
-      }
-    }
-  }
-};
-
-struct PeleLMCCFillExtDirRhoH
-{
-
-  ProbParm const* lprobparm;
-  pele::physics::PMF::PmfData::DataContainer const* lpmfdata;
-  const int m_nAux;
-
-  AMREX_GPU_HOST
-  constexpr PeleLMCCFillExtDirRhoH(
-    ProbParm const* a_prob_parm,
-    pele::physics::PMF::PmfData::DataContainer const* a_pmf_data,
-    int a_nAux)
-    : lprobparm(a_prob_parm), lpmfdata(a_pmf_data), m_nAux(a_nAux)
-  {
-  }
-
-  AMREX_GPU_DEVICE
-  void operator()(
-    const amrex::IntVect& iv,
-    amrex::Array4<amrex::Real> const& rhoH,
-    const int /*dcomp*/,
-    const int /*numcomp*/,
-    amrex::GeometryData const& geom,
-    const amrex::Real time,
-    const amrex::BCRec* bcr,
-    const int /*bcomp*/,
-    const int /*orig_comp*/) const
-  {
-
-    // Get geometry data
-    const int* domlo = geom.Domain().loVect();
-    const int* domhi = geom.Domain().hiVect();
-    const amrex::Real* prob_lo = geom.ProbLo();
-    const amrex::Real* dx = geom.CellSize();
-    const amrex::Real x[AMREX_SPACEDIM] = {AMREX_D_DECL(
-      prob_lo[0] + (iv[0] + 0.5) * dx[0], prob_lo[1] + (iv[1] + 0.5) * dx[1],
-      prob_lo[2] + (iv[2] + 0.5) * dx[2])};
-
-    // Get the first species component BC
-    const int* bc = bcr->data();
-
-    // bcnormal handles all the state components at once
-    amrex::Real s_ext[NVAR] = {0.0};
-
-    for (int idir = 0; idir < AMREX_SPACEDIM; idir++) {
-      // Low
-      if ((bc[idir] == amrex::BCType::ext_dir) and (iv[idir] < domlo[idir])) {
-
-        // bcnormal() is defined in pelelmex_prob.H in problem directory in
-        // /Exec
-        bcnormal(x, m_nAux, s_ext, idir, 1, time, geom, *lprobparm, lpmfdata);
-
-        rhoH(iv) = s_ext[RHOH];
-
-        // High
-      } else if (
-        (bc[idir + AMREX_SPACEDIM] == amrex::BCType::ext_dir) and
-        (iv[idir] > domhi[idir])) {
-
-        // bcnormal() is defined in pelelmex_prob.H in problem directory in
-        // /Exec
-        bcnormal(x, m_nAux, s_ext, idir, -1, time, geom, *lprobparm, lpmfdata);
-
-        rhoH(iv) = s_ext[RHOH];
-      }
-    }
-  }
-};
-
-struct PeleLMCCFillExtDirTemp
-{
-
-  ProbParm const* lprobparm;
-  pele::physics::PMF::PmfData::DataContainer const* lpmfdata;
-  const int m_nAux;
-
-  AMREX_GPU_HOST
-  constexpr PeleLMCCFillExtDirTemp(
-    ProbParm const* a_prob_parm,
-    pele::physics::PMF::PmfData::DataContainer const* a_pmf_data,
-    int a_nAux)
-    : lprobparm(a_prob_parm), lpmfdata(a_pmf_data), m_nAux(a_nAux)
-  {
-  }
-
-  AMREX_GPU_DEVICE
-  void operator()(
-    const amrex::IntVect& iv,
-    amrex::Array4<amrex::Real> const& state,
-    const int dcomp,
-    const int /*numcomp*/,
-    amrex::GeometryData const& geom,
-    const amrex::Real time,
-    const amrex::BCRec* bcr,
-    const int /*bcomp*/,
-    const int /*orig_comp*/) const
-  {
-
-    // Get geometry data
-    const int* domlo = geom.Domain().loVect();
-    const int* domhi = geom.Domain().hiVect();
-    const amrex::Real* prob_lo = geom.ProbLo();
-    const amrex::Real* dx = geom.CellSize();
-    const amrex::Real x[AMREX_SPACEDIM] = {AMREX_D_DECL(
-      prob_lo[0] + (iv[0] + 0.5) * dx[0], prob_lo[1] + (iv[1] + 0.5) * dx[1],
-      prob_lo[2] + (iv[2] + 0.5) * dx[2])};
-
-    // Get the first species component BC
-    const int* bc = bcr->data();
-
-    // bcnormal handles all the state components at once
-    amrex::Real s_ext[NVAR] = {0.0};
-
-    for (int idir = 0; idir < AMREX_SPACEDIM; idir++) {
-      // Low
-      if ((bc[idir] == amrex::BCType::ext_dir) and (iv[idir] < domlo[idir])) {
-
-        // bcnormal() is defined in pelelmex_prob.H in problem directory in
-        // /Exec
-        bcnormal(x, m_nAux, s_ext, idir, 1, time, geom, *lprobparm, lpmfdata);
-
-        state(iv, dcomp) = s_ext[TEMP];
-
-        // High
-      } else if (
-        (bc[idir + AMREX_SPACEDIM] == amrex::BCType::ext_dir) and
-        (iv[idir] > domhi[idir])) {
-
-        // bcnormal() is defined in pelelmex_prob.H in problem directory in
-        // /Exec
-        bcnormal(x, m_nAux, s_ext, idir, -1, time, geom, *lprobparm, lpmfdata);
-
-        state(iv, dcomp) = s_ext[TEMP];
-      }
-    }
-  }
-};
-
-#ifdef PELE_USE_EFIELD
-struct PeleLMCCFillExtDirnE
-{
-
-  ProbParm const* lprobparm;
-  pele::physics::PMF::PmfData::DataContainer const* lpmfdata;
-  const int m_nAux;
-
-  AMREX_GPU_HOST
-  constexpr PeleLMCCFillExtDirnE(
-    ProbParm const* a_prob_parm,
-    pele::physics::PMF::PmfData::DataContainer const* a_pmf_data,
-    int a_nAux)
-    : lprobparm(a_prob_parm), lpmfdata(a_pmf_data), m_nAux(a_nAux)
-  {
-  }
-
-  AMREX_GPU_DEVICE
-  void operator()(
-    const amrex::IntVect& iv,
-    amrex::Array4<amrex::Real> const& nE,
-    const int /*dcomp*/,
-    const int /*numcomp*/,
-    amrex::GeometryData const& geom,
-    const amrex::Real time,
-    const amrex::BCRec* bcr,
-    const int /*bcomp*/,
-    const int /*orig_comp*/) const
-  {
-
-    // Get geometry data
-    const int* domlo = geom.Domain().loVect();
-    const int* domhi = geom.Domain().hiVect();
-    const amrex::Real* prob_lo = geom.ProbLo();
-    const amrex::Real* dx = geom.CellSize();
-    const amrex::Real x[AMREX_SPACEDIM] = {AMREX_D_DECL(
-      prob_lo[0] + (iv[0] + 0.5) * dx[0], prob_lo[1] + (iv[1] + 0.5) * dx[1],
-      prob_lo[2] + (iv[2] + 0.5) * dx[2])};
-
-    // Get the first species component BC
-    const int* bc = bcr->data();
-
-    // bcnormal handles all the state components at once
-    amrex::Real s_ext[NVAR] = {0.0};
-
-    for (int idir = 0; idir < AMREX_SPACEDIM; idir++) {
-      // Low
-      if ((bc[idir] == amrex::BCType::ext_dir) and (iv[idir] < domlo[idir])) {
-
-        // bcnormal() is defined in pelelmex_prob.H in problem directory in
-        // /Exec
-        bcnormal(x, m_nAux, s_ext, idir, 1, time, geom, *lprobparm, lpmfdata);
-
-        nE(iv) = s_ext[NE];
-
-        // High
-      } else if (
-        (bc[idir + AMREX_SPACEDIM] == amrex::BCType::ext_dir) and
-        (iv[idir] > domhi[idir])) {
-
-        // bcnormal() is defined in pelelmex_prob.H in problem directory in
-        // /Exec
-        bcnormal(x, m_nAux, s_ext, idir, -1, time, geom, *lprobparm, lpmfdata);
-
-        nE(iv) = s_ext[NE];
-      }
-    }
-  }
-};
-#endif
-
-#ifdef PELE_USE_EFIELD
-struct PeleLMCCFillExtDirPhiV
-{
-
-  ProbParm const* lprobparm;
-  pele::physics::PMF::PmfData::DataContainer const* lpmfdata;
-  const int m_nAux;
-
-  AMREX_GPU_HOST
-  constexpr PeleLMCCFillExtDirPhiV(
-    ProbParm const* a_prob_parm,
-    pele::physics::PMF::PmfData::DataContainer const* a_pmf_data,
-    int a_nAux)
-    : lprobparm(a_prob_parm), lpmfdata(a_pmf_data), m_nAux(a_nAux)
-  {
-  }
-
-  AMREX_GPU_DEVICE
-  void operator()(
-    const amrex::IntVect& iv,
-    amrex::Array4<amrex::Real> const& phiV,
-    const int dcomp,
-    const int /*numcomp*/,
-    amrex::GeometryData const& geom,
-    const amrex::Real time,
-    const amrex::BCRec* bcr,
-    const int /*bcomp*/,
-    const int /*orig_comp*/) const
-  {
-
-    // Get geometry data
-    const int* domlo = geom.Domain().loVect();
-    const int* domhi = geom.Domain().hiVect();
-    const amrex::Real* prob_lo = geom.ProbLo();
-    const amrex::Real* dx = geom.CellSize();
-    const amrex::Real x[AMREX_SPACEDIM] = {AMREX_D_DECL(
-      prob_lo[0] + (iv[0] + 0.5) * dx[0], prob_lo[1] + (iv[1] + 0.5) * dx[1],
-      prob_lo[2] + (iv[2] + 0.5) * dx[2])};
-
-    // Get the first species component BC
-    const int* bc = bcr->data();
-
-    // bcnormal handles all the state components at once
-    amrex::Real s_ext[NVAR] = {0.0};
-
-    for (int idir = 0; idir < AMREX_SPACEDIM; idir++) {
-      // Low
-      if ((bc[idir] == amrex::BCType::ext_dir) and (iv[idir] < domlo[idir])) {
-
-        // bcnormal() is defined in pelelmex_prob.H in problem directory in
-        // /Exec
-        bcnormal(x, m_nAux, s_ext, idir, 1, time, geom, *lprobparm, lpmfdata);
-
-        phiV(iv, dcomp) = s_ext[PHIV];
-
-        // High
-      } else if (
-        (bc[idir + AMREX_SPACEDIM] == amrex::BCType::ext_dir) and
-        (iv[idir] > domhi[idir])) {
-
-        // bcnormal() is defined in pelelmex_prob.H in problem directory in
-        // /Exec
-        bcnormal(x, m_nAux, s_ext, idir, -1, time, geom, *lprobparm, lpmfdata);
-
-        phiV(iv, dcomp) = s_ext[PHIV];
-      }
-    }
-  }
-};
-#endif
 
 struct PeleLMCCFillExtDirDummy
 {

--- a/Source/PeleLMeX_BCfill.H
+++ b/Source/PeleLMeX_BCfill.H
@@ -68,7 +68,7 @@ struct PeleLMCCFillExtDirState
           // If using TurbInflow, pass in the turbulent data. User can overwrite
           // if needed
           if (m_do_turbInflow != 0) {
-            if (n >= VELX && n < DENSITY) {
+            if ((start_fill + n >= VELX) && (start_fill + n < DENSITY)) {
               if (!isnan(
                     state(iv, VELX + n))) { // During fillcoarsepatch, get here
                                             // with nan. TODO: find a better fix
@@ -79,7 +79,7 @@ struct PeleLMCCFillExtDirState
           // bcnormal() is defined in pelelmex_prob.H in problem directory in
           // /Exec
           bcnormal(x, m_nAux, s_ext, idir, 1, time, geom, *lprobparm, lpmfdata);
-          state(iv, n) = s_ext[n];
+          state(iv, dcomp + n) = s_ext[start_fill + n];
         }
       }
 
@@ -99,7 +99,7 @@ struct PeleLMCCFillExtDirState
           // If using TurbInflow, pass in the turbulent data. User can overwrite
           // if needed
           if (m_do_turbInflow != 0) {
-            if (start_fill + n >= VELX && start_fill + n < DENSITY) {
+            if ((start_fill + n >= VELX) && (start_fill + n < DENSITY)) {
               if (!isnan(
                     state(iv, VELX + n))) { // During fillcoarsepatch, get here
                                             // with nan. TODO: find a better fix


### PR DESCRIPTION
Leaving as a draft for now pending further testing and other PRs currently in the queue that affect the same area of code. 

May also be able to do something similar to eliminate some of the `PeleLM::fillpatch_XXX` functions in PeleLMeX_BC.cpp.

