### PR TITLE
Fix ProbParm for HITDecay case on GPU

### DIFF
--- a/Exec/Production/ChallengeProblem/PeleLMeX_EBUserDefined.H
+++ b/Exec/Production/ChallengeProblem/PeleLMeX_EBUserDefined.H
@@ -33,56 +33,56 @@ EBUserDefined(
   scaleFact *= 0.01;     // MKS conversion
 
   if (!useFlatHead) {
-    p = amrex::RealVect(D_DECL(
+    p = amrex::RealVect(AMREX_D_DECL(
       radius * 1.1 * 0.1 * scaleFact, (7.8583 + zoffset) * 0.1 * scaleFact,
       0.0));
     lnpts.push_back(p);
-    p = amrex::RealVect(D_DECL(
+    p = amrex::RealVect(AMREX_D_DECL(
       36.193 * 0.1 * scaleFact, (7.8583 + zoffset) * 0.1 * scaleFact, 0.0));
     lnpts.push_back(p);
     Piston.addLineElement(lnpts);
     lnpts.clear();
 
-    p = amrex::RealVect(D_DECL(
+    p = amrex::RealVect(AMREX_D_DECL(
       36.193 * 0.1 * scaleFact, (7.8583 + zoffset) * 0.1 * scaleFact, 0.0));
     lnpts.push_back(p);
-    p = amrex::RealVect(D_DECL(
+    p = amrex::RealVect(AMREX_D_DECL(
       24.035 * 0.1 * scaleFact, (-7.8586 + zoffset) * 0.1 * scaleFact, 0.0));
     lnpts.push_back(p);
     Piston.addLineElement(lnpts);
     lnpts.clear();
 
-    p = amrex::RealVect(D_DECL(
+    p = amrex::RealVect(AMREX_D_DECL(
       24.035 * 0.1 * scaleFact, (-7.8586 + zoffset) * 0.1 * scaleFact, 0.0));
     lnpts.push_back(p);
-    p = amrex::RealVect(D_DECL(
+    p = amrex::RealVect(AMREX_D_DECL(
       20.0 * 0.1 * scaleFact, (-7.8586 + zoffset) * 0.1 * scaleFact, 0.0));
     lnpts.push_back(p);
     Piston.addLineElement(lnpts);
     lnpts.clear();
 
-    p = amrex::RealVect(D_DECL(
+    p = amrex::RealVect(AMREX_D_DECL(
       20.0 * 0.1 * scaleFact, (-7.8586 + zoffset) * 0.1 * scaleFact, 0.0));
     lnpts.push_back(p);
-    p = amrex::RealVect(D_DECL(
+    p = amrex::RealVect(AMREX_D_DECL(
       1.9934 * 0.1 * scaleFact, (3.464 + zoffset) * 0.1 * scaleFact, 0.0));
     lnpts.push_back(p);
     Piston.addLineElement(lnpts);
     lnpts.clear();
 
-    p = amrex::RealVect(D_DECL(
+    p = amrex::RealVect(AMREX_D_DECL(
       1.9934 * 0.1 * scaleFact, (3.464 + zoffset) * 0.1 * scaleFact, 0.0));
     lnpts.push_back(p);
-    p = amrex::RealVect(D_DECL(
+    p = amrex::RealVect(AMREX_D_DECL(
       0.09061 * 0.1 * scaleFact, (3.464 + zoffset) * 0.1 * scaleFact, 0.0));
     lnpts.push_back(p);
     Piston.addLineElement(lnpts);
   } else {
-    p = amrex::RealVect(D_DECL(
+    p = amrex::RealVect(AMREX_D_DECL(
       radius * 1.1 * 0.1 * scaleFact, (-7.8586 + zoffset) * 0.1 * scaleFact,
       0.0));
     lnpts.push_back(p);
-    p = amrex::RealVect(D_DECL(
+    p = amrex::RealVect(AMREX_D_DECL(
       0.0 * 0.1 * scaleFact, (-7.8586 + zoffset) * 0.1 * scaleFact, 0.0));
     lnpts.push_back(p);
     Piston.addLineElement(lnpts);

--- a/Exec/Production/ChallengeProblem/pelelmex_prob.cpp
+++ b/Exec/Production/ChallengeProblem/pelelmex_prob.cpp
@@ -232,3 +232,13 @@ PeleLM::readProbParm()
       PeleLM::prob_parm->d_winput);
   }
 }
+
+void
+PeleLM::freeProbParm()
+{
+  amrex::The_Arena()->free(PeleLM::prob_parm->d_xarray);
+  amrex::The_Arena()->free(PeleLM::prob_parm->d_xdiff);
+  amrex::The_Arena()->free(PeleLM::prob_parm->d_uinput);
+  amrex::The_Arena()->free(PeleLM::prob_parm->d_vinput);
+  amrex::The_Arena()->free(PeleLM::prob_parm->d_winput);
+}

--- a/Exec/Production/ChallengeProblem/pelelmex_prob_parm.H
+++ b/Exec/Production/ChallengeProblem/pelelmex_prob_parm.H
@@ -4,6 +4,8 @@
 #include <AMReX_REAL.H>
 #include <AMReX_GpuMemory.H>
 
+#define PELE_PROB_PARM_NEEDS_FREEING
+
 using namespace amrex::literals;
 
 struct ProbParm

--- a/Exec/RegTests/HITDecay/pelelmex_prob.cpp
+++ b/Exec/RegTests/HITDecay/pelelmex_prob.cpp
@@ -196,3 +196,14 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
     amrex::Gpu::hostToDevice, winput.begin(), winput.end(),
     PeleLM::prob_parm->d_winput);
 }
+
+void
+PeleLM::freeProbParm()
+{
+  amrex::Print() << "Freeing prob parm" << std::endl;
+  amrex::The_Arena()->free(PeleLM::prob_parm->d_xarray);
+  amrex::The_Arena()->free(PeleLM::prob_parm->d_xdiff);
+  amrex::The_Arena()->free(PeleLM::prob_parm->d_uinput);
+  amrex::The_Arena()->free(PeleLM::prob_parm->d_vinput);
+  amrex::The_Arena()->free(PeleLM::prob_parm->d_winput);
+}

--- a/Exec/RegTests/HITDecay/pelelmex_prob.cpp
+++ b/Exec/RegTests/HITDecay/pelelmex_prob.cpp
@@ -200,7 +200,6 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
 void
 PeleLM::freeProbParm()
 {
-  amrex::Print() << "Freeing prob parm" << std::endl;
   amrex::The_Arena()->free(PeleLM::prob_parm->d_xarray);
   amrex::The_Arena()->free(PeleLM::prob_parm->d_xdiff);
   amrex::The_Arena()->free(PeleLM::prob_parm->d_uinput);

--- a/Exec/RegTests/HITDecay/pelelmex_prob.cpp
+++ b/Exec/RegTests/HITDecay/pelelmex_prob.cpp
@@ -101,11 +101,9 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
 {
   amrex::ParmParse pp("prob");
 
-  ProbParm local_prob_parm;
-
   // Read HIT user-defined options from the input file
-  pp.query("input_resolution", local_prob_parm.input_resolution);
-  if (local_prob_parm.input_resolution == 0) {
+  pp.query("input_resolution", PeleLM::prob_parm->input_resolution);
+  if (PeleLM::prob_parm->input_resolution == 0) {
     amrex::Abort("for HIT, the input resolution cannot be 0 !");
   }
 
@@ -113,22 +111,22 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
   pp.query("input_name", datafile);
   int binfmt = 0; // Default is ASCII format
   pp.query("input_binaryformat", binfmt);
-  pp.query("urms0", local_prob_parm.urms0);
+  pp.query("urms0", PeleLM::prob_parm->urms0);
 
   amrex::Real lambda0 = 0.5;
-  amrex::Real tau = lambda0 / local_prob_parm.urms0;
+  amrex::Real tau = lambda0 / PeleLM::prob_parm->urms0;
 
   // Output initial conditions
   std::ofstream ofs("initialConditions.txt", std::ofstream::out);
   amrex::Print(ofs) << "lambda0, urms0, tau \n";
   amrex::Print(ofs).SetPrecision(17)
-    << lambda0 << "," << local_prob_parm.urms0 << "," << tau << std::endl;
+    << lambda0 << "," << PeleLM::prob_parm->urms0 << "," << tau << std::endl;
   ofs.close();
 
   // Read initial velocity field
-  const size_t nx = local_prob_parm.input_resolution;
-  const size_t ny = local_prob_parm.input_resolution;
-  const size_t nz = local_prob_parm.input_resolution;
+  const size_t nx = PeleLM::prob_parm->input_resolution;
+  const size_t ny = PeleLM::prob_parm->input_resolution;
+  const size_t nz = PeleLM::prob_parm->input_resolution;
   amrex::Vector<amrex::Real> data(
     nx * ny * nz * 6); /* this needs to be double */
   if (binfmt != 0) {
@@ -148,11 +146,11 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
   for (long i = 0; i < xinput.size(); i++) {
     xinput[i] = data[0 + i * 6];
     uinput[i] =
-      data[3 + i * 6] * local_prob_parm.urms0 / local_prob_parm.uin_norm;
+      data[3 + i * 6] * PeleLM::prob_parm->urms0 / PeleLM::prob_parm->uin_norm;
     vinput[i] =
-      data[4 + i * 6] * local_prob_parm.urms0 / local_prob_parm.uin_norm;
+      data[4 + i * 6] * PeleLM::prob_parm->urms0 / PeleLM::prob_parm->uin_norm;
     winput[i] =
-      data[5 + i * 6] * local_prob_parm.urms0 / local_prob_parm.uin_norm;
+      data[5 + i * 6] * PeleLM::prob_parm->urms0 / PeleLM::prob_parm->uin_norm;
   }
 
   // Get the xarray table and the differences.
@@ -167,31 +165,9 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
     amrex::Abort("Error: non ascending x-coordinate array.");
   }
 
-  // Pass data to the local_prob_parm
-  local_prob_parm.Linput = xarray[nx - 1] + 0.5 * xdiff[nx - 1];
+  // Pass data to the PeleLM::prob_parm
+  PeleLM::prob_parm->Linput = xarray[nx - 1] + 0.5 * xdiff[nx - 1];
 
-  local_prob_parm.d_xarray =
-    (amrex::Real*)amrex::The_Arena()->alloc(nx * sizeof(amrex::Real));
-  local_prob_parm.d_xdiff =
-    (amrex::Real*)amrex::The_Arena()->alloc(nx * sizeof(amrex::Real));
-  local_prob_parm.d_uinput =
-    (amrex::Real*)amrex::The_Arena()->alloc(nx * ny * nz * sizeof(amrex::Real));
-  local_prob_parm.d_vinput =
-    (amrex::Real*)amrex::The_Arena()->alloc(nx * ny * nz * sizeof(amrex::Real));
-  local_prob_parm.d_winput =
-    (amrex::Real*)amrex::The_Arena()->alloc(nx * ny * nz * sizeof(amrex::Real));
-
-  for (unsigned long i = 0; i < nx; i++) {
-    local_prob_parm.d_xarray[i] = xarray[i];
-    local_prob_parm.d_xdiff[i] = xdiff[i];
-  }
-  for (unsigned long i = 0; i < nx * ny * nz; i++) {
-    local_prob_parm.d_uinput[i] = uinput[i];
-    local_prob_parm.d_vinput[i] = vinput[i];
-    local_prob_parm.d_winput[i] = winput[i];
-  }
-
-  // Initialize PeleLM::prob_parm container
   PeleLM::prob_parm->d_xarray =
     (amrex::Real*)amrex::The_Arena()->alloc(nx * sizeof(amrex::Real));
   PeleLM::prob_parm->d_xdiff =
@@ -203,26 +179,20 @@ PeleLM::readProbParm() // NOLINT(readability-make-member-function-const)
   PeleLM::prob_parm->d_winput =
     (amrex::Real*)amrex::The_Arena()->alloc(nx * ny * nz * sizeof(amrex::Real));
 
-  // Copy into PeleLM::prob_parm: CPU only for now
-  PeleLM::prob_parm->d_xarray =
-    (amrex::Real*)amrex::The_Arena()->alloc(nx * sizeof(amrex::Real));
-  std::memcpy(
-    &PeleLM::prob_parm->d_xarray, &local_prob_parm.d_xarray,
-    sizeof(local_prob_parm.d_xarray));
-  std::memcpy(
-    &PeleLM::prob_parm->d_xdiff, &local_prob_parm.d_xdiff,
-    sizeof(local_prob_parm.d_xdiff));
-  std::memcpy(
-    &PeleLM::prob_parm->d_uinput, &local_prob_parm.d_uinput,
-    sizeof(local_prob_parm.d_uinput));
-  std::memcpy(
-    &PeleLM::prob_parm->d_vinput, &local_prob_parm.d_vinput,
-    sizeof(local_prob_parm.d_vinput));
-  std::memcpy(
-    &PeleLM::prob_parm->d_winput, &local_prob_parm.d_winput,
-    sizeof(local_prob_parm.d_winput));
-  PeleLM::prob_parm->Linput = local_prob_parm.Linput;
-  PeleLM::prob_parm->input_resolution = local_prob_parm.input_resolution;
-  PeleLM::prob_parm->urms0 = local_prob_parm.urms0;
-  PeleLM::prob_parm->uin_norm = local_prob_parm.uin_norm;
+  // Copy into PeleLM::prob_parm
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, xarray.begin(), xarray.end(),
+    PeleLM::prob_parm->d_xarray);
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, xdiff.begin(), xdiff.end(),
+    PeleLM::prob_parm->d_xdiff);
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, uinput.begin(), uinput.end(),
+    PeleLM::prob_parm->d_uinput);
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, vinput.begin(), vinput.end(),
+    PeleLM::prob_parm->d_vinput);
+  amrex::Gpu::copy(
+    amrex::Gpu::hostToDevice, winput.begin(), winput.end(),
+    PeleLM::prob_parm->d_winput);
 }

--- a/Exec/RegTests/HITDecay/pelelmex_prob_parm.H
+++ b/Exec/RegTests/HITDecay/pelelmex_prob_parm.H
@@ -4,6 +4,8 @@
 #include <AMReX_REAL.H>
 #include <AMReX_GpuMemory.H>
 
+#define PELE_PROB_PARM_NEEDS_FREEING
+
 using namespace amrex::literals;
 
 struct ProbParm

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -118,6 +118,7 @@ public:
 
   // ReadProblemParameters
   void readProbParm();
+  void freeProbParm();
 
   // ReadGridFile
   void

--- a/Source/PeleLMeX.cpp
+++ b/Source/PeleLMeX.cpp
@@ -28,7 +28,9 @@ PeleLM::~PeleLM()
 
   closeTempFile();
   typical_values.clear();
-
+#ifdef PELE_PROB_PARM_NEEDS_FREEING
+  freeProbParm();
+#endif
   delete prob_parm;
   The_Arena()->free(prob_parm_d);
   m_initial_ba.clear();


### PR DESCRIPTION
It looks like the HITDecay case was never set up to run properly on GPU. It can be fixed by following the ChallengeProblem case, which uses a similar HIT initialization but correctly copied data from host to device. 

We also don't properly free the device data within ProbParm at the end of the simulation in PeleLMeX. This hasn't been caught yet because only HITDecay and ChallengeProblem actually use dynamically allocated device memory in ProbParm. I added in an ugly fix with macros to fix the memory leak here. A more elegant solution that doesn't break things for users should be possible after #477.