### PR TITLE
Extract velocity field from an outflow plane

### DIFF
--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1821,7 +1821,7 @@ public:
   amrex::Vector<std::string> m_evaluatePlotVars;
   bool m_write_hdf5_pltfile = false;
   bool m_do_patch_flow_variables = false;
-  int m_write_outflow_plane_verbose = true;
+  int m_write_outflow_plane_verbose = 1;
   int m_write_outflow_plane_dir = -1;
   int m_write_outflow_plane_loc = -1;
   int m_write_outflow_plane_int = 1;

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -990,7 +990,7 @@ public:
   void WriteDebugPlotFile(
     const amrex::Vector<const amrex::MultiFab*>& a_MF,
     const std::string& pltname);
-  void WriteOutflowPlane(int  a_step, amrex::Real a_time) const;
+  void WriteOutflowPlane(int a_step, amrex::Real a_time) const;
   //-----------------------------------------------------------------------------
 
   //-----------------------------------------------------------------------------

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1822,10 +1822,11 @@ public:
   bool m_write_hdf5_pltfile = false;
   bool m_do_patch_flow_variables = false;
   int m_write_outflow_plane_verbose = true;
-  int m_write_outflow_plane = -1;
+  int m_write_outflow_plane_dir = -1;
+  int m_write_outflow_plane_loc = -1;
   int m_write_outflow_plane_int = 1;
-  std::string m_write_outflow_plane_dir{"OUTFLOW"};
-  std::string m_write_outflow_plane_fprefix{"plane"};
+  std::string m_write_outflow_plane_folder{"OUTFLOW"};
+  std::string m_write_outflow_plane_file_prefix{"plane"};
 
   //-----------------------------------------------------------------------------
   // ALGORITHM

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -990,6 +990,7 @@ public:
   void WriteDebugPlotFile(
     const amrex::Vector<const amrex::MultiFab*>& a_MF,
     const std::string& pltname);
+  void WriteOutflowPlane(int  a_step, amrex::Real a_time) const;
   //-----------------------------------------------------------------------------
 
   //-----------------------------------------------------------------------------
@@ -1820,6 +1821,11 @@ public:
   amrex::Vector<std::string> m_evaluatePlotVars;
   bool m_write_hdf5_pltfile = false;
   bool m_do_patch_flow_variables = false;
+  int m_write_outflow_plane_verbose = true;
+  int m_write_outflow_plane = -1;
+  int m_write_outflow_plane_int = 1;
+  std::string m_write_outflow_plane_dir{"OUTFLOW"};
+  std::string m_write_outflow_plane_fprefix{"plane"};
 
   //-----------------------------------------------------------------------------
   // ALGORITHM

--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -243,11 +243,6 @@ PeleLM::Advance(int is_initIter)
   }
 
   //----------------------------------------------------------------
