### PR TITLE
restart from plot file: enable mapping to different names for species

### DIFF
--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -130,7 +130,7 @@ IO parameters
     amr.restart          = chk00100        # [OPT, DEF=""] Checkpoint from which to restart the simulation
     amr.initDataPlt      = plt01000        # [OPT, DEF=""] Provide a plotfile from which to extract initial data
     peleLM.initDataPlt_reset_time = 1               # [OPT, DEF=1] Resets time and nsteps to 0 after restarting from a plot file. (Warning: plot file will be rewritten if not renamed and argument value = 0)
-    peleLM/initDataPlt_specname_map = spec1 spec2 # [OPT, DEF=""] If specified, lookup these entries instead of species names when populating species from the init plot file (length must match NUM_SPECIES)
+    peleLM.initDataPlt_specname_map = spec1 spec2 # [OPT, DEF=""] If specified, lookup these entries instead of species names when populating species from the init plot file (length must match NUM_SPECIES)
     peleLM.initDataPlt_patch_flow_variables = false # [OPT, DEF=false] Enable user-defined flow variable patching after reading a plot solution file
     amr.regrid_on_restart = 1              # [OPT, DEF="0"] Trigger a regrid after the data from checkpoint are loaded
     amr.n_files          = 64              # [OPT, DEF="min(256,NProcs)"] Number of files to write per level

--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -130,6 +130,7 @@ IO parameters
     amr.restart          = chk00100        # [OPT, DEF=""] Checkpoint from which to restart the simulation
     amr.initDataPlt      = plt01000        # [OPT, DEF=""] Provide a plotfile from which to extract initial data
     peleLM.initDataPlt_reset_time = 1               # [OPT, DEF=1] Resets time and nsteps to 0 after restarting from a plot file. (Warning: plot file will be rewritten if not renamed and argument value = 0)
+    peleLM/initDataPlt_specname_map = spec1 spec2 # [OPT, DEF=""] If specified, lookup these entries instead of species names when populating species from the init plot file (length must match NUM_SPECIES)
     peleLM.initDataPlt_patch_flow_variables = false # [OPT, DEF=false] Enable user-defined flow variable patching after reading a plot solution file
     amr.regrid_on_restart = 1              # [OPT, DEF="0"] Trigger a regrid after the data from checkpoint are loaded
     amr.n_files          = 64              # [OPT, DEF="min(256,NProcs)"] Number of files to write per level

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1901,6 +1901,7 @@ public:
   amrex::Vector<std::string> m_evaluatePlotVars;
   bool m_write_hdf5_pltfile = false;
   bool m_do_patch_flow_variables = false;
+  amrex::Vector<std::string> m_initDataPlt_specname_map = {};
 
   //-----------------------------------------------------------------------------
   // ALGORITHM

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -872,12 +872,14 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
       " restarting from plotfile with auxiliaries not currently "
       "implemented, and will not be captured");
   }
-  amrex::Print() << " initData on level " << a_lev << " from pltfile "
-                 << a_dataPltFile << "\n";
-  if (pltfileSource == "LM") {
-    amrex::Print() << " Assuming pltfile was generated in LM/LMeX \n";
-  } else if (pltfileSource == "C") {
-    amrex::Print() << " Assuming pltfile was generated in PeleC \n";
+  if (m_verbose > 0) {
+    amrex::Print() << " initData on level " << a_lev << " from pltfile "
+                   << a_dataPltFile << "\n";
+    if (pltfileSource == "LM") {
+      amrex::Print() << " Assuming pltfile was generated in LM/LMeX \n";
+    } else if (pltfileSource == "C") {
+      amrex::Print() << " Assuming pltfile was generated in PeleC \n";
+    }
   }
 
   // Use PelePhysics PltFileManager
@@ -938,8 +940,10 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   } else if (idT < 0) {
     Abort("Couldn't find temperature in pltfile");
   }
-  Print() << " " << nSpecPlt << " species found in pltfile, starting with "
-          << plt_vars[idY] << "\n";
+  if (m_verbose > 0) {
+    Print() << " " << nSpecPlt << " species found in pltfile, starting with "
+            << plt_vars[idY] << "\n";
+  }
 
   // Get level data
   auto* ldata_p = getLevelDataPtr(a_lev, AmrNewTime);
