### PR TITLE
check for NaNs at end of timestep

### DIFF
--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1505,6 +1505,7 @@ public:
     std::unique_ptr<AdvanceAdvData>& advData,
     std::unique_ptr<AdvanceDiffData>& diffData);
 
+  bool checkForNaNs();
   void copyTransportOldToNew();
   void copyStateNewToOld(int nGhost = 0);
   void copyPressNewToOld();

--- a/Source/PeleLMeX_Data.cpp
+++ b/Source/PeleLMeX_Data.cpp
@@ -351,3 +351,17 @@ PeleLM::copyDiffusionOldToNew(std::unique_ptr<AdvanceDiffData>& diffData)
     }
   }
 }
+
+bool
+PeleLM::checkForNaNs()
+{
+  bool contains_nan = false;
+  for (int lev = 0; lev <= finest_level; lev++) {
+    if (
+      m_leveldata_new[lev]->state.contains_nan() ||
+      m_leveldata_new[lev]->state.contains_inf()) {
+      contains_nan = true;
+    }
+  }
+  return contains_nan;
+}

--- a/Source/PeleLMeX_Evolve.cpp
+++ b/Source/PeleLMeX_Evolve.cpp
@@ -12,6 +12,7 @@ PeleLM::Evolve()
 
   int plt_justDidIt = 0;
   int chk_justDidIt = 0;
+  bool nans_in_solution = false;
 
   while (!do_not_evolve) {
 
@@ -101,10 +102,12 @@ PeleLM::Evolve()
         }
       }
     }
+    nans_in_solution = checkForNaNs();
     do_not_evolve =
       ((m_max_step >= 0 && m_nstep >= m_max_step) ||
        (m_stop_time >= 0.0 && m_cur_time >= m_stop_time - 1.0e-12 * m_dt) ||
-       (m_dt < m_min_dt) || over_max_wall_time || dump_and_stop);
+       (m_dt < m_min_dt) || over_max_wall_time || dump_and_stop ||
+       nans_in_solution);
   }
 
   if (m_verbose > 0) {
@@ -119,6 +122,10 @@ PeleLM::Evolve()
     (m_check_int > 0 || m_check_per > 0.) && (chk_justDidIt == 0) &&
     m_nstep > 0) {
     WriteCheckPointFile();
+  }
+
+  if (nans_in_solution) {
+    amrex::Error("Stopped early because NaNs detected in solution");
   }
 }
 


### PR DESCRIPTION
Check for NaNs in solution at the end of each timestep and stop if there are any. Ensures simulation doesn't continue unnecessarily with everything NaN when `amrex.fpe_trap_invalid = 0`. Similar to what happens in PeleC in these cases.