-
-  // Manage outflow data
-  WriteOutflowPlane(m_nstep, m_cur_time);
-
-  //----------------------------------------------------------------
   // Wrapup advance
   // Timing current time step
   if (m_verbose > 0) {
@@ -261,24 +256,25 @@ PeleLM::Advance(int is_initIter)
 void
 PeleLM::WriteOutflowPlane(int a_step, Real a_time) const
 {
-  if (
-    m_write_outflow_plane >= 0 && m_write_outflow_plane < 2 * AMREX_SPACEDIM &&
-    a_step >= 0 && a_step % m_write_outflow_plane_int == 0) {
-    const int outflow_dir = m_write_outflow_plane % AMREX_SPACEDIM;
-    const Orientation::Side outflow_face =
-      m_write_outflow_plane >= AMREX_SPACEDIM ? Orientation::high
-                                              : Orientation::low;
-    const Orientation orient(outflow_dir, outflow_face);
+  Box outflow_box = geom[0].Domain();
 
-    Box outflow_box = amrex::adjCell(geom[0].Domain(), orient, 1);
-    outflow_box.shift(outflow_dir, outflow_face == Orientation::high ? -1 : 1);
+  if (
+    m_write_outflow_plane_dir >= 0 &&
+    m_write_outflow_plane_dir <= AMREX_SPACEDIM &&
+    m_write_outflow_plane_loc >= 0 &&
+    m_write_outflow_plane_loc <=
+      outflow_box.bigEnd()[m_write_outflow_plane_dir] &&
+    a_step % m_write_outflow_plane_int == 0) {
+    outflow_box.setSmall(m_write_outflow_plane_dir, m_write_outflow_plane_loc);
+    outflow_box.setBig(m_write_outflow_plane_dir, m_write_outflow_plane_loc);
+
     FArrayBox outflow_fab(outflow_box, BL_SPACEDIM);
     outflow_fab.setVal(0);
     m_leveldata_new[0]->state.copyTo(outflow_fab, 0, 0, AMREX_SPACEDIM);
 
     std::string outflow_name =
-      m_write_outflow_plane_dir +
-      Concatenate("/" + m_write_outflow_plane_fprefix + "_", m_nstep);
+      m_write_outflow_plane_folder +
+      Concatenate("/" + m_write_outflow_plane_file_prefix + "_", a_step);
 
     if (m_write_outflow_plane_verbose != 0) {
       amrex::Print() << "\n Writing outflow data to " << outflow_name << "\n\n";
@@ -286,8 +282,8 @@ PeleLM::WriteOutflowPlane(int a_step, Real a_time) const
 
     // Create dir if required, write plane data (overwrite if exists)
     if (ParallelDescriptor::IOProcessor()) {
-      if (!FileExists(m_write_outflow_plane_dir)) {
-        UtilCreateDirectory(m_write_outflow_plane_dir, 0755, true);
+      if (!FileExists(m_write_outflow_plane_folder)) {
+        UtilCreateDirectory(m_write_outflow_plane_folder, 0755, true);
       }
 
       // Write plane as fab file, append time in file

--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -243,6 +243,11 @@ PeleLM::Advance(int is_initIter)
   }
 
   //----------------------------------------------------------------
+
+  // Manage outflow data
+  WriteOutflowPlane(m_nstep, m_cur_time);
+
+  //----------------------------------------------------------------
   // Wrapup advance
   // Timing current time step
   if (m_verbose > 0) {
@@ -252,30 +257,48 @@ PeleLM::Advance(int is_initIter)
     amrex::Print() << " >> PeleLMeX::Advance() --> Time: " << run_time << "\n";
   }
   
-#if 1
-  const int dump_outflow_plane = -1; // 0-2 low side, 3-5 high side
-  if (dump_outflow_plane>=0 && dump_outflow_plane<2*AMREX_SPACEDIM)
+}
+
+void
+PeleLM::WriteOutflowPlane(
+  int  a_step,
+  Real a_time) const
+{
+  if (m_write_outflow_plane>=0 && m_write_outflow_plane<2*AMREX_SPACEDIM
+    && a_step >= 0 && a_step % m_write_outflow_plane_int == 0)
   {
-    const int outflow_dir = dump_outflow_plane % AMREX_SPACEDIM;
-    const Orientation::Side outflow_face = dump_outflow_plane >= AMREX_SPACEDIM
+    const int outflow_dir = m_write_outflow_plane % AMREX_SPACEDIM;
+    const Orientation::Side outflow_face = m_write_outflow_plane >= AMREX_SPACEDIM
       ? Orientation::high : Orientation::low;
     const Orientation orient(outflow_dir, outflow_face);
+    
     Box outflow_box = amrex::adjCell(geom[0].Domain(),orient,1);
     outflow_box.shift(outflow_dir,outflow_face==Orientation::high ? -1 : 1);
-    FArrayBox outflow_fab(outflow_box,BL_SPACEDIM);
+    FArrayBox outflow_fab(outflow_box,BL_SPACEDIM);    
     outflow_fab.setVal(0);
     m_leveldata_new[0]->state.copyTo(outflow_fab,0,0,AMREX_SPACEDIM);
-    if (ParallelDescriptor::IOProcessor()) {
-      std::string odir = "OUTLFOW";
-      if (!FileExists(odir)) UtilCreateDirectory(odir,0755,true);
-      std::string outflow_name = odir + Concatenate("/plane_",m_nstep);      
+
+    std::string outflow_name = m_write_outflow_plane_dir
+      + Concatenate("/" + m_write_outflow_plane_fprefix + "_", m_nstep);      
+
+    if (m_write_outflow_plane_verbose != 0) {
+      amrex::Print() << "\n Writing outflow data to " << outflow_name << "\n\n";
+    }
+
+    // Create dir if required, write plane data (overwrite if exists)
+    if (ParallelDescriptor::IOProcessor())
+    {
+      if (!FileExists(m_write_outflow_plane_dir)) {
+	UtilCreateDirectory(m_write_outflow_plane_dir,0755,true);
+      }
+      
+      // Write plane as fab file, append time in file
       std::ofstream os(outflow_name.c_str());
       outflow_fab.writeOn(os);
-      os << m_cur_time;
+      os << a_time;
       os.close();
     }
   }
-#endif
 }
 
 void

--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -269,7 +269,7 @@ PeleLM::WriteOutflowPlane(int a_step, Real a_time) const
     outflow_box.setBig(m_write_outflow_plane_dir, m_write_outflow_plane_loc);
 
     FArrayBox outflow_fab(outflow_box, BL_SPACEDIM);
-    outflow_fab.setVal(0);
+    outflow_fab.setVal<amrex::RunOn::Device>(0);
     m_leveldata_new[0]->state.copyTo(outflow_fab, 0, 0, AMREX_SPACEDIM);
 
     std::string outflow_name =

--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -256,42 +256,40 @@ PeleLM::Advance(int is_initIter)
       run_time, ParallelDescriptor::IOProcessorNumber());
     amrex::Print() << " >> PeleLMeX::Advance() --> Time: " << run_time << "\n";
   }
-  
 }
 
 void
-PeleLM::WriteOutflowPlane(
-  int  a_step,
-  Real a_time) const
+PeleLM::WriteOutflowPlane(int a_step, Real a_time) const
 {
-  if (m_write_outflow_plane>=0 && m_write_outflow_plane<2*AMREX_SPACEDIM
-    && a_step >= 0 && a_step % m_write_outflow_plane_int == 0)
-  {
+  if (
+    m_write_outflow_plane >= 0 && m_write_outflow_plane < 2 * AMREX_SPACEDIM &&
+    a_step >= 0 && a_step % m_write_outflow_plane_int == 0) {
     const int outflow_dir = m_write_outflow_plane % AMREX_SPACEDIM;
-    const Orientation::Side outflow_face = m_write_outflow_plane >= AMREX_SPACEDIM
-      ? Orientation::high : Orientation::low;
+    const Orientation::Side outflow_face =
+      m_write_outflow_plane >= AMREX_SPACEDIM ? Orientation::high
+                                              : Orientation::low;
     const Orientation orient(outflow_dir, outflow_face);
-    
-    Box outflow_box = amrex::adjCell(geom[0].Domain(),orient,1);
-    outflow_box.shift(outflow_dir,outflow_face==Orientation::high ? -1 : 1);
-    FArrayBox outflow_fab(outflow_box,BL_SPACEDIM);    
-    outflow_fab.setVal(0);
-    m_leveldata_new[0]->state.copyTo(outflow_fab,0,0,AMREX_SPACEDIM);
 
-    std::string outflow_name = m_write_outflow_plane_dir
-      + Concatenate("/" + m_write_outflow_plane_fprefix + "_", m_nstep);      
+    Box outflow_box = amrex::adjCell(geom[0].Domain(), orient, 1);
+    outflow_box.shift(outflow_dir, outflow_face == Orientation::high ? -1 : 1);
+    FArrayBox outflow_fab(outflow_box, BL_SPACEDIM);
+    outflow_fab.setVal(0);
+    m_leveldata_new[0]->state.copyTo(outflow_fab, 0, 0, AMREX_SPACEDIM);
+
+    std::string outflow_name =
+      m_write_outflow_plane_dir +
+      Concatenate("/" + m_write_outflow_plane_fprefix + "_", m_nstep);
 
     if (m_write_outflow_plane_verbose != 0) {
       amrex::Print() << "\n Writing outflow data to " << outflow_name << "\n\n";
     }
 
     // Create dir if required, write plane data (overwrite if exists)
-    if (ParallelDescriptor::IOProcessor())
-    {
+    if (ParallelDescriptor::IOProcessor()) {
       if (!FileExists(m_write_outflow_plane_dir)) {
-	UtilCreateDirectory(m_write_outflow_plane_dir,0755,true);
+        UtilCreateDirectory(m_write_outflow_plane_dir, 0755, true);
       }
-      
+
       // Write plane as fab file, append time in file
       std::ofstream os(outflow_name.c_str());
       outflow_fab.writeOn(os);

--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -251,6 +251,31 @@ PeleLM::Advance(int is_initIter)
       run_time, ParallelDescriptor::IOProcessorNumber());
     amrex::Print() << " >> PeleLMeX::Advance() --> Time: " << run_time << "\n";
   }
+  
+#if 1
+  const int dump_outflow_plane = -1; // 0-2 low side, 3-5 high side
+  if (dump_outflow_plane>=0 && dump_outflow_plane<2*AMREX_SPACEDIM)
+  {
+    const int outflow_dir = dump_outflow_plane % AMREX_SPACEDIM;
+    const Orientation::Side outflow_face = dump_outflow_plane >= AMREX_SPACEDIM
+      ? Orientation::high : Orientation::low;
+    const Orientation orient(outflow_dir, outflow_face);
+    Box outflow_box = amrex::adjCell(geom[0].Domain(),orient,1);
+    outflow_box.shift(outflow_dir,outflow_face==Orientation::high ? -1 : 1);
+    FArrayBox outflow_fab(outflow_box,BL_SPACEDIM);
+    outflow_fab.setVal(0);
+    m_leveldata_new[0]->state.copyTo(outflow_fab,0,0,AMREX_SPACEDIM);
+    if (ParallelDescriptor::IOProcessor()) {
+      std::string odir = "OUTLFOW";
+      if (!FileExists(odir)) UtilCreateDirectory(odir,0755,true);
+      std::string outflow_name = odir + Concatenate("/plane_",m_nstep);      
+      std::ofstream os(outflow_name.c_str());
+      outflow_fab.writeOn(os);
+      os << m_cur_time;
+      os.close();
+    }
+  }
+#endif
 }
 
 void

--- a/Source/PeleLMeX_Evolve.cpp
+++ b/Source/PeleLMeX_Evolve.cpp
@@ -71,6 +71,9 @@ PeleLM::Evolve()
     // Diagnostics
     doDiagnostics();
 
+    // Manage outflow data
+    WriteOutflowPlane(m_nstep, m_cur_time);
+
     // Check message
     bool dump_and_stop = checkMessage("dump_and_stop");
     bool plt_and_continue = checkMessage("plt_and_continue");

--- a/Source/PeleLMeX_Init.cpp
+++ b/Source/PeleLMeX_Init.cpp
@@ -326,6 +326,9 @@ PeleLM::initData()
     int is_restart = 1;
     activeControl(is_restart);
   }
+  //----------------------------------------------------------------
+  // Manage outflow data
+  WriteOutflowPlane(m_nstep, m_cur_time);
 }
 
 void

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -769,12 +769,12 @@ PeleLM::readParameters()
   // -----------------------------------------
   // I/O
   // -----------------------------------------
-  pp.query(
-    "write_outflow_plane",
-    m_write_outflow_plane); // 0-2 low side, 3-5 high side
-  pp.query("write_outflow_plane_int", m_write_outflow_plane_int);
   pp.query("write_outflow_plane_dir", m_write_outflow_plane_dir);
-  pp.query("write_outflow_plane_fprefix", m_write_outflow_plane_fprefix);
+  pp.query("write_outflow_plane_loc", m_write_outflow_plane_loc);
+  pp.query("write_outflow_plane_int", m_write_outflow_plane_int);
+  pp.query("write_outflow_plane_folder", m_write_outflow_plane_folder);
+  pp.query(
+    "write_outflow_plane_file_prefix", m_write_outflow_plane_file_prefix);
   pp.query("write_outflow_plane_verbose", m_write_outflow_plane_verbose);
 }
 

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -765,6 +765,15 @@ PeleLM::readParameters()
   m_plot_extSource = false;
   pp.query("user_defined_ext_sources", m_user_defined_ext_sources);
   pp.query("plot_extSource", m_plot_extSource);
+
+  // -----------------------------------------
+  // I/O
+  // -----------------------------------------
+  pp.query("write_outflow_plane",m_write_outflow_plane); // 0-2 low side, 3-5 high side
+  pp.query("write_outflow_plane_int",m_write_outflow_plane_int);
+  pp.query("write_outflow_plane_dir",m_write_outflow_plane_dir);
+  pp.query("write_outflow_plane_fprefix",m_write_outflow_plane_fprefix);
+  pp.query("write_outflow_plane_verbose",m_write_outflow_plane_verbose);
 }
 
 void

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -542,15 +542,15 @@ PeleLM::readParameters()
     if (mgsc_size == 1) {
       int mgsc;
       pp.query("max_grid_size_chem", mgsc);
-      AMREX_D_TERM(
-        m_max_grid_size_chem[0] = mgsc;, m_max_grid_size_chem[1] = mgsc;
-        , m_max_grid_size_chem[2] = mgsc);
+      AMREX_D_TERM(m_max_grid_size_chem[0] = mgsc;
+                   , m_max_grid_size_chem[1] = mgsc;
+                   , m_max_grid_size_chem[2] = mgsc);
     } else if (mgsc_size == AMREX_SPACEDIM) {
       Vector<int> mgsc;
       pp.getarr("max_grid_size_chem", mgsc, 0, AMREX_SPACEDIM);
-      AMREX_D_TERM(
-        m_max_grid_size_chem[0] = mgsc[0];, m_max_grid_size_chem[1] = mgsc[1];
-        , m_max_grid_size_chem[2] = mgsc[2]);
+      AMREX_D_TERM(m_max_grid_size_chem[0] = mgsc[0];
+                   , m_max_grid_size_chem[1] = mgsc[1];
+                   , m_max_grid_size_chem[2] = mgsc[2]);
     } else {
       Abort("peleLM.max_grid_size_chem should have 1 or AMREX_SPACEDIM values");
     }
@@ -609,9 +609,8 @@ PeleLM::readParameters()
     m_advection_type = "BDS";
     m_Godunov_ppm = 0;
   } else {
-    Abort(
-      "Unknown 'advection_scheme'. Recognized options are: Godunov_PLM, "
-      "Godunov_PPM or Godunov_BDS");
+    Abort("Unknown 'advection_scheme'. Recognized options are: Godunov_PLM, "
+          "Godunov_PPM or Godunov_BDS");
   }
   m_predict_advection_type =
     "Godunov"; // Only option at this point. This will disappear when
