### PR TITLE
fix species flux summing so final Dnp1 isnt double counted

### DIFF
--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -609,7 +609,8 @@ public:
   void computeDifferentialDiffusionTerms(
     const PeleLM::TimeStamp a_time,
     const std::unique_ptr<AdvanceDiffData>& diffData,
-    const int is_init = 0);
+    const int is_init = 0,
+    const amrex::Real flux_tracking_factor = 0.0);
 
   /**
    * \brief Add the Wbar contribution to the face-centered species diffusion

--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -129,7 +129,8 @@ PeleLM::Advance(const int is_initIter)
     BL_PROFILE_VAR_STOP(PLM_MAC);
     //----------------------------------------------------------------
     BL_PROFILE_VAR("PeleLMeX::advance::diffusion", PLM_DIFF);
-    computeDifferentialDiffusionTerms(AmrOldTime, diffData);
+    const amrex::Real fluxfact = (m_nSDCmax > 1) ? 0.5 : 0.0;
+    computeDifferentialDiffusionTerms(AmrOldTime, diffData, 0, fluxfact);
     BL_PROFILE_VAR_STOP(PLM_DIFF);
     //----------------------------------------------------------------
   }
@@ -297,7 +298,8 @@ PeleLM::oneSDC(
     }
 
     calcDiffusivity(AmrNewTime);
-    computeDifferentialDiffusionTerms(AmrNewTime, diffData);
+    const amrex::Real fluxfact = (sdcIter == m_nSDCmax) ? -0.5 : 0.0;
+    computeDifferentialDiffusionTerms(AmrNewTime, diffData, 0, fluxfact);
     if (m_has_divu != 0) {
       constexpr int is_initialization = 0;    // Not here
       constexpr int computeDiffusionTerm = 0; // Nope, we just did that

--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -181,8 +181,8 @@ PeleLM::Advance(const int is_initIter)
   } else {
 
     // SDC iterations
-    for (int sdc_iter = 1; sdc_iter <= m_nSDCmax; ++sdc_iter) {
-      oneSDC(sdc_iter, advData, diffData);
+    for (m_sdcIter = 1; m_sdcIter <= m_nSDCmax; ++m_sdcIter) {
+      oneSDC(m_sdcIter, advData, diffData);
     }
 
     // Post SDC
@@ -272,7 +272,6 @@ PeleLM::oneSDC(
   const std::unique_ptr<AdvanceDiffData>& diffData)
 {
   BL_PROFILE("PeleLMeX::oneSDC()");
-  m_sdcIter = sdcIter;
 
   if (m_verbose > 0) {
     amrex::Print() << "   SDC iter [" << sdcIter << "] \n";

--- a/Source/PeleLMeX_Diffusion.cpp
+++ b/Source/PeleLMeX_Diffusion.cpp
@@ -41,7 +41,8 @@ void
 PeleLM::computeDifferentialDiffusionTerms(
   const TimeStamp a_time,
   const std::unique_ptr<AdvanceDiffData>& diffData,
-  const int is_init)
+  const int is_init,
+  const amrex::Real flux_tracking_factor)
 {
   BL_PROFILE("PeleLMeX::computeDifferentialDiffusionTerms()");
 
@@ -129,10 +130,9 @@ PeleLM::computeDifferentialDiffusionTerms(
   // If doing species balances, compute face domain integrals
   // using level 0 since we've averaged down the fluxes already
   // Factor for SDC is 0.5 is for Dn and -0.5 for Dnp1
-  if (
-    (m_sdcIter == 0 || m_sdcIter == m_nSDCmax) && (m_do_speciesBalance != 0)) {
-    const amrex::Real sdc_weight = (a_time == AmrOldTime) ? 0.5 : -0.5;
-    addRhoYFluxes(GetArrOfConstPtrs(fluxes[0]), geom[0], sdc_weight);
+  amrex::Print() << "Computed Diffuion Terms" << std::endl;
+  if ((flux_tracking_factor != 0.0) && (m_do_speciesBalance != 0)) {
+    addRhoYFluxes(GetArrOfConstPtrs(fluxes[0]), geom[0], flux_tracking_factor);
   }
 
   //----------------------------------------------------------------


### PR DESCRIPTION
In `PeleLM::computeDifferentialDiffusionTerms` we [do a check](https://github.com/AMReX-Combustion/PeleLMeX/blob/019098b933d1ae5ba7c99c75e9ff3ed29a67582a/Source/PeleLMeX_Diffusion.cpp#L132) on whether we are at the 0th or final SDC iteration to determine whether the species fluxes computed should be added for flux tracking purposes ($D^n$ and $D^{n+1,k}$) in the species diffusion update below).

<img width="699" height="77" alt="Screenshot 2025-12-30 at 4 59 57 PM" src="https://github.com/user-attachments/assets/cbb2110d-c80c-454c-b787-0d95343e1497" />

However, `PeleLM::computeDifferentialDiffusionTerms` also gets called after the SDC iteration loop while computing the final divu for the velocity update. Currently, this trips the check on being at the final SDC iteration, and the flux is spuriously added into the flux trackers for a second time. This PR fixes the issue by changing the SDC iteration loop to directly update `m_sdcIter`, so once the SDC iteration loop completes this value exceeds m_nSDCmax and the check does not trip.

Hat tip to @wengzf20 for catching this in #608. @wengzf20 please confirm this change addresses the issue you are seeing.
