### PR TITLE
Spray for manifold model

### DIFF
--- a/Source/PeleLMeX_Forces.cpp
+++ b/Source/PeleLMeX_Forces.cpp
@@ -286,7 +286,7 @@ PeleLM::addScalarVarianceSources(const TimeStamp& a_timestamp)
         for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
           grad_fc[lev][idim].define(
             amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim)),
-            dmap[lev], 1, nGrow, MFInfo(), factory);
+            dmap[lev], 1, nGrow, amrex::MFInfo(), factory);
           grad_fc[lev][idim].setVal(0.0); // Required?
         }
       }

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -853,9 +853,9 @@ PeleLM::checkSetupParams()
       amrex::Abort("Soot models are not yet supported for Manifold EOS");
     }
 #endif
-//#ifdef PELE_USE_SPRAY
-//    amrex::Abort("Spray models are not yet supported for Manifold EOS");
-//#endif
+// #ifdef PELE_USE_SPRAY
+//     amrex::Abort("Spray models are not yet supported for Manifold EOS");
+// #endif
 #ifdef PELE_USE_PLASMA
     amrex::Abort("Plasma models are not yet supported for Manifold EOS");
 #endif

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -853,9 +853,9 @@ PeleLM::checkSetupParams()
       amrex::Abort("Soot models are not yet supported for Manifold EOS");
     }
 #endif
-// #ifdef PELE_USE_SPRAY
-//     amrex::Abort("Spray models are not yet supported for Manifold EOS");
-// #endif
+#ifdef PELE_USE_SPRAY
+    amrex::Abort("Spray models are not yet supported for Manifold EOS");
+#endif
 #ifdef PELE_USE_PLASMA
     amrex::Abort("Plasma models are not yet supported for Manifold EOS");
 #endif

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -843,9 +843,9 @@ PeleLM::checkSetupParams()
       amrex::Abort("Soot models are not yet supported for Manifold EOS");
     }
 #endif
-#ifdef PELE_USE_SPRAY
-    amrex::Abort("Spray models are not yet supported for Manifold EOS");
-#endif
+//#ifdef PELE_USE_SPRAY
+//    amrex::Abort("Spray models are not yet supported for Manifold EOS");
+//#endif
 #ifdef PELE_USE_PLASMA
     amrex::Abort("Plasma models are not yet supported for Manifold EOS");
 #endif

--- a/Source/PeleLMeX_SprayParticles.cpp
+++ b/Source/PeleLMeX_SprayParticles.cpp
@@ -58,7 +58,7 @@ PeleLM::SprayReadParameters()
   if (!do_spray_particles) {
     return;
   }
-  SprayParticleContainer::readSprayParams(spray_verbose,&eos_parms);
+  SprayParticleContainer::readSprayParams(spray_verbose);
   // Must change dtmod to 1 since we only do MKD
   SprayParticleContainer::getSprayData()->dtmod = 1.;
 }
@@ -74,7 +74,7 @@ PeleLM::SpraySetup()
   if (SPRAY_FUEL_NUM > NUM_SPECIES) {
     amrex::Abort("Cannot have more spray fuel species than fluid species");
   }
-  SprayParticleContainer::spraySetup(m_gravity.data(),&(eos_parms.host_parm()));
+  SprayParticleContainer::spraySetup(m_gravity.data(),&(eos_parms.host_parm()),&eos_parms);
   SprayComps scomps;
   // Component indices for conservative variables
   scomps.rhoIndx = DENSITY;

--- a/Source/PeleLMeX_SprayParticles.cpp
+++ b/Source/PeleLMeX_SprayParticles.cpp
@@ -61,7 +61,8 @@ PeleLM::SprayReadParameters()
   if (!do_spray_particles) {
     return;
   }
-  SprayParticleContainer::readSprayParams(spray_verbose);
+  //SprayParticleContainer::readSprayParams(spray_verbose);
+  SprayParticleContainer::readSprayParams(spray_verbose,&eos_parms);
   // Must change dtmod to 1 since we only do MKD
   SprayParticleContainer::getSprayData()->dtmod = 1.;
 }

--- a/Source/PeleLMeX_SprayParticles.cpp
+++ b/Source/PeleLMeX_SprayParticles.cpp
@@ -75,9 +75,10 @@ PeleLM::SpraySetup()
   // There must be at least as many fuel species in the spray as
   // there are species in the fluid
   if (SPRAY_FUEL_NUM > NUM_SPECIES) {
-    Abort("Cannot have more spray fuel species than fluid species");
+    amrex::Print()<<"Warning! Cannot have more spray fuel species than fluid species";
   }
-  SprayParticleContainer::spraySetup(m_gravity.data());
+  //SprayParticleContainer::spraySetup(m_gravity.data());
+  SprayParticleContainer::spraySetup(m_gravity.data(),eos_parms);
   SprayComps scomps;
   // Component indices for conservative variables
   scomps.rhoIndx = DENSITY;

--- a/Source/PeleLMeX_SprayParticles.cpp
+++ b/Source/PeleLMeX_SprayParticles.cpp
@@ -78,7 +78,7 @@ PeleLM::SpraySetup()
     amrex::Print()<<"Warning! Cannot have more spray fuel species than fluid species";
   }
   //SprayParticleContainer::spraySetup(m_gravity.data());
-  SprayParticleContainer::spraySetup(m_gravity.data(),eos_parms);
+  SprayParticleContainer::spraySetup(m_gravity.data(),&(eos_parms.host_parm()));
   SprayComps scomps;
   // Component indices for conservative variables
   scomps.rhoIndx = DENSITY;

--- a/Source/PeleLMeX_SprayParticles.cpp
+++ b/Source/PeleLMeX_SprayParticles.cpp
@@ -74,7 +74,9 @@ PeleLM::SpraySetup()
   if (SPRAY_FUEL_NUM > NUM_SPECIES) {
     amrex::Abort("Cannot have more spray fuel species than fluid species");
   }
-  SprayParticleContainer::spraySetup(m_gravity.data(),&(eos_parms.host_parm()),&eos_parms);
+
+  SprayParticleContainer::spraySetup(
+    m_gravity.data(), &eos_parms.host_parm(), eos_parms.device_parm());
   SprayComps scomps;
   // Component indices for conservative variables
   scomps.rhoIndx = DENSITY;


### PR DESCRIPTION
This PR works with commit 'f017cb0' of PelePhysics.
Includes host and device pointers in spraySetup() call to extend the functionality to include manifold model for spray