@@ -813,10 +812,9 @@ PeleLM::checkSetupParams()
       std::abs(
         (0.1 * eos_parms.host_parm().Pnom_cgs - prob_parm->P_mean) /
         prob_parm->P_mean) > 1e-6) {
-      amrex::Abort(
-        "For Manifold EOS, pressure in manifold model "
-        "(manifold.nominal_pressure_cgs) and pressure in PeleLMeX "
-        "(prob.Pmean) must match");
+      amrex::Abort("For Manifold EOS, pressure in manifold model "
+                   "(manifold.nominal_pressure_cgs) and pressure in PeleLMeX "
+                   "(prob.Pmean) must match");
     }
 #endif
   }
@@ -930,15 +928,13 @@ PeleLM::variablesSetup()
     Print() << " First ODE: " << FIRSTODE << "\n";
     set_ode_names(m_ode_names);
     if (m_ode_names.size() != NUM_ODE) {
-      Abort(
-        "ODEQty names improperly set. Adjust set_ode_names in "
-        "ProblemSpecificFunctions or NUM_ODE in GNUMakefile");
+      Abort("ODEQty names improperly set. Adjust set_ode_names in "
+            "ProblemSpecificFunctions or NUM_ODE in GNUMakefile");
     }
     for (int n = 0; n < NUM_ODE; ++n) {
       if (m_ode_names[n].empty()) {
-        Abort(
-          "ODEQty names improperly set. Adjust set_ode_names in "
-          "ProblemSpecificFunctions or NUM_ODE in GNUMakefile");
+        Abort("ODEQty names improperly set. Adjust set_ode_names in "
+              "ProblemSpecificFunctions or NUM_ODE in GNUMakefile");
       }
       stateComponents.emplace_back(FIRSTODE + n, m_ode_names[n]);
     }
