### PR TITLE
Fix memory leak for Soret isothermal boundaries

### DIFF
--- a/Source/PeleLMeX_Diffusion.cpp
+++ b/Source/PeleLMeX_Diffusion.cpp
@@ -453,6 +453,11 @@ PeleLM::correctIsothermalBoundary(
     }
   }
   // TODO: wbar fluxes disabled for this case - boundary system becomes complex
+  for (int lev = 0; lev <= finest_level; lev++) {
+    for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+      delete soretfluxes[lev][idim];
+    }
+  }
 }
 
 void


### PR DESCRIPTION
Some multifabs for setting up Soret isothermal BCs are allocated with `new` but never `delete`d. This causes a memory leak that was noticed by @bssoriano. 