### PR TITLE
move reset covered mask outside if to avoid undefined usage

### DIFF
--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1675,7 +1675,7 @@ public:
 
   // Fine-covered cells mask
   amrex::Vector<std::unique_ptr<amrex::iMultiFab>> m_coveredMask;
-  int m_resetCoveredMask;
+  int m_resetCoveredMask{0};
 
   // Chemistry BA & DM
   amrex::Vector<std::unique_ptr<amrex::BoxArray>> m_baChem;

--- a/Source/PeleLMeX_Init.cpp
+++ b/Source/PeleLMeX_Init.cpp
@@ -72,8 +72,9 @@ PeleLM::MakeNewLevelFromScratch(
   if (max_level > 0 && lev != max_level) {
     m_coveredMask[lev] =
       std::make_unique<iMultiFab>(grids[lev], dmap[lev], 1, 0);
-    m_resetCoveredMask = 1;
   }
+  m_resetCoveredMask = 1;
+
   if (m_do_react != 0) {
     m_leveldatareact[lev] =
       std::make_unique<LevelDataReact>(grids[lev], dmap[lev], *m_factory[lev]);


### PR DESCRIPTION
Closes #491 

Something similar was done in 55c3e67 for regridding, but it looks like this was missed, which can lead to entering resetCoveredMask with `m_resetCoveredMask` in an undefined state when initializing single level simulations as found by @QuentinMale