@@ -1336,9 +1332,8 @@ PeleLM::evaluateSetup()
   {
     Vector<std::string> var_names(
       NVAR - 2); // Skip temperature and RhoRT, unused
-    AMREX_D_TERM(
-      var_names[VELX] = "A(VELX)";, var_names[VELY] = "A(VELY)";
-      , var_names[VELZ] = "A(VELZ)");
+    AMREX_D_TERM(var_names[VELX] = "A(VELX)";, var_names[VELY] = "A(VELY)";
+                 , var_names[VELZ] = "A(VELZ)");
     var_names[DENSITY] = "A(Rho)";
     for (int n = 0; n < NUM_SPECIES; n++) {
       var_names[FIRSTSPEC + n] = "A(" + spec_names[n] + ")";
@@ -1475,10 +1470,9 @@ PeleLM::taggingSetup()
       errTags.push_back(AMRErrorTag(info));
       itexists = true;
     } else {
-      Abort(
-        std::string(
-          "Unrecognized refinement indicator for " + refinement_indicator)
-          .c_str());
+      Abort(std::string(
+              "Unrecognized refinement indicator for " + refinement_indicator)
+              .c_str());
     }
 
     if (!itexists) {

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -542,15 +542,15 @@ PeleLM::readParameters()
     if (mgsc_size == 1) {
       int mgsc;
       pp.query("max_grid_size_chem", mgsc);
-      AMREX_D_TERM(m_max_grid_size_chem[0] = mgsc;
-                   , m_max_grid_size_chem[1] = mgsc;
-                   , m_max_grid_size_chem[2] = mgsc);
+      AMREX_D_TERM(
+        m_max_grid_size_chem[0] = mgsc;, m_max_grid_size_chem[1] = mgsc;
+        , m_max_grid_size_chem[2] = mgsc);
     } else if (mgsc_size == AMREX_SPACEDIM) {
       Vector<int> mgsc;
       pp.getarr("max_grid_size_chem", mgsc, 0, AMREX_SPACEDIM);
-      AMREX_D_TERM(m_max_grid_size_chem[0] = mgsc[0];
-                   , m_max_grid_size_chem[1] = mgsc[1];
-                   , m_max_grid_size_chem[2] = mgsc[2]);
+      AMREX_D_TERM(
+        m_max_grid_size_chem[0] = mgsc[0];, m_max_grid_size_chem[1] = mgsc[1];
+        , m_max_grid_size_chem[2] = mgsc[2]);
     } else {
       Abort("peleLM.max_grid_size_chem should have 1 or AMREX_SPACEDIM values");
     }
@@ -609,8 +609,9 @@ PeleLM::readParameters()
     m_advection_type = "BDS";
     m_Godunov_ppm = 0;
   } else {
-    Abort("Unknown 'advection_scheme'. Recognized options are: Godunov_PLM, "
-          "Godunov_PPM or Godunov_BDS");
+    Abort(
+      "Unknown 'advection_scheme'. Recognized options are: Godunov_PLM, "
+      "Godunov_PPM or Godunov_BDS");
   }
   m_predict_advection_type =
     "Godunov"; // Only option at this point. This will disappear when
@@ -769,11 +770,13 @@ PeleLM::readParameters()
   // -----------------------------------------
   // I/O
   // -----------------------------------------
-  pp.query("write_outflow_plane",m_write_outflow_plane); // 0-2 low side, 3-5 high side
-  pp.query("write_outflow_plane_int",m_write_outflow_plane_int);
-  pp.query("write_outflow_plane_dir",m_write_outflow_plane_dir);
-  pp.query("write_outflow_plane_fprefix",m_write_outflow_plane_fprefix);
-  pp.query("write_outflow_plane_verbose",m_write_outflow_plane_verbose);
+  pp.query(
+    "write_outflow_plane",
+    m_write_outflow_plane); // 0-2 low side, 3-5 high side
+  pp.query("write_outflow_plane_int", m_write_outflow_plane_int);
+  pp.query("write_outflow_plane_dir", m_write_outflow_plane_dir);
+  pp.query("write_outflow_plane_fprefix", m_write_outflow_plane_fprefix);
+  pp.query("write_outflow_plane_verbose", m_write_outflow_plane_verbose);
 }
 
 void
