### PR TITLE
Fix gpu segfault for extend signed distance

### DIFF
--- a/Source/PeleLMeX_Utils.cpp
+++ b/Source/PeleLMeX_Utils.cpp
@@ -2192,7 +2192,6 @@ PeleLM::extendSignedDistance(
   // This is a not-so-pretty piece of code that'll take AMReX cell-averaged
   // signed distance and propagates it manually up to the point where we need to
   // have it for derefining.
-  const auto geomdata = geom[0].data();
   const amrex::Real maxSignedDist = a_signDist->max(0);
   const auto& ebfactory =
     dynamic_cast<amrex::EBFArrayBoxFactory const&>(a_signDist->Factory());
@@ -2200,7 +2199,7 @@ PeleLM::extendSignedDistance(
   const int nGrowFac = flags.nGrow() + 1;
 
   // First set the region far away at the max value we need
-  const amrex::Real* dx = geomdata.CellSize();
+  const auto& dx = geom[0].CellSizeArray();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())


### PR DESCRIPTION
The issue is that we capture geomdata on host. And then we take a pointer to dx in geomdata and use that on device. That causes a 
```
amrex::Abort::0::CUDA error 700 in file /mnt/vdb/home/mhenryde/combustion/Pele/PeleLMeX/Submodules/PelePhysics/Submodules/amrex/Src/Base/AMReX_GpuDevice.cpp line 689: an illegal memory ac
cess was encountered !!!
SIGABRT
```

The fix is to grab dx as a gpuarray and then everything is fine.