@@ -957,22 +961,52 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   MultiFab speciesPlt(grids[a_lev], dmap[a_lev], nSpecPlt, 0);
   pltData.fillPatchFromPlt(a_lev, geom[a_lev], idY, 0, nSpecPlt, speciesPlt);
   for (int i = 0; i < NUM_SPECIES; i++) {
-    std::string specString = "Y(" + spec_names[i] + ")";
+    std::string specName = "Y(" + spec_names[i] + ")";
+    std::string specString = specName;
+    amrex::Print() << m_initDataPlt_specname_map[0] << std::endl;
+    if (!m_initDataPlt_specname_map.empty()) {
+      specString = m_initDataPlt_specname_map[i];
+    }
     int foundSpec = 0;
     for (int iplt = 0; iplt < nSpecPlt; iplt++) {
       if (specString == plt_vars[idY + iplt]) {
         MultiFab::Copy(ldata_p->state, speciesPlt, iplt, FIRSTSPEC + i, 1, 0);
         foundSpec = 1;
+        if (m_verbose > 0) {
+          amrex::Print() << "Loading species " << specName
+                         << " from plotfile species " << specString
+                         << std::endl;
+        }
+      }
+    }
+    if (foundSpec == 0) {
+      for (int iplt = 0; iplt < plt_vars.size(); iplt++) {
+        if (specString == plt_vars[iplt]) {
+          foundSpec = 1;
+          if (m_verbose > 0) {
+            amrex::Print() << "Loading species " << specName
+                           << " from plotfile entry " << specString
+                           << std::endl;
+          }
+          pltData.fillPatchFromPlt(
+            a_lev, geom[a_lev], iplt, FIRSTSPEC + i, 1, ldata_p->state);
+        }
       }
     }
     if (foundSpec == 0) {
       ldata_p->state.setVal(0.0, FIRSTSPEC + i, 1);
+      if (m_verbose > 0) {
+        amrex::Print() << "For species " << specName << " entry " << specString
+                       << " not found in plot file, setting to 0 " << std::endl;
+      }
     }
   }
 
   // Converting units when pltfile is coming from PeleC solution
   if (pltfileSource == "C") {
-    amrex::Print() << " Converting CGS to MKS units... \n";
+    if (m_verbose > 0) {
+      amrex::Print() << " Converting CGS to MKS units... \n";
+    }
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -1103,8 +1137,10 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
 void
 PeleLM::addLevelVelocityDataFromPlt(int a_lev, const std::string& a_velPltFile)
 {
-  amrex::Print() << " init velocity data on level " << a_lev << " from pltfile "
-                 << a_velPltFile << "\n";
+  if (m_verbose > 0) {
+    amrex::Print() << " init velocity data on level " << a_lev
+                   << " from pltfile " << a_velPltFile << "\n";
+  }
 
   // Use PelePhysics PltFileManager
   pele::physics::pltfilemanager::PltFileManager pltData(a_velPltFile);

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -963,7 +963,6 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   for (int i = 0; i < NUM_SPECIES; i++) {
     std::string specName = "Y(" + spec_names[i] + ")";
     std::string specString = specName;
-    amrex::Print() << m_initDataPlt_specname_map[0] << std::endl;
     if (!m_initDataPlt_specname_map.empty()) {
       specString = m_initDataPlt_specname_map[i];
     }

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -947,8 +947,9 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
     amrex::Abort("Couldn't find temperature in pltfile");
   }
   if (m_verbose > 0) {
-      amrex::Print() << " " << nSpecPlt << " species found in pltfile, starting with "
-            << plt_vars[idY] << "\n";
+    amrex::Print() << " " << nSpecPlt
+                   << " species found in pltfile, starting with "
+                   << plt_vars[idY] << "\n";
   }
 
   // Get level data

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -545,6 +545,13 @@ PeleLM::readParameters()
   pp.query("do_init_proj", m_do_init_proj);
   pp.query("num_init_iter", m_init_iter);
   pp.query("initDataPlt_patch_flow_variables", m_do_patch_flow_variables);
+  pp.queryarr("initDataPlt_specname_map", m_initDataPlt_specname_map);
+  if (
+    !m_initDataPlt_specname_map.empty() &&
+    m_initDataPlt_specname_map.size() != NUM_SPECIES) {
+    amrex::Abort(
+      "If specifying a species name map, length must equal number of species");
+  }
   pp.query("initDataPlt_reset_time", m_do_reset_time);
 
   // -----------------------------------------


### PR DESCRIPTION
You can now specify 

```
peleLM.initDataPlt_specname_map = spec1 spec2 spec3
```

to lookup species from the plot file used for initialization with different variable names in that file. The number of names in the map must equal NUM_SPECIES and go in the same order as defined in `mechanism.H`.

Also adds some verbosity level checks around Print statements in the `initLevelDataFromPlt` function.