@@ -810,9 +813,10 @@ PeleLM::checkSetupParams()
       std::abs(
         (0.1 * eos_parms.host_parm().Pnom_cgs - prob_parm->P_mean) /
         prob_parm->P_mean) > 1e-6) {
-      amrex::Abort("For Manifold EOS, pressure in manifold model "
-                   "(manifold.nominal_pressure_cgs) and pressure in PeleLMeX "
-                   "(prob.Pmean) must match");
+      amrex::Abort(
+        "For Manifold EOS, pressure in manifold model "
+        "(manifold.nominal_pressure_cgs) and pressure in PeleLMeX "
+        "(prob.Pmean) must match");
     }
 #endif
   }
@@ -926,13 +930,15 @@ PeleLM::variablesSetup()
     Print() << " First ODE: " << FIRSTODE << "\n";
     set_ode_names(m_ode_names);
     if (m_ode_names.size() != NUM_ODE) {
-      Abort("ODEQty names improperly set. Adjust set_ode_names in "
-            "ProblemSpecificFunctions or NUM_ODE in GNUMakefile");
+      Abort(
+        "ODEQty names improperly set. Adjust set_ode_names in "
+        "ProblemSpecificFunctions or NUM_ODE in GNUMakefile");
     }
     for (int n = 0; n < NUM_ODE; ++n) {
       if (m_ode_names[n].empty()) {
-        Abort("ODEQty names improperly set. Adjust set_ode_names in "
-              "ProblemSpecificFunctions or NUM_ODE in GNUMakefile");
+        Abort(
+          "ODEQty names improperly set. Adjust set_ode_names in "
+          "ProblemSpecificFunctions or NUM_ODE in GNUMakefile");
       }
       stateComponents.emplace_back(FIRSTODE + n, m_ode_names[n]);
     }
