### PR TITLE
Small manifold fixes

### DIFF
--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -284,6 +284,7 @@ PeleLMeX algorithm
     peleLM.a.Schmidt = 0.7                 # [OPT, DEF = -1] Schmidt number for auxiliary variable. If unspecified or negative, assumed to diffuse with unity Lewis number.
 
     peleLM.user_defined_ext_sources = 0    # [OPT, DEF=0] Enable user defined source terms. Requires local ProblemSpecificFunctions.cpp.
+    peleLM.add_variance_sources = 1        # [OPT, DEF=1] (only relevant for Manifold EOS) include production/dissipation for variances if present in model
 
 
 Transport coefficients and LES

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -911,6 +911,7 @@ public:
   bool m_user_defined_ext_sources;
   bool m_plot_extSource;
   bool m_ext_sources_SDC;
+  bool m_add_variance_sources;
   void getExternalSources(
     int is_initIter,
     const PeleLM::TimeStamp& a_timestamp_old,

--- a/Source/PeleLMeX_Forces.cpp
+++ b/Source/PeleLMeX_Forces.cpp
@@ -246,132 +246,136 @@ PeleLM::addScalarVarianceSources(const TimeStamp& a_timestamp)
   amrex::ignore_unused(a_timestamp);
 #else
 
-  auto const& leosparm = eos_parms.host_parm();
+  if (m_add_variance_sources) {
+    auto const& leosparm = eos_parms.host_parm();
 
-  // Determine if we have any scalar variances that need sources added
-  // Could be moved elsewhere to not do every timestep
-  int nvariances = 0;
-  int var_of_scalar = -1;
-  for (int n = 0; n < MANIFOLD_DIM; ++n) {
-    if (leosparm.is_variance_of[n] >= 0) {
-      if (!m_do_les) {
-        amrex::Abort(
-          "PeleLM::addScalarVarianceSources(): cannot add a "
-          "scalar dissipation without an active LES model");
-      }
-      nvariances += 1;
-      var_of_scalar = FIRSTSPEC + leosparm.is_variance_of[n];
-    }
-  }
-
-  if (nvariances > 1) {
-    amrex::Abort(
-      "PeleLM::addScalarVarianceSources(): currently we only support "
-      "manifold models with 0 or 1 variances");
-  } else if (nvariances > 0) {
-
-    // Compute scalar gradients (no need to average down here)
-    int do_avgDown = 0;
-    auto bcRecScalar = fetchBCRecArray(var_of_scalar, 1);
-    int nGrow = 0; // No need for ghost face on fluxes
-    Vector<Array<MultiFab, AMREX_SPACEDIM>> grad_fc(finest_level + 1);
-    for (int lev = 0; lev <= finest_level; ++lev) {
-      const auto& ba = grids[lev];
-      const auto& factory = Factory(lev);
-      for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
-        grad_fc[lev][idim].define(
-          amrex::convert(ba, IntVect::TheDimensionVector(idim)), dmap[lev], 1,
-          nGrow, MFInfo(), factory);
-        grad_fc[lev][idim].setVal(0.0); // Required?
+    // Determine if we have any scalar variances that need sources added
+    // Could be moved elsewhere to not do every timestep
+    int nvariances = 0;
+    int var_of_scalar = -1;
+    for (int n = 0; n < MANIFOLD_DIM; ++n) {
+      if (leosparm.is_variance_of[n] >= 0) {
+        if (!m_do_les) {
+          amrex::Abort(
+            "PeleLM::addScalarVarianceSources(): cannot add a "
+            "scalar dissipation without an active LES model");
+        }
+        nvariances += 1;
+        var_of_scalar = FIRSTSPEC + leosparm.is_variance_of[n];
       }
     }
-    getDiffusionOp()->computeGradient(
-      GetVecOfArrOfPtrs(grad_fc), {},
-      GetVecOfConstPtrs(getStateVect(a_timestamp)), {}, bcRecScalar[0],
-      do_avgDown, var_of_scalar);
 
-    // Add in Production and Dissipation source terms for subfilter variances
-    for (int lev = 0; lev <= finest_level; lev++) {
-
-      auto* ldata_p = getLevelDataPtr(lev, a_timestamp);
-
-      // Require the turbulent viscosity to be pre-computed
-      // it always is stored at AmrOldTime, so we just use that
-      // We need cell-centered mu_t but have it at faces
-      // The simple interpolation below probably isn't valid for EB
-#ifdef AMREX_USE_EB
+    if (nvariances > 1) {
       amrex::Abort(
-        "PeleLM::addScalarVarianceSources(): this is not supported with EB");
-#endif
+        "PeleLM::addScalarVarianceSources(): currently we only support "
+        "manifold models with 0 or 1 variances");
+    } else if (nvariances > 0) {
 
-      for (int n = 0; n < MANIFOLD_DIM; ++n) {
-        if (leosparm.is_variance_of[n] >= 0) {
-
-          constexpr amrex::Real fact = 0.5 / AMREX_SPACEDIM;
-          const amrex::Real C_chi = m_les_c_chi;
-          const amrex::Real ScInv = m_Schmidt_inv;
-
-          AMREX_D_TERM(
-            auto const& mut_arr_x =
-              m_leveldata_old[lev]->visc_turb_fc[0].const_arrays();
-            , auto const& mut_arr_y =
-                m_leveldata_old[lev]->visc_turb_fc[1].const_arrays();
-            , auto const& mut_arr_z =
-                m_leveldata_old[lev]->visc_turb_fc[2].const_arrays();)
-          AMREX_D_TERM(
-            auto const& gx = grad_fc[lev][0].const_arrays();
-            , auto const& gy = grad_fc[lev][1].const_arrays();
-            , auto const& gz = grad_fc[lev][2].const_arrays();)
-          auto extma = m_extSource[lev]->arrays();
-          auto statema = ldata_p->state.const_arrays();
-
-          // l_scale will also need modification for EB
-          const amrex::Real vol = AMREX_D_TERM(
-            geom[lev].CellSize(0), *geom[lev].CellSize(1),
-            *geom[lev].CellSize(2));
-          const amrex::Real l_scale =
-            (AMREX_SPACEDIM == 2) ? std::sqrt(vol) : std::cbrt(vol);
-          const amrex::Real inv_l_scale2 = 1.0 / (l_scale * l_scale);
-
-          amrex::ParallelFor(
-            *m_extSource[lev],
-            [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
-              // Subfilter Scalar Dissipation: Linear Relaxation model
-              // rho chi_sgs = C_chi * mu_t / Delta^2 * Variance
-              amrex::Real mu_t =
-                fact * (AMREX_D_TERM(
-                         mut_arr_x[bx](i, j, k) + mut_arr_x[bx](i + 1, j, k),
-                         +mut_arr_y[bx](i, j, k) + mut_arr_y[bx](i, j + 1, k),
-                         +mut_arr_z[bx](i, j, k) + mut_arr_z[bx](i, j, k + 1)));
-
-              extma[bx](i, j, k, FIRSTSPEC + n) -=
-                C_chi * mu_t * inv_l_scale2 *
-                statema[bx](i, j, k, FIRSTSPEC + n);
-
-              // Production term (w/ Smagorinsky closure for turbulent flux)
-              // -2 (rho <u_j C> - rho <u_j><C>) d<C>/dx_j
-              // = 2 *mu_t/Sc_t * d<C>/dx_j * d<C>/dx_j
-              amrex::Real mu_grad2 =
-                fact *
-                (AMREX_D_TERM(
-                  mut_arr_x[bx](i, j, k) * gx[bx](i, j, k) * gx[bx](i, j, k) +
-                    mut_arr_x[bx](i + 1, j, k) * gx[bx](i + 1, j, k) *
-                      gx[bx](i + 1, j, k),
-                  +mut_arr_y[bx](i, j, k) * gy[bx](i, j, k) * gy[bx](i, j, k) +
-                    mut_arr_y[bx](i, j + 1, k) * gy[bx](i, j + 1, k) *
-                      gy[bx](i, j + 1, k),
-                  +mut_arr_z[bx](i, j, k) * gz[bx](i, j, k) * gz[bx](i, j, k) +
-                    mut_arr_z[bx](i, j, k + 1) * gz[bx](i, j, k + 1) *
-                      gz[bx](i, j, k + 1)));
-
-              extma[bx](i, j, k, FIRSTSPEC + n) += 2.0 * ScInv * mu_grad2;
-            });
+      // Compute scalar gradients (no need to average down here)
+      int do_avgDown = 0;
+      auto bcRecScalar = fetchBCRecArray(var_of_scalar, 1);
+      int nGrow = 0; // No need for ghost face on fluxes
+      Vector<Array<MultiFab, AMREX_SPACEDIM>> grad_fc(finest_level + 1);
+      for (int lev = 0; lev <= finest_level; ++lev) {
+        const auto& ba = grids[lev];
+        const auto& factory = Factory(lev);
+        for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+          grad_fc[lev][idim].define(
+            amrex::convert(ba, IntVect::TheDimensionVector(idim)), dmap[lev], 1,
+            nGrow, MFInfo(), factory);
+          grad_fc[lev][idim].setVal(0.0); // Required?
         }
       }
-      Gpu::streamSynchronize();
+      getDiffusionOp()->computeGradient(
+        GetVecOfArrOfPtrs(grad_fc), {},
+        GetVecOfConstPtrs(getStateVect(a_timestamp)), {}, bcRecScalar[0],
+        do_avgDown, var_of_scalar);
+
+      // Add in Production and Dissipation source terms for subfilter variances
+      for (int lev = 0; lev <= finest_level; lev++) {
+
+        auto* ldata_p = getLevelDataPtr(lev, a_timestamp);
+
+        // Require the turbulent viscosity to be pre-computed
+        // it always is stored at AmrOldTime, so we just use that
+        // We need cell-centered mu_t but have it at faces
+        // The simple interpolation below probably isn't valid for EB
+#ifdef AMREX_USE_EB
+        amrex::Abort(
+          "PeleLM::addScalarVarianceSources(): this is not supported with EB");
+#endif
+
+        for (int n = 0; n < MANIFOLD_DIM; ++n) {
+          if (leosparm.is_variance_of[n] >= 0) {
+
+            constexpr amrex::Real fact = 0.5 / AMREX_SPACEDIM;
+            const amrex::Real C_chi = m_les_c_chi;
+            const amrex::Real ScInv = m_Schmidt_inv;
+
+            AMREX_D_TERM(
+              auto const& mut_arr_x =
+                m_leveldata_old[lev]->visc_turb_fc[0].const_arrays();
+              , auto const& mut_arr_y =
+                  m_leveldata_old[lev]->visc_turb_fc[1].const_arrays();
+              , auto const& mut_arr_z =
+                  m_leveldata_old[lev]->visc_turb_fc[2].const_arrays();)
+            AMREX_D_TERM(
+              auto const& gx = grad_fc[lev][0].const_arrays();
+              , auto const& gy = grad_fc[lev][1].const_arrays();
+              , auto const& gz = grad_fc[lev][2].const_arrays();)
+            auto extma = m_extSource[lev]->arrays();
+            auto statema = ldata_p->state.const_arrays();
+
+            // l_scale will also need modification for EB
+            const amrex::Real vol = AMREX_D_TERM(
+              geom[lev].CellSize(0), *geom[lev].CellSize(1),
+              *geom[lev].CellSize(2));
+            const amrex::Real l_scale =
+              (AMREX_SPACEDIM == 2) ? std::sqrt(vol) : std::cbrt(vol);
+            const amrex::Real inv_l_scale2 = 1.0 / (l_scale * l_scale);
+
+            amrex::ParallelFor(
+              *m_extSource[lev],
+              [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
+                // Subfilter Scalar Dissipation: Linear Relaxation model
+                // rho chi_sgs = C_chi * mu_t / Delta^2 * Variance
+                amrex::Real mu_t =
+                  fact *
+                  (AMREX_D_TERM(
+                    mut_arr_x[bx](i, j, k) + mut_arr_x[bx](i + 1, j, k),
+                    +mut_arr_y[bx](i, j, k) + mut_arr_y[bx](i, j + 1, k),
+                    +mut_arr_z[bx](i, j, k) + mut_arr_z[bx](i, j, k + 1)));
+
+                extma[bx](i, j, k, FIRSTSPEC + n) -=
+                  C_chi * mu_t * inv_l_scale2 *
+                  statema[bx](i, j, k, FIRSTSPEC + n);
+
+                // Production term (w/ Smagorinsky closure for turbulent flux)
+                // -2 (rho <u_j C> - rho <u_j><C>) d<C>/dx_j
+                // = 2 *mu_t/Sc_t * d<C>/dx_j * d<C>/dx_j
+                amrex::Real mu_grad2 =
+                  fact *
+                  (AMREX_D_TERM(
+                    mut_arr_x[bx](i, j, k) * gx[bx](i, j, k) * gx[bx](i, j, k) +
+                      mut_arr_x[bx](i + 1, j, k) * gx[bx](i + 1, j, k) *
+                        gx[bx](i + 1, j, k),
+                    +mut_arr_y[bx](i, j, k) * gy[bx](i, j, k) *
+                        gy[bx](i, j, k) +
+                      mut_arr_y[bx](i, j + 1, k) * gy[bx](i, j + 1, k) *
+                        gy[bx](i, j + 1, k),
+                    +mut_arr_z[bx](i, j, k) * gz[bx](i, j, k) *
+                        gz[bx](i, j, k) +
+                      mut_arr_z[bx](i, j, k + 1) * gz[bx](i, j, k + 1) *
+                        gz[bx](i, j, k + 1)));
+
+                extma[bx](i, j, k, FIRSTSPEC + n) += 2.0 * ScInv * mu_grad2;
+              });
+          }
+        }
+        Gpu::streamSynchronize();
+      }
     }
   }
-
 #endif
 }
 

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -520,6 +520,11 @@ PeleLM::readParameters()
                    << std::endl;
   }
 
+  // Manifold EOS: invPrandtl needs to be 0 because H not used
+  if (pele::physics::PhysicsType::eos_type::identifier() == "Manifold") {
+    m_Prandtl_inv = 0.0;
+  }
+
   pp.query("deltaT_verbose", m_deltaT_verbose);
   pp.query("deltaT_iterMax", m_deltaTIterMax);
   pp.query("deltaT_tol", m_deltaT_norm_max);

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -99,9 +99,15 @@ PeleLM::Setup()
     trans_parms.initialize();
     if ((m_les_verbose != 0) and m_do_les) { // Say what transport model we're
                                              // going to use
+
       amrex::Print() << "    Using LES in transport with Sc = "
-                     << 1.0 / m_Schmidt_inv
-                     << " and Pr = " << 1.0 / m_Prandtl_inv << std::endl;
+                     << 1.0 / m_Schmidt_inv;
+      if (pele::physics::PhysicsType::eos_type::identifier() == "Manifold") {
+        amrex::Print() << ", enthalpy not diffused for Manifold EOS "
+                       << std::endl;
+      } else {
+        amrex::Print() << " and Pr = " << 1.0 / m_Prandtl_inv << std::endl;
+      }
     } else if (m_verbose != 0) {
       if (m_fixed_Le == 0 && m_fixed_Pr == 0) {
         if (m_use_soret == 0) {

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -792,8 +792,10 @@ PeleLM::readParameters()
   m_user_defined_ext_sources = false;
   m_ext_sources_SDC = false; // TODO: add capability to update ext_srcs in SDC
   m_plot_extSource = false;
+  m_add_variance_sources = true;
   pp.query("user_defined_ext_sources", m_user_defined_ext_sources);
   pp.query("plot_extSource", m_plot_extSource);
+  pp.query("add_variance_sources", m_add_variance_sources);
 }
 
 void

--- a/Source/PeleLMeX_Utils.cpp
+++ b/Source/PeleLMeX_Utils.cpp
@@ -782,20 +782,16 @@ PeleLM::floorSpecies(const TimeStamp& a_time)
         fabMinMax(
           i, j, k, 1, 0.0, AMREX_REAL_MAX, Array4<Real>(sma[box_no], NE));
 #endif
-        // Update density accordingly ...
-        sma[box_no](i, j, k, DENSITY) = 0.0;
-        for (int n = 0; n < NUM_SPECIES; n++) {
-          sma[box_no](i, j, k, DENSITY) += sma[box_no](i, j, k, FIRSTSPEC + n);
-        }
-
-        // ... as well as rhoh
-        auto eos = pele::physics::PhysicsType::eos(leosparm);
+        // Update density and RhoH accordingly ...
         Real massfrac[NUM_SPECIES] = {0.0};
-        Real rhoinv = Real(1.0) / sma[box_no](i, j, k, DENSITY);
+        Real massdens[NUM_SPECIES] = {0.0};
+        Real rhoinv, h_cgs = 0.0;
         for (int n = 0; n < NUM_SPECIES; n++) {
-          massfrac[n] = sma[box_no](i, j, k, FIRSTSPEC + n) * rhoinv;
+          massdens[n] = sma[box_no](i, j, k, FIRSTSPEC + n);
         }
-        Real h_cgs = 0.0;
+        auto eos = pele::physics::PhysicsType::eos(leosparm);
+        eos.RY2RRinvY(
+          massdens, sma[box_no](i, j, k, DENSITY), rhoinv, massfrac);
         eos.TY2H(sma[box_no](i, j, k, TEMP), massfrac, h_cgs);
         sma[box_no](i, j, k, RHOH) =
           h_cgs * 1.0e-4 * sma[box_no](i, j, k, DENSITY);


### PR DESCRIPTION
Make necessary change to compute density from species densities using `eos.RY2RRinvY` in `floorSpecies` function. 

Add option to not compute variance production/dissipation rates when manifold model contains variances (for debugging purposes)

Zero out turbulent diffusivity for temperature/enthalpy when using Manifold EOS. The enthalpy variable is still carried as 0 in these cases. Diffusivity should be zero so it doesn't change. 