### PR TITLE
correct fake_state in initActiveControl()

### DIFF
--- a/Source/PeleLMeX_FlowController.cpp
+++ b/Source/PeleLMeX_FlowController.cpp
@@ -77,7 +77,9 @@ PeleLM::initActiveControl()
     const int ctrl_flameDir_l = m_ctrl_flameDir;
     const amrex::Real time_l = -1.0;
     const auto geomdata = Geom(0).data();
-    auto fake_state = amrex::Array4<amrex::Real>{};
+    amrex::Dim3 begin{AMREX_D_DECL(0, 0, 0)};
+    amrex::Dim3 end{AMREX_D_DECL(1, 1, 1)};
+    auto fake_state = amrex::Array4<amrex::Real>(nullptr, begin, end, NVAR);
 
     amrex::Box dumbx({AMREX_D_DECL(0, 0, 0)}, {AMREX_D_DECL(0, 0, 0)});
     amrex::ParallelFor(

--- a/Source/PeleLMeX_FlowController.cpp
+++ b/Source/PeleLMeX_FlowController.cpp
@@ -77,8 +77,8 @@ PeleLM::initActiveControl()
     const int ctrl_flameDir_l = m_ctrl_flameDir;
     const amrex::Real time_l = -1.0;
     const auto geomdata = Geom(0).data();
-    amrex::Dim3 begin{AMREX_D_DECL(0, 0, 0)};
-    amrex::Dim3 end{AMREX_D_DECL(1, 1, 1)};
+    amrex::Dim3 begin{0, 0, 0};
+    amrex::Dim3 end{1, 1, 1};
     auto fake_state = amrex::Array4<amrex::Real>(nullptr, begin, end, NVAR);
 
     amrex::Box dumbx({AMREX_D_DECL(0, 0, 0)}, {AMREX_D_DECL(0, 0, 0)});


### PR DESCRIPTION
impossible to run in debug mode due to the incomplete declaration of fake_state in initActiveControl(), propose a solution to be able to run in debug mode with a proper declaration of fake_state variable