@@ -1330,8 +1336,9 @@ PeleLM::evaluateSetup()
   {
     Vector<std::string> var_names(
       NVAR - 2); // Skip temperature and RhoRT, unused
-    AMREX_D_TERM(var_names[VELX] = "A(VELX)";, var_names[VELY] = "A(VELY)";
-                 , var_names[VELZ] = "A(VELZ)");
+    AMREX_D_TERM(
+      var_names[VELX] = "A(VELX)";, var_names[VELY] = "A(VELY)";
+      , var_names[VELZ] = "A(VELZ)");
     var_names[DENSITY] = "A(Rho)";
     for (int n = 0; n < NUM_SPECIES; n++) {
       var_names[FIRSTSPEC + n] = "A(" + spec_names[n] + ")";
@@ -1468,9 +1475,10 @@ PeleLM::taggingSetup()
       errTags.push_back(AMRErrorTag(info));
       itexists = true;
     } else {
-      Abort(std::string(
-              "Unrecognized refinement indicator for " + refinement_indicator)
-              .c_str());
+      Abort(
+        std::string(
+          "Unrecognized refinement indicator for " + refinement_indicator)
+          .c_str());
     }
 
     if (!itexists) {


### PR DESCRIPTION
Adds code in PeleLMeX::Advance to optionally write a FAB slice file of the velocity field using level 0 data from a specified plane of the simulation (and appends the current time for later use).  Can be turned on during any restart, and provides options for setting the frequency (in time steps), and folder and filename prefixes.  Note that this will overwrite any identically-named files that existed previously.

Code to assemble these slices into a "turbulence" file used by the turbInflow code was added to AMReX in this  [pull request](https://github.com/AMReX-Codes/amrex/pull/4418),, and the turbInflow code modifications required to read these assembled files is added in a [companion](https://github.com/AMReX-Combustion/PelePhysics/pull/566) for PelePhysics.  I've done some cursory testing of this capability, but more extensive testing should be done and the documentation should be modified to explain how it works and how it is to be used.