### PR TITLE
Fix how the species fluxes are summed

### DIFF
--- a/Source/PeleLMeX_Temporals.cpp
+++ b/Source/PeleLMeX_Temporals.cpp
@@ -63,10 +63,7 @@ PeleLM::speciesBalancePatch()
     for (int i = 0; i < bphost->num_groups; ++i) {
       tmppatchmfrFile << ",";
       amrex::Real tmp = 0.0;
-      for (int j = 0; j < m_bPatche->speciesinGroup[i].size(); j++) {
-        // speciesinGroup[i][j] contains the mechanism species index
-        // Find the corresponding index in the speciesIndex array
-        int mechSpeciesIdx = m_bPatche->speciesinGroup[i][j];
+      for (const auto& mechSpeciesIdx : m_bPatche->speciesinGroup[i]) {
         for (int k = 0; k < bphost->num_species; k++) {
           if (bphost->speciesIndex[k] == mechSpeciesIdx) {
             tmp += bphost->speciesFlux[k];

--- a/Source/PeleLMeX_Temporals.cpp
+++ b/Source/PeleLMeX_Temporals.cpp
@@ -64,7 +64,15 @@ PeleLM::speciesBalancePatch()
       tmppatchmfrFile << ",";
       amrex::Real tmp = 0.0;
       for (int j = 0; j < m_bPatche->speciesinGroup[i].size(); j++) {
-        tmp += bphost->speciesFlux[j];
+        // speciesinGroup[i][j] contains the mechanism species index
+        // Find the corresponding index in the speciesIndex array
+        int mechSpeciesIdx = m_bPatche->speciesinGroup[i][j];
+        for (int k = 0; k < bphost->num_species; k++) {
+          if (bphost->speciesIndex[k] == mechSpeciesIdx) {
+            tmp += bphost->speciesFlux[k];
+            break;
+          }
+        }
       }
       tmppatchmfrFile << tmp;
     }


### PR DESCRIPTION
This PR fixes how the species fluxes are summed for each group in speciesBalancePatch(). 

The old code was using `j = 0, 1, 2...` directly to index speciesFlux, but it needed to:
1. Get the mechanism species index from `speciesinGroup[i]`
2. Find which local index `k`
3. Use that `k` to get the correct flux from `speciesFlux[k]`

This fix ensures that fluxes are correctly summed for all group definitions, including multiple groups like {Air:O2,N2} {Fuel:POSF10264} 