### PR TITLE
Make sure viscturb is always initialized when plotting

### DIFF
--- a/Source/PeleLMeX_Init.cpp
+++ b/Source/PeleLMeX_Init.cpp
@@ -226,9 +226,18 @@ PeleLM::initData()
       fillPatchAux(AmrNewTime);
     }
 
+    //----------------------------------------------------------------
+    // Initialize turbulent viscosity for LES
+    if (m_do_les) {
+      calcTurbViscosity(AmrNewTime);
+    }
+
+    //----------------------------------------------------------------
+    // Plot state before initial iterations
     if (m_plot_init_state) {
       WritePlotFile();
     }
+
     //----------------------------------------------------------------
     // If performing UnitTest, let's stop here
     if (runMode() != "normal") {

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -449,11 +449,11 @@ PeleLM::WritePlotFile()
       auto const& plot_arr = mf_plt[lev].arrays();
       AMREX_D_TERM(
         auto const& mut_arr_x =
-          m_leveldata_old[lev]->visc_turb_fc[0].const_arrays();
+          m_leveldata_new[lev]->visc_turb_fc[0].const_arrays();
         , auto const& mut_arr_y =
-            m_leveldata_old[lev]->visc_turb_fc[1].const_arrays();
+            m_leveldata_new[lev]->visc_turb_fc[1].const_arrays();
         , auto const& mut_arr_z =
-            m_leveldata_old[lev]->visc_turb_fc[2].const_arrays();)
+            m_leveldata_new[lev]->visc_turb_fc[2].const_arrays();)
       // interpolate turbulent viscosity from faces to centers
       amrex::ParallelFor(
         mf_plt[lev], [plot_arr, cnt, mut_arr_x, mut_arr_y


### PR DESCRIPTION
The turbulent viscosity is not currently computed on initialization in the "old" state, only the "new" state. So if we don't have any init iters, the state plotted for `plt00000` is uninitialized.  Also, the "-1" state that gets plotted with the `plot_init_state` option is never properly initialized.

Two fixes:
- Plot turbulent viscosity from the "new" state rather than the old "state" (although after initialization, turbulent_viscosity is always computed at the old state, it gets copied to the new state so this should be fine)
- Compute turbulent viscosity on initialization prior to dumping the "-1" plt file