### PR TITLE
Add option to plot state before init proj

### DIFF
--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -110,6 +110,7 @@ IO parameters
     #--------------------------IO CONTROL--------------------------
     amr.plot_int         = 20              # [OPT, DEF=-1] Frequency (as step #) for writing plot file
     amr.plot_overwrite   = false           # [OPT, DEF=false] Overwrite plot files with same name if present
+    amr.plot_init_state  = false           # [OPT, DEF=false] Create a plot file during initialization before the initial projections
     amr.plot_per         = 0.002           # [OPT, DEF=-1] Period (time in s) for writing plot file
     amr.plot_per_exact   = 1               # [OPT, DEF=0] Flag to enforce exactly plt_per by shortening dt
     amr.plot_file        = "plt_"          # [OPT, DEF="plt_"] Plot file prefix

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1805,6 +1805,7 @@ public:
   int m_plotStateSpec = 0;
   int m_plot_int = 0;
   bool m_plot_overwrite = false;
+  bool m_plot_init_state = false;
   int m_plot_zeroEBcovered = 1;
   amrex::Real m_plot_per_approx = -1.;
   amrex::Real m_plot_per_exact = -1.;

--- a/Source/PeleLMeX_Init.cpp
+++ b/Source/PeleLMeX_Init.cpp
@@ -216,6 +216,9 @@ PeleLM::initData()
     averageDownState(AmrNewTime);
     fillPatchState(AmrNewTime);
 
+    if (m_plot_init_state) {
+      WritePlotFile();
+    }
     //----------------------------------------------------------------
     // If performing UnitTest, let's stop here
     if (runMode() != "normal") {

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -820,6 +820,7 @@ PeleLM::readIOParameters()
   pp.query("plot_file", m_plot_file);
   pp.query("plot_int", m_plot_int);
   pp.query("plot_overwrite", m_plot_overwrite);
+  pp.query("plot_init_state", m_plot_init_state);
   if (pp.contains("plot_per")) {
     int do_exact = 0;
     pp.query("plot_per_exact", do_exact);


### PR DESCRIPTION
PeleLMeX doesn't dump a plot file until after initial projections/iterations. When setting up new cases, this can make debugging hard, because if there are problems in the initdata function, the solver will crash before dumping a plot file, so the problems aren't easily visualized. 

This PR adds an option `amr.plot_init_state` that, when activated, dumps a plot file after initdata but before any of the initial projection/iteration stuff. The plot file gets named `plt000-1`.