### PR TITLE
use host manfunc data on host eosparm

### DIFF
--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -79,6 +79,12 @@ PeleLM::Setup()
   if (m_incompressible == 0) {
     amrex::Print() << " Initialization of Eos ... \n";
     eos_parms.initialize();
+    // TODO: this is a bit of a hack so the host eos_parm has access to
+    // the host blackboxfunction data (manfunc_data)
+#ifdef USE_MANIFOLD_EOS
+    eos_parms.host_parm().manf_data =
+      &(eos_parms.host_only_parm().manfunc_par->host_parm());
+#endif
   }
 
   // Setup the state variables


### PR DESCRIPTION
Fix for manifold stuff with cuda that was broken in #436. 

Manifold EOS relies on an `eos_parm` that contains within it a pointer to some `BlackBoxFunctionData` (e.g., tabulated function data). Both are dynamically allocated and inherit from `PeleParamsGeneric` to handle passing data from host to device. The host eos_parm should have host `BlackBoxFunctionData`, but the way copying is done it currently ends up with device `BlackBoxFunctionData`. This PR institutes a hack to fix that.

Semi-related note: runtime selection of table vs. network doesn't work well on GPUs, best to enforce at compile time  with `Manifold_Type = Table` in the GNUmakefile.