### PR TITLE
Group species for temporals

### DIFF
--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -631,7 +631,7 @@ advective \& diffusive fluxes across the domain boundaries, consumption rate int
 Users can also monitor species advective fluxes through specific regions of the domain boundaries (called as boundary patches).
 Patches can be defined on the low or high sides of non-embedded boundaries through the use of pre-defined shapes such as `circle`,
 `rectangle`,`circle-annular`, `rectangle-annular` and `full-boundary`. The zero AMR level, advective fluxes of each of the user-specified species will be
-reported in the ASCII `temppatchmfr` file in the temporals folder. User can also group species to define a mixture in the species list, in the format {<mixture-name>:<species1>,<species2>,..,<speciesN>}. For example, to get the total air mass flow rate
+reported in the ASCII `temppatchmfr` file in the temporals folder. User can also group species to define a mixture in the species list, in the format {<mixture-name>:<species1>,<species2>,..,<speciesN>}. For example, to get the total air mass flow rate,
 the user can define {Air:O2,N2} in the species list. The temporal function would then print total species fluxes of O2 and N2 through the specified patch.
 
 Combustion diagnostics often involve the use of a mixture fraction and/or a progress variable, both of which can be defined

--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -588,7 +588,7 @@ to activate `temporal` diagnostics performing these reductions at given interval
     bpatch.patch_name1.patchtype=full-boundary             # patchtype one of "full-boundary", "circle, "rectangle", "circle-annular" or "rectangle-annular"
     bpatch.patch_name1.boundary_direction=2                # patch normal direction
     bpatch.patch_name1.boundary_lo_or_hi=0                 # patch in low or high side of boundary
-    bpatch.patch_name1.species= O2 N2                      # list of species names
+    bpatch.patch_name1.species= {Air:O2,N2} O2 N2                      # list of species names
 
     bpatch.patch_name2.patchtype=circle                    # patchtype one of "full-boundary", "circle, "rectangle", "circle-annular" or "rectangle-annular"
     bpatch.patch_name2.boundary_direction=2                # patch normal direction
@@ -631,7 +631,8 @@ advective \& diffusive fluxes across the domain boundaries, consumption rate int
 Users can also monitor species advective fluxes through specific regions of the domain boundaries (called as boundary patches).
 Patches can be defined on the low or high sides of non-embedded boundaries through the use of pre-defined shapes such as `circle`,
 `rectangle`,`circle-annular`, `rectangle-annular` and `full-boundary`. The zero AMR level, advective fluxes of each of the user-specified species will be
-reported in the ASCII `temppatchmfr` file in the temporals folder.
+reported in the ASCII `temppatchmfr` file in the temporals folder. User can also group species to define a mixture in the species list, in the format {<mixture-name>:<species1>,<species2>,..,<speciesN>}. For example, to get the total air mass flow rate
+the user can define {Air:O2,N2} in the species list. The temporal function would then print total species fluxes of O2 and N2 through the specified patch.
 
 Combustion diagnostics often involve the use of a mixture fraction and/or a progress variable, both of which can be defined
 at run time and added to the derived variables included in the plotfile. If `mixture_fraction` or `progress_variable` is

--- a/Source/PeleLMeX_BPatch.H
+++ b/Source/PeleLMeX_BPatch.H
@@ -16,7 +16,8 @@ public:
   {
     int m_boundary_dir;
     int m_boundary_lo_hi;
-    int num_species;
+    int num_species = 0;
+    int num_groups = 0;
     int m_patchtype_num;
     int* speciesIndex = nullptr;
     amrex::Real* speciesFlux = nullptr;
@@ -228,6 +229,8 @@ public:
     m_patchtype; // values:
                  // "fullboundary","circle","rectangle","annular-circle","annular-rectangle"
   amrex::Vector<std::string> speciesList;
+  amrex::Vector<std::string> groupNames;
+  amrex::Vector<amrex::Vector<int>> speciesinGroup;
 
 protected:
   BpatchDataContainer m_bpdata_h;

--- a/Source/PeleLMeX_BPatch.cpp
+++ b/Source/PeleLMeX_BPatch.cpp
@@ -201,7 +201,26 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
             tmp_species_only.push_back(item);
           }
         }
+        //Check and remove if there are duplicate species in the group definitions
+        std::sort(speciesList.begin(), speciesList.end());
+          speciesList.erase(
+            std::unique(speciesList.begin(), speciesList.end()), speciesList.end());
       }
+
+      std::unordered_set<std::string> check_duplicate;
+      bool hasDuplicateSpecies = false;
+      for (const auto& s : tokens)
+      {
+    	  if (!check_duplicate.insert(s).second) { // insert returns {iterator, success}
+    		  hasDuplicateSpecies = true;
+    		  std::string msg =
+    		            "\nError! Duplicate species "+s+" in group definition " +
+    		            groupname_tmp;
+    		          amrex::Abort(msg);
+
+    	  }
+      }
+
       // If tokens is null vector abort
       if (tokens.size() <= 0) {
         std::string msg =

--- a/Source/PeleLMeX_BPatch.cpp
+++ b/Source/PeleLMeX_BPatch.cpp
@@ -226,11 +226,9 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
       }
 
       std::unordered_set<std::string> check_duplicate;
