### PR TITLE
Fix heap use after free in device vector transform

### DIFF
--- a/Source/PeleLMeX_Advection.cpp
+++ b/Source/PeleLMeX_Advection.cpp
@@ -271,7 +271,8 @@ PeleLM::getScalarAdvForce(
   const std::unique_ptr<AdvanceDiffData>& diffData)
 {
 
-  const int* aux_diffuse_d = convertToDeviceVector(m_DiffTypeAux).dataPtr();
+  const auto aux_diffuse_v = convertToDeviceVector(m_DiffTypeAux);
+  const auto* aux_diffuse_d = aux_diffuse_v.dataPtr();
   auto const* leosparm = eos_parms.device_parm();
 
   for (int lev = 0; lev <= finest_level; ++lev) {

--- a/Source/PeleLMeX_Diffusion.cpp
+++ b/Source/PeleLMeX_Diffusion.cpp
@@ -1714,8 +1714,10 @@ PeleLM::getScalarDiffForce(
   const std::unique_ptr<AdvanceDiffData>& diffData)
 {
 
-  const int* aux_advect_d = convertToDeviceVector(m_aux_advect).dataPtr();
-  const int* aux_diffuse_d = convertToDeviceVector(m_DiffTypeAux).dataPtr();
+  const auto aux_advect_v = convertToDeviceVector(m_aux_advect);
+  const auto aux_diffuse_v = convertToDeviceVector(m_DiffTypeAux);
+  const auto* aux_advect_d = aux_advect_v.dataPtr();
+  const auto* aux_diffuse_d = aux_diffuse_v.dataPtr();
 
   for (int lev = 0; lev <= finest_level; ++lev) {
 

--- a/Source/PeleLMeX_Utils.H
+++ b/Source/PeleLMeX_Utils.H
@@ -2,8 +2,10 @@
 #define PELELM_UTILS_H
 template <class T>
 amrex::Gpu::DeviceVector<T>
-convertToDeviceVector(amrex::Vector<T> v)
+convertToDeviceVector(const amrex::Vector<T>& v)
 {
+  static_assert(
+    std::is_trivially_copyable_v<T>, "T must be trivially copyable");
   int ncomp = v.size();
   amrex::Gpu::DeviceVector<T> v_d(ncomp);
 #ifdef AMREX_USE_GPU


### PR DESCRIPTION
This PR removes this error:
```
==3652521==ERROR: AddressSanitizer: heap-use-after-free on address 0x7b729e858630 at pc 0x5608147fd075 bp 0x7ffd2739bc10 sp 0x7ffd2739bc08
READ of size 4 at 0x7b729e858630 thread T0
```

which comes because we immediately take a pointer to a vector which is only stored as a temporary and gets destroyed and so the pointer points to nothing.