### PR TITLE
initialize GradVel for TurbVisc

### DIFF
--- a/Source/PeleLMeX_TransportProp.cpp
+++ b/Source/PeleLMeX_TransportProp.cpp
@@ -33,6 +33,7 @@ PeleLM::calcTurbViscosity(const TimeStamp& a_time)
       GradVel[lev][idim].define(
         amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim)), dm, ncomp,
         0, amrex::MFInfo(), factory);
+      GradVel[lev][idim].setVal(0.0);
     }
   }
 


### PR DESCRIPTION
I think there are issues for both covered FABs and covered cells in single values FABs, so this is the best solution.