-      bool hasDuplicateSpecies = false;
       for (const auto& s : tokens) {
         if (!check_duplicate.insert(s)
-               .second) { // insert returns {iterator, success}
-          hasDuplicateSpecies = true;
+              .second) { // insert returns {iterator, success}
           std::string msg = "\nError! Duplicate species " + s +
                             " in group definition " + groupname_tmp +
                             "  in the patch " + patch_name;

--- a/Source/PeleLMeX_BPatch.cpp
+++ b/Source/PeleLMeX_BPatch.cpp
@@ -215,7 +215,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
         	item_trimmed = Trim_First_Last_Whitespace(item);
           tokens.push_back(item_trimmed);
           auto it =
-            std::find(tmp_species_only.begin(), tmp_species_only.end(), item);
+            std::find(tmp_species_only.begin(), tmp_species_only.end(), item_trimmed);
           if (it != tmp_species_only.end()) {
             // Do nothing
           } else {
@@ -331,8 +331,10 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
         // Split by comma
         std::stringstream ss(rest);
         std::string item;
+        std::string item_trimmed;
         while (std::getline(ss, item, ',')) {
-          auto it = std::find(names.begin(), names.end(), item);
+        	item_trimmed = Trim_First_Last_Whitespace(item);
+          auto it = std::find(names.begin(), names.end(), item_trimmed);
           size_t index = std::distance(names.begin(), it);
           tmp.push_back(static_cast<int>(index));
         }

--- a/Source/PeleLMeX_BPatch.cpp
+++ b/Source/PeleLMeX_BPatch.cpp
@@ -222,10 +222,6 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
             tmp_species_only.push_back(item_trimmed);
           }
         }
-        //Check and remove if there are duplicate species in the group definitions
-        std::sort(speciesList.begin(), speciesList.end());
-          speciesList.erase(
-            std::unique(speciesList.begin(), speciesList.end()), speciesList.end());
       }
 
       std::unordered_set<std::string> check_duplicate;
@@ -302,7 +298,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
 
   for (const auto& s : speciesList) {
     amrex::Vector<int> tmp;
-    if (s.front() != '{' && s.back() != '}') {
+    if (!(s.front() == '{' && s.back() == '}')) {
       auto it = std::find(names.begin(), names.end(), s);
       if (it != names.end()) {
         size_t index = std::distance(names.begin(), it);

--- a/Source/PeleLMeX_BPatch.cpp
+++ b/Source/PeleLMeX_BPatch.cpp
@@ -266,7 +266,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
       auto it = std::find(names.begin(), names.end(), s);
       if (it != names.end()) {
         size_t index = std::distance(names.begin(), it);
-        tmp.push_back(index);
+        tmp.push_back(static_cast<int>(index));
       }
       speciesinGroup.push_back(tmp);
       groupNames.push_back(s);
@@ -294,7 +294,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
         while (std::getline(ss, item, ',')) {
           auto it = std::find(names.begin(), names.end(), item);
           size_t index = std::distance(names.begin(), it);
-          tmp.push_back(index);
+          tmp.push_back(static_cast<int>(index));
         }
       }
       speciesinGroup.push_back(tmp);
@@ -304,7 +304,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
   // If species are not found by now, they could be defined in groups. Check for
   // species group definitions
 
-  m_bpdata_h.num_groups = groupNames.size();
+  m_bpdata_h.num_groups = static_cast<int>(groupNames.size());
 
   allocate();
   amrex::Gpu::streamSynchronize();

--- a/Source/PeleLMeX_BPatch.cpp
+++ b/Source/PeleLMeX_BPatch.cpp
@@ -1,6 +1,14 @@
 #include "PeleLMeX_BPatch.H"
 #include "PelePhysics.H"
 
+std::string Trim_First_Last_Whitespace(const std::string& species_name) {
+    auto start = species_name.find_first_not_of(" \t\n\r\f\v");
+    auto end   = species_name.find_last_not_of(" \t\n\r\f\v");
+
+    if (start == std::string::npos) return ""; // all whitespace
+    return species_name.substr(start, end - start + 1);
+}
+
 BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
   : m_patchname(std::move(patch_name))
 {
@@ -162,8 +170,10 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
   // now, we are not checking if the species actually exist in the mechanism
 
   for (const auto& s : speciesList) {
+	  std::string s_trimmed;
     if (s.front() != '{' && s.back() != '}') {
-      tmp_species_only.push_back(s);
+    	s_trimmed = Trim_First_Last_Whitespace(s);
+      tmp_species_only.push_back(s_trimmed);
     }
   }
 
@@ -191,14 +201,16 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
         // Split by comma
         std::stringstream ss(rest);
         std::string item;
+        std::string item_trimmed;
         while (std::getline(ss, item, ',')) {
-          tokens.push_back(item);
+        	item_trimmed = Trim_First_Last_Whitespace(item);
+          tokens.push_back(item_trimmed);
           auto it =
             std::find(tmp_species_only.begin(), tmp_species_only.end(), item);
           if (it != tmp_species_only.end()) {
             // Do nothing
           } else {
-            tmp_species_only.push_back(item);
+            tmp_species_only.push_back(item_trimmed);
           }
         }
         //Check and remove if there are duplicate species in the group definitions

--- a/Source/PeleLMeX_BPatch.cpp
+++ b/Source/PeleLMeX_BPatch.cpp
@@ -160,39 +160,33 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
 
   // To begin with, fill tmp_species_only with pure species in the list. For
   // now, we are not checking if the species actually exist in the mechanism
-  for (int n = 0; n < speciesList.size(); ++n) {
-    if (
-      speciesList[n][0] != '{' &&
-      speciesList[n][speciesList[n].size() - 1] != '}') {
-      tmp_species_only.push_back(speciesList[n]);
+
+  for (const auto& s : speciesList) {
+    if (s.front() != '{' && s.back() != '}') {
+      tmp_species_only.push_back(s);
     }
   }
 
   // Now search for species in the group definitions and fill them in
   // tmp_species_only. For now, we are not checking if the species actually
   // exist in the mechanism
-  for (int n = 0; n < speciesList.size(); ++n) {
-    if (
-      speciesList[n][0] == '{' and speciesList[n][speciesList[n].size() - 1] ==
-                                     '}') // Found a group definition
-    {
-      size_t start = speciesList[n].find('{'); // opening brace
-      size_t colon = speciesList[n].find(':'); // first colon
-      size_t end = speciesList[n].find('}');   // ending brace
 
+  for (const auto& s : speciesList) {
+    if (s.front() == '{' && s.back() == '}') {
+      size_t start = s.find('{');
+      size_t colon = s.find(':');
+      size_t end = s.find('}');
       std::string groupname_tmp;
-
       if (
         start != std::string::npos && colon != std::string::npos &&
         colon > start) {
-        groupname_tmp = speciesList[n].substr(start + 1, colon - start - 1);
+        groupname_tmp = s.substr(start + 1, colon - start - 1);
       }
-
       amrex::Vector<std::string> tokens;
       if (
         colon != std::string::npos && end != std::string::npos && end > colon) {
         // Extract substring between ':' and '}'
-        std::string rest = speciesList[n].substr(colon + 1, end - colon - 1);
+        std::string rest = s.substr(colon + 1, end - colon - 1);
 
         // Split by comma
         std::stringstream ss(rest);
@@ -220,11 +214,11 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
 
   // Now we collected all the species for which we need to find flux. Now let us
   // check if all the species in tmp_species_only exist in the mechanism
-  for (int n = 0; n < tmp_species_only.size(); ++n) {
-    auto it = std::find(names.begin(), names.end(), tmp_species_only[n]);
+  for (const auto& s : tmp_species_only) {
+    auto it = std::find(names.begin(), names.end(), s);
     if (it == names.end()) {
       std::string msg =
-        "\nError! Unable to find species " + tmp_species_only[n] +
+        "\nError! Unable to find species " + s +
         " in the mechanism. Please correct the bpatch species list";
       amrex::Abort(msg);
     }
@@ -232,7 +226,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
 
   // Now the species list should be devoid of any duplicates or non-existent
   // species
-  m_bpdata_h.num_species = tmp_species_only.size();
+  m_bpdata_h.num_species = static_cast<int>(tmp_species_only.size());
 
   // Now allocate memory for speciesIndex and speciesFlux
   if (m_bpdata_h.num_species > 0) {
@@ -255,53 +249,44 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
     auto it = std::find(names.begin(), names.end(), tmp_species_only[n]);
     if (it != names.end()) {
       size_t index = std::distance(names.begin(), it);
-      m_bpdata_h.speciesIndex[n] = index;
+      m_bpdata_h.speciesIndex[n] = static_cast<int>(index);
     }
   }
 
-  // Check if there is -1. There shouldnt be any
+  // Check if there is -1. There shouldn't be any
   for (int n = 0; n < m_bpdata_h.num_species; n++) {
     if (m_bpdata_h.speciesIndex[n] == -1) {
-      amrex::Abort("\nError! -1 found in specied index vector");
+      amrex::Abort("\nError! -1 found in specified index vector");
     }
   }
 
-  for (int n = 0; n < speciesList.size(); ++n) {
-    // First add pure species to grouplist
+  for (const auto& s : speciesList) {
     amrex::Vector<int> tmp;
-    if (
-      speciesList[n][0] != '{' &&
-      speciesList[n][speciesList[n].size() - 1] != '}') {
-      auto it = std::find(names.begin(), names.end(), speciesList[n]);
+    if (s.front() != '{' && s.back() != '}') {
+      auto it = std::find(names.begin(), names.end(), s);
       if (it != names.end()) {
         size_t index = std::distance(names.begin(), it);
         tmp.push_back(index);
       }
-
       speciesinGroup.push_back(tmp);
-      groupNames.push_back(speciesList[n]);
-    }
-
-    if (
-      speciesList[n][0] == '{' and speciesList[n][speciesList[n].size() - 1] ==
-                                     '}') // Found a group definition
+      groupNames.push_back(s);
+    } else if (s.front() == '{' && s.back() == '}') // Found a group definition
     {
-      size_t start = speciesList[n].find('{'); // opening brace
-      size_t colon = speciesList[n].find(':'); // first colon
-      size_t end = speciesList[n].find('}');   // ending brace
+      size_t start = s.find('{'); // opening brace
+      size_t colon = s.find(':'); // first colon
+      size_t end = s.find('}');   // ending brace
 
       if (
         start != std::string::npos && colon != std::string::npos &&
         colon > start) {
-        groupNames.push_back(
-          speciesList[n].substr(start + 1, colon - start - 1));
+        groupNames.push_back(s.substr(start + 1, colon - start - 1));
       }
 
       amrex::Vector<std::string> tokens;
       if (
         colon != std::string::npos && end != std::string::npos && end > colon) {
         // Extract substring between ':' and '}'
-        std::string rest = speciesList[n].substr(colon + 1, end - colon - 1);
+        std::string rest = s.substr(colon + 1, end - colon - 1);
 
         // Split by comma
         std::stringstream ss(rest);
@@ -320,21 +305,6 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
   // species group definitions
 
   m_bpdata_h.num_groups = groupNames.size();
-
-  for (int n = 0; n < groupNames.size(); n++) {
-    amrex::Print() << "\n Group names = " << groupNames[n];
-    for (int m = 0; m < speciesinGroup[n].size(); m++) {
-      amrex::Print() << "\n\t Species index: " << speciesinGroup[n][m];
-    }
-  }
-
-  for (int n = 0; n < m_bpdata_h.num_species; ++n) {
-    if (m_bpdata_h.speciesIndex[n] == -1) {
-      std::string msg = "\nError! Unable to find species index " +
-                        std::to_string(n) + " with name " + speciesList[n];
-      amrex::Abort(msg);
-    }
-  }
 
   allocate();
   amrex::Gpu::streamSynchronize();

--- a/Source/PeleLMeX_BPatch.cpp
+++ b/Source/PeleLMeX_BPatch.cpp
@@ -1,12 +1,15 @@
 #include "PeleLMeX_BPatch.H"
 #include "PelePhysics.H"
 
-std::string Trim_First_Last_Whitespace(const std::string& species_name) {
-    auto start = species_name.find_first_not_of(" \t\n\r\f\v");
-    auto end   = species_name.find_last_not_of(" \t\n\r\f\v");
+std::string
+Trim_First_Last_Whitespace(const std::string& species_name)
+{
+  auto start = species_name.find_first_not_of(" \t\n\r\f\v");
+  auto end = species_name.find_last_not_of(" \t\n\r\f\v");
 
-    if (start == std::string::npos) return ""; // all whitespace
-    return species_name.substr(start, end - start + 1);
+  if (start == std::string::npos)
+    return ""; // all whitespace
+  return species_name.substr(start, end - start + 1);
 }
 
 BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
@@ -170,9 +173,9 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
   // now, we are not checking if the species actually exist in the mechanism
 
   for (const auto& s : speciesList) {
-	  std::string s_trimmed;
+    std::string s_trimmed;
     if (!(s.front() == '{' && s.back() == '}')) {
-    	s_trimmed = Trim_First_Last_Whitespace(s);
+      s_trimmed = Trim_First_Last_Whitespace(s);
       tmp_species_only.push_back(s_trimmed);
     }
   }
@@ -198,13 +201,11 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
         // Extract substring between ':' and '}'
         std::string rest = s.substr(colon + 1, end - colon - 1);
 
-        if(rest.empty())
-        {
-        	std::string msg =
-        	    		            "\nError! Empty species list in the group definition " +
-        	    		            groupname_tmp+"  in the patch "+patch_name;
-        	    		          amrex::Abort(msg);
-
+        if (rest.empty()) {
+          std::string msg =
+            "\nError! Empty species list in the group definition " +
+            groupname_tmp + "  in the patch " + patch_name;
+          amrex::Abort(msg);
         }
 
         // Split by comma
@@ -212,10 +213,10 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
         std::string item;
         std::string item_trimmed;
         while (std::getline(ss, item, ',')) {
-        	item_trimmed = Trim_First_Last_Whitespace(item);
+          item_trimmed = Trim_First_Last_Whitespace(item);
           tokens.push_back(item_trimmed);
-          auto it =
-            std::find(tmp_species_only.begin(), tmp_species_only.end(), item_trimmed);
+          auto it = std::find(
+            tmp_species_only.begin(), tmp_species_only.end(), item_trimmed);
           if (it != tmp_species_only.end()) {
             // Do nothing
           } else {
@@ -226,23 +227,22 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
 
       std::unordered_set<std::string> check_duplicate;
       bool hasDuplicateSpecies = false;
-      for (const auto& s : tokens)
-      {
-    	  if (!check_duplicate.insert(s).second) { // insert returns {iterator, success}
-    		  hasDuplicateSpecies = true;
-    		  std::string msg =
-    		            "\nError! Duplicate species "+s+" in group definition " +
-    		            groupname_tmp+"  in the patch "+patch_name;
-    		          amrex::Abort(msg);
-
-    	  }
+      for (const auto& s : tokens) {
+        if (!check_duplicate.insert(s)
+               .second) { // insert returns {iterator, success}
+          hasDuplicateSpecies = true;
+          std::string msg = "\nError! Duplicate species " + s +
+                            " in group definition " + groupname_tmp +
+                            "  in the patch " + patch_name;
+          amrex::Abort(msg);
+        }
       }
 
       // If tokens is null vector abort
       if (tokens.size() <= 0) {
         std::string msg =
           "\nError! Unable to find species in the group definition " +
-          groupname_tmp+"  in the patch "+patch_name;
+          groupname_tmp + "  in the patch " + patch_name;
         amrex::Abort(msg);
       }
     }
@@ -253,9 +253,10 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
   for (const auto& s : tmp_species_only) {
     auto it = std::find(names.begin(), names.end(), s);
     if (it == names.end()) {
-      std::string msg =
-        "\nError! Unable to find species " + s +
-        " in the mechanism. Please correct the bpatch species list in the patch "+patch_name;
+      std::string msg = "\nError! Unable to find species " + s +
+                        " in the mechanism. Please correct the bpatch species "
+                        "list in the patch " +
+                        patch_name;
       amrex::Abort(msg);
     }
   }
@@ -329,7 +330,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
         std::string item;
         std::string item_trimmed;
         while (std::getline(ss, item, ',')) {
-        	item_trimmed = Trim_First_Last_Whitespace(item);
+          item_trimmed = Trim_First_Last_Whitespace(item);
           auto it = std::find(names.begin(), names.end(), item_trimmed);
           size_t index = std::distance(names.begin(), it);
           tmp.push_back(static_cast<int>(index));

--- a/Source/PeleLMeX_BPatch.cpp
+++ b/Source/PeleLMeX_BPatch.cpp
@@ -7,8 +7,9 @@ Trim_First_Last_Whitespace(const std::string& species_name)
   auto start = species_name.find_first_not_of(" \t\n\r\f\v");
   auto end = species_name.find_last_not_of(" \t\n\r\f\v");
 
-  if (start == std::string::npos)
+  if (start == std::string::npos) {
     return ""; // all whitespace
+  }
   return species_name.substr(start, end - start + 1);
 }
 
@@ -169,13 +170,27 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
   amrex::Vector<std::string> names;
   pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(names);
 
-  // To begin with, fill tmp_species_only with pure species in the list. For
-  // now, we are not checking if the species actually exist in the mechanism
-
+  // Check if there are unpaired open or closing braces in group definitions.
   for (const auto& s : speciesList) {
     std::string s_trimmed;
-    if (!(s.front() == '{' && s.back() == '}')) {
-      s_trimmed = Trim_First_Last_Whitespace(s);
+    s_trimmed = Trim_First_Last_Whitespace(s);
+    if (
+      (s_trimmed.front() == '{' && s_trimmed.back() != '}') ||
+      (s_trimmed.front() != '{' && s_trimmed.back() == '}')) {
+      std::string msg = "\nError! Unpaired open or closing braces in group "
+                        "definition in the patch " +
+                        m_patchname;
+      amrex::Abort(msg);
+    }
+  }
+
+  // To begin with, fill tmp_species_only with pure species in the list. For
+  // now, we are not checking if the species actually exist in the mechanism
+  for (const auto& s : speciesList) {
+    std::string s_trimmed;
+    s_trimmed = Trim_First_Last_Whitespace(s);
+    if ((s_trimmed.front() != '{' && s_trimmed.back() != '}')) {
+
       tmp_species_only.push_back(s_trimmed);
     }
   }
@@ -204,7 +219,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
         if (rest.empty()) {
           std::string msg =
             "\nError! Empty species list in the group definition " +
-            groupname_tmp + "  in the patch " + patch_name;
+            groupname_tmp + "  in the patch " + m_patchname;
           amrex::Abort(msg);
         }
 
@@ -226,12 +241,12 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
       }
 
       std::unordered_set<std::string> check_duplicate;
-      for (const auto& s : tokens) {
-        if (!check_duplicate.insert(s)
+      for (const auto& token : tokens) {
+        if (!check_duplicate.insert(token)
                .second) { // insert returns {iterator, success}
           std::string msg = "\nError! Duplicate species " + s +
                             " in group definition " + groupname_tmp +
-                            "  in the patch " + patch_name;
+                            "  in the patch " + m_patchname;
           amrex::Abort(msg);
         }
       }
@@ -240,7 +255,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
       if (tokens.size() <= 0) {
         std::string msg =
           "\nError! Unable to find species in the group definition " +
-          groupname_tmp + "  in the patch " + patch_name;
+          groupname_tmp + "  in the patch " + m_patchname;
         amrex::Abort(msg);
       }
     }
@@ -254,7 +269,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
       std::string msg = "\nError! Unable to find species " + s +
                         " in the mechanism. Please correct the bpatch species "
                         "list in the patch " +
-                        patch_name;
+                        m_patchname;
       amrex::Abort(msg);
     }
   }
@@ -297,7 +312,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
 
   for (const auto& s : speciesList) {
     amrex::Vector<int> tmp;
-    if (!(s.front() == '{' && s.back() == '}')) {
+    if (s.front() != '{' && s.back() != '}') {
       auto it = std::find(names.begin(), names.end(), s);
       if (it != names.end()) {
         size_t index = std::distance(names.begin(), it);

--- a/Source/PeleLMeX_BPatch.cpp
+++ b/Source/PeleLMeX_BPatch.cpp
@@ -228,7 +228,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
       std::unordered_set<std::string> check_duplicate;
       for (const auto& s : tokens) {
         if (!check_duplicate.insert(s)
-              .second) { // insert returns {iterator, success}
+               .second) { // insert returns {iterator, success}
           std::string msg = "\nError! Duplicate species " + s +
                             " in group definition " + groupname_tmp +
                             "  in the patch " + patch_name;

--- a/Source/PeleLMeX_BPatch.cpp
+++ b/Source/PeleLMeX_BPatch.cpp
@@ -140,38 +140,198 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
   }
 
   m_bpdata_h.num_species = ps.countval("species");
-  ps.getarr("species", speciesList);
+  ps.getarr("species", speciesList); // This is not exactly species list. This
+                                     // should also include species groups
 
+  // First find out the total number of species&groups specified in the input
+  // file
   if (m_bpdata_h.num_species > 0) {
     speciesList.resize(m_bpdata_h.num_species);
+  }
+
+  // Remove duplicate entries
+  std::sort(speciesList.begin(), speciesList.end());
+  speciesList.erase(
+    std::unique(speciesList.begin(), speciesList.end()), speciesList.end());
+
+  amrex::Vector<std::string> tmp_species_only;
+  amrex::Vector<std::string> names;
+  pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(names);
+
+  // To begin with, fill tmp_species_only with pure species in the list. For
+  // now, we are not checking if the species actually exist in the mechanism
+  for (int n = 0; n < speciesList.size(); ++n) {
+    if (
+      speciesList[n][0] != '{' &&
+      speciesList[n][speciesList[n].size() - 1] != '}') {
+      tmp_species_only.push_back(speciesList[n]);
+    }
+  }
+
+  // Now search for species in the group definitions and fill them in
+  // tmp_species_only. For now, we are not checking if the species actually
+  // exist in the mechanism
+  for (int n = 0; n < speciesList.size(); ++n) {
+    if (
+      speciesList[n][0] == '{' and speciesList[n][speciesList[n].size() - 1] ==
+                                     '}') // Found a group definition
+    {
+      size_t start = speciesList[n].find('{'); // opening brace
+      size_t colon = speciesList[n].find(':'); // first colon
+      size_t end = speciesList[n].find('}');   // ending brace
+
+      std::string groupname_tmp;
+
+      if (
+        start != std::string::npos && colon != std::string::npos &&
+        colon > start) {
+        groupname_tmp = speciesList[n].substr(start + 1, colon - start - 1);
+      }
+
+      amrex::Vector<std::string> tokens;
+      if (
+        colon != std::string::npos && end != std::string::npos && end > colon) {
+        // Extract substring between ':' and '}'
+        std::string rest = speciesList[n].substr(colon + 1, end - colon - 1);
+
+        // Split by comma
+        std::stringstream ss(rest);
+        std::string item;
+        while (std::getline(ss, item, ',')) {
+          tokens.push_back(item);
+          auto it =
+            std::find(tmp_species_only.begin(), tmp_species_only.end(), item);
+          if (it != tmp_species_only.end()) {
+            // Do nothing
+          } else {
+            tmp_species_only.push_back(item);
+          }
+        }
+      }
+      // If tokens is null vector abort
+      if (tokens.size() <= 0) {
+        std::string msg =
+          "\nError! Unable to find species in the group definition " +
+          groupname_tmp;
+        amrex::Abort(msg);
+      }
+    }
+  }
+
+  // Now we collected all the species for which we need to find flux. Now let us
+  // check if all the species in tmp_species_only exist in the mechanism
+  for (int n = 0; n < tmp_species_only.size(); ++n) {
+    auto it = std::find(names.begin(), names.end(), tmp_species_only[n]);
+    if (it == names.end()) {
+      std::string msg =
+        "\nError! Unable to find species " + tmp_species_only[n] +
+        " in the mechanism. Please correct the bpatch species list";
+      amrex::Abort(msg);
+    }
+  }
+
+  // Now the species list should be devoid of any duplicates or non-existent
+  // species
+  m_bpdata_h.num_species = tmp_species_only.size();
+
+  // Now allocate memory for speciesIndex and speciesFlux
+  if (m_bpdata_h.num_species > 0) {
     m_bpdata_h.speciesIndex = (int*)amrex::The_Pinned_Arena()->alloc(
       m_bpdata_h.num_species * sizeof(int));
     m_bpdata_h.speciesFlux = (amrex::Real*)amrex::The_Pinned_Arena()->alloc(
       m_bpdata_h.num_species * sizeof(amrex::Real));
+    m_host_allocated = true;
   } else {
     amrex::Abort("\nError! No species provided to plot flux at boundary patch");
   }
 
-  amrex::Vector<std::string> names;
-  pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(names);
-  names.resize(names.size());
-
-  for (int n = 0; n < names.size(); ++n) {
+  // Initialise with -1
+  for (int n = 0; n < m_bpdata_h.num_species; n++) {
     m_bpdata_h.speciesIndex[n] = -1;
   }
 
-  for (int m = 0; m < m_bpdata_h.num_species; ++m) {
-    for (int n = 0; n < names.size(); ++n) {
-      if (speciesList[m] == names[n]) {
-        m_bpdata_h.speciesIndex[m] = n;
+  // Now fill speciesIndex
+  for (int n = 0; n < tmp_species_only.size(); n++) {
+    auto it = std::find(names.begin(), names.end(), tmp_species_only[n]);
+    if (it != names.end()) {
+      size_t index = std::distance(names.begin(), it);
+      m_bpdata_h.speciesIndex[n] = index;
+    }
+  }
+
+  // Check if there is -1. There shouldnt be any
+  for (int n = 0; n < m_bpdata_h.num_species; n++) {
+    if (m_bpdata_h.speciesIndex[n] == -1) {
+      amrex::Abort("\nError! -1 found in specied index vector");
+    }
+  }
+
+  for (int n = 0; n < speciesList.size(); ++n) {
+    // First add pure species to grouplist
+    amrex::Vector<int> tmp;
+    if (
+      speciesList[n][0] != '{' &&
+      speciesList[n][speciesList[n].size() - 1] != '}') {
+      auto it = std::find(names.begin(), names.end(), speciesList[n]);
+      if (it != names.end()) {
+        size_t index = std::distance(names.begin(), it);
+        tmp.push_back(index);
       }
+
+      speciesinGroup.push_back(tmp);
+      groupNames.push_back(speciesList[n]);
+    }
+
+    if (
+      speciesList[n][0] == '{' and speciesList[n][speciesList[n].size() - 1] ==
+                                     '}') // Found a group definition
+    {
+      size_t start = speciesList[n].find('{'); // opening brace
+      size_t colon = speciesList[n].find(':'); // first colon
+      size_t end = speciesList[n].find('}');   // ending brace
+
+      if (
+        start != std::string::npos && colon != std::string::npos &&
+        colon > start) {
+        groupNames.push_back(
+          speciesList[n].substr(start + 1, colon - start - 1));
+      }
+
+      amrex::Vector<std::string> tokens;
+      if (
+        colon != std::string::npos && end != std::string::npos && end > colon) {
+        // Extract substring between ':' and '}'
+        std::string rest = speciesList[n].substr(colon + 1, end - colon - 1);
+
+        // Split by comma
+        std::stringstream ss(rest);
+        std::string item;
+        while (std::getline(ss, item, ',')) {
+          auto it = std::find(names.begin(), names.end(), item);
+          size_t index = std::distance(names.begin(), it);
+          tmp.push_back(index);
+        }
+      }
+      speciesinGroup.push_back(tmp);
+    }
+  }
+
+  // If species are not found by now, they could be defined in groups. Check for
+  // species group definitions
+
+  m_bpdata_h.num_groups = groupNames.size();
+
+  for (int n = 0; n < groupNames.size(); n++) {
+    amrex::Print() << "\n Group names = " << groupNames[n];
+    for (int m = 0; m < speciesinGroup[n].size(); m++) {
+      amrex::Print() << "\n\t Species index: " << speciesinGroup[n][m];
     }
   }
 
   for (int n = 0; n < m_bpdata_h.num_species; ++n) {
     if (m_bpdata_h.speciesIndex[n] == -1) {
-      std::string msg =
-        "\nError! Unable to find species index " + std::to_string(n);
+      std::string msg = "\nError! Unable to find species index " +
+                        std::to_string(n) + " with name " + speciesList[n];
       amrex::Abort(msg);
     }
   }

--- a/Source/PeleLMeX_BPatch.cpp
+++ b/Source/PeleLMeX_BPatch.cpp
@@ -171,7 +171,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
 
   for (const auto& s : speciesList) {
 	  std::string s_trimmed;
-    if (s.front() != '{' && s.back() != '}') {
+    if (!(s.front() == '{' && s.back() == '}')) {
     	s_trimmed = Trim_First_Last_Whitespace(s);
       tmp_species_only.push_back(s_trimmed);
     }
@@ -197,6 +197,15 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
         colon != std::string::npos && end != std::string::npos && end > colon) {
         // Extract substring between ':' and '}'
         std::string rest = s.substr(colon + 1, end - colon - 1);
+
+        if(rest.empty())
+        {
+        	std::string msg =
+        	    		            "\nError! Empty species list in the group definition " +
+        	    		            groupname_tmp+"  in the patch "+patch_name;
+        	    		          amrex::Abort(msg);
+
+        }
 
         // Split by comma
         std::stringstream ss(rest);
@@ -227,7 +236,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
     		  hasDuplicateSpecies = true;
     		  std::string msg =
     		            "\nError! Duplicate species "+s+" in group definition " +
-    		            groupname_tmp;
+    		            groupname_tmp+"  in the patch "+patch_name;
     		          amrex::Abort(msg);
 
     	  }
@@ -237,7 +246,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
       if (tokens.size() <= 0) {
         std::string msg =
           "\nError! Unable to find species in the group definition " +
-          groupname_tmp;
+          groupname_tmp+"  in the patch "+patch_name;
         amrex::Abort(msg);
       }
     }
@@ -250,7 +259,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
     if (it == names.end()) {
       std::string msg =
         "\nError! Unable to find species " + s +
-        " in the mechanism. Please correct the bpatch species list";
+        " in the mechanism. Please correct the bpatch species list in the patch "+patch_name;
       amrex::Abort(msg);
     }
   }

--- a/Source/PeleLMeX_Temporals.cpp
+++ b/Source/PeleLMeX_Temporals.cpp
@@ -63,8 +63,9 @@ PeleLM::speciesBalancePatch()
     for (int i = 0; i < bphost->num_groups; ++i) {
       tmppatchmfrFile << ",";
       amrex::Real tmp = 0.0;
-      for (const auto& s : m_bPatche->speciesinGroup[i]) {
-        tmp += bphost->speciesFlux[s];
+      for(int j=0;j<m_bPatche->speciesinGroup[i].size();j++){
+      //for (const auto& s : m_bPatche->speciesinGroup[i]) {
+        tmp += bphost->speciesFlux[j];
       }
       tmppatchmfrFile << tmp;
     }

--- a/Source/PeleLMeX_Temporals.cpp
+++ b/Source/PeleLMeX_Temporals.cpp
@@ -64,7 +64,6 @@ PeleLM::speciesBalancePatch()
       tmppatchmfrFile << ",";
       amrex::Real tmp = 0.0;
       for (int j = 0; j < m_bPatche->speciesinGroup[i].size(); j++) {
-        // for (const auto& s : m_bPatche->speciesinGroup[i]) {
         tmp += bphost->speciesFlux[j];
       }
       tmppatchmfrFile << tmp;

--- a/Source/PeleLMeX_Temporals.cpp
+++ b/Source/PeleLMeX_Temporals.cpp
@@ -63,8 +63,8 @@ PeleLM::speciesBalancePatch()
     for (int i = 0; i < bphost->num_groups; ++i) {
       tmppatchmfrFile << ",";
       amrex::Real tmp = 0.0;
-      for(int j=0;j<m_bPatche->speciesinGroup[i].size();j++){
-      //for (const auto& s : m_bPatche->speciesinGroup[i]) {
+      for (int j = 0; j < m_bPatche->speciesinGroup[i].size(); j++) {
+        // for (const auto& s : m_bPatche->speciesinGroup[i]) {
         tmp += bphost->speciesFlux[j];
       }
       tmppatchmfrFile << tmp;

--- a/Source/PeleLMeX_Temporals.cpp
+++ b/Source/PeleLMeX_Temporals.cpp
@@ -63,8 +63,8 @@ PeleLM::speciesBalancePatch()
     for (int i = 0; i < bphost->num_groups; ++i) {
       tmppatchmfrFile << ",";
       amrex::Real tmp = 0.0;
-      for (int j = 0; j < m_bPatche->speciesinGroup[i].size(); j++) {
-        tmp += bphost->speciesFlux[m_bPatche->speciesinGroup[i][j]];
+      for (const auto& s : m_bPatche->speciesinGroup[i]) {
+        tmp += bphost->speciesFlux[s];
       }
       tmppatchmfrFile << tmp;
     }

--- a/Source/PeleLMeX_Temporals.cpp
+++ b/Source/PeleLMeX_Temporals.cpp
@@ -60,8 +60,13 @@ PeleLM::speciesBalancePatch()
   tmppatchmfrFile << m_nstep << "," << m_cur_time; // Time info
   for (const auto& m_bPatche : m_bPatches) {
     BPatch::BpatchDataContainer* bphost = m_bPatche->getHostDataPtr();
-    for (int i = 0; i < bphost->num_species; ++i) {
-      tmppatchmfrFile << "," << bphost->speciesFlux[i];
+    for (int i = 0; i < bphost->num_groups; ++i) {
+      tmppatchmfrFile << ",";
+      amrex::Real tmp = 0.0;
+      for (int j = 0; j < m_bPatche->speciesinGroup[i].size(); j++) {
+        tmp += bphost->speciesFlux[m_bPatche->speciesinGroup[i][j]];
+      }
+      tmppatchmfrFile << tmp;
     }
   }
   tmppatchmfrFile << "\n";
@@ -785,9 +790,9 @@ PeleLM::openTempFile()
       for (const auto& m_bPatche : m_bPatches) {
         BPatch* patch = m_bPatche.get();
         BPatch::BpatchDataContainer bphost = patch->getHostData();
-        for (int i = 0; i < bphost.num_species; ++i) {
+        for (int i = 0; i < bphost.num_groups; ++i) {
           tmppatchmfrFile << ","
-                          << patch->m_patchname + "_" + patch->speciesList[i];
+                          << patch->m_patchname + "_" + patch->groupNames[i];
         }
       }
       tmppatchmfrFile << "\n";


### PR DESCRIPTION
At times, we may need to monitor the combined mass flow rates of a set of species through temporals. For example, we might be interested to monitor the mass flow rate of air through a boundary patch 'inlet'. Currently, the code outputs the MFRs of O2 and N2 separately when the user specifies O2 and N2 in the species list of the bpatch functionality as,

 bpatch.inlet.species= O2 N2
 
 This PR lets the user specify a mixture and group species in it in the following way:
 
bpatch.inlet.species= {Air:O2,N2}

The temporal then outputs the total air MFR under the column 'inlet_Air'.
 
 
 