### PR TITLE
give option to specify custom chemistry_model paths

### DIFF
--- a/Docs/sphinx/manual/Tutorials_BFSFlame.rst
+++ b/Docs/sphinx/manual/Tutorials_BFSFlame.rst
@@ -226,7 +226,9 @@ the relevant files, for example: ::
 
    Chemistry_Model = drm19
 
-Here, the model ``drm19`` contains 21 species and describe the chemical decomposition of methane.
+Here, the model ``drm19`` contains 21 species and describe the chemical decomposition of methane. Advanced users may also specify
+``USE_CUSTOM_CHEMISTRY = TRUE``, in which case ``Chemistry_Model`` is interpreted as a path and can point to models not included in
+PelePhysics by default, though the new model directory must contain valid chemistry model files.
 The user is referred to the `PelePhysics <https://pelephysics.readthedocs.io/en/latest/>`_ documentation for a
 list of available mechanisms and more information regarding the EOS, chemistry and transport models specified: ::
 

--- a/Docs/sphinx/manual/Tutorials_FlameSheet.rst
+++ b/Docs/sphinx/manual/Tutorials_FlameSheet.rst
@@ -244,7 +244,9 @@ In `PeleLMeX`, the chemistry model (set of species, their thermodynamic and tran
 
    Chemistry_Model = drm19
 
-Here, the model ``drm19``, contains 21 species and describe the chemical decomposition of methane.
+Here, the model ``drm19``, contains 21 species and describe the chemical decomposition of methane. Advanced users may also specify
+``USE_CUSTOM_CHEMISTRY = TRUE``, in which case ``Chemistry_Model`` is interpreted as a path and can point to models not included in
+PelePhysics by default, though the new model directory must contain valid chemistry model files.
 The user is referred to the `PelePhysics <https://pelephysics.readthedocs.io/en/latest/>`_ documentation for a
 list of available mechanisms and more information regarding the EOS, chemistry and transport models specified: ::
 

--- a/Docs/sphinx/manual/Tutorials_FlowPastCyl.rst
+++ b/Docs/sphinx/manual/Tutorials_FlowPastCyl.rst
@@ -171,7 +171,10 @@ In `PeleLMeX`, the chemistry model (set of species, their thermodynamic and tran
 
    Chemistry_Model = air
 
-Here, the model ``air``, only contains 2 species (O2 and N2). The user is referred to the `PelePhysics <https://pelephysics.readthedocs.io/en/latest/>`_ documentation for a list of available mechanisms and more information regarding the EOS, chemistry and transport models specified: ::
+Here, the model ``air``, only contains 2 species (O2 and N2). Advanced users may also specify
+``USE_CUSTOM_CHEMISTRY = TRUE``, in which case ``Chemistry_Model`` is interpreted as a path and can point to models not included in
+PelePhysics by default, though the new model directory must contain valid chemistry model files.
+The user is referred to the `PelePhysics <https://pelephysics.readthedocs.io/en/latest/>`_ documentation for a list of available mechanisms and more information regarding the EOS, chemistry and transport models specified: ::
 
     Eos_Model       := Fuego
     Transport_Model := Constant

--- a/Docs/sphinx/manual/Tutorials_HotBubble.rst
+++ b/Docs/sphinx/manual/Tutorials_HotBubble.rst
@@ -182,7 +182,9 @@ the relevant files, for example: ::
 
    Chemistry_Model = air
 
-Here, the model ``air`` contains only 2 species (O2 and N2) without any reactions. A constant transport model is used
+Here, the model ``air`` contains only 2 species (O2 and N2) without any reactions. Advanced users may also specify
+``USE_CUSTOM_CHEMISTRY = TRUE``, in which case ``Chemistry_Model`` is interpreted as a path and can point to models not included in
+PelePhysics by default, though the new model directory must contain valid chemistry model files. A constant transport model is used
 and transport properties are set to zero in the input files which is effectively equivalent to solving the variable-density
 Euler equations.
 The user is referred to the `PelePhysics <https://pelephysics.readthedocs.io/en/latest/>`_ documentation for a

--- a/Docs/sphinx/manual/Tutorials_TripleFlame.rst
+++ b/Docs/sphinx/manual/Tutorials_TripleFlame.rst
@@ -215,7 +215,9 @@ the relevant files, for example: ::
 
    Chemistry_Model = drm19
 
-Here, the methane kinetic model ``drm19``, containing 21 species is employed. The user is referred to
+Here, the methane kinetic model ``drm19``, containing 21 species is employed. Advanced users may also specify
+``USE_CUSTOM_CHEMISTRY = TRUE``, in which case ``Chemistry_Model`` is interpreted as a path and can point to models not included in
+PelePhysics by default, though the new model directory must contain valid chemistry model files. The user is referred to
 the `PelePhysics <https://pelephysics.readthedocs.io/en/latest/>`_ documentation for a list of available
 mechanisms and more information regarding the EOS, chemistry and transport models specified: ::
 

--- a/Exec/Make.PeleLMeX
+++ b/Exec/Make.PeleLMeX
@@ -140,15 +140,22 @@ ifeq ($(PELE_CVODE_FORCE_YCORDER), TRUE)
   DEFINES += -DPELE_CVODE_FORCE_YCORDER
 endif
 
-ChemDir  = Mechanisms/$(Chemistry_Model)
-
 PPdirs := Source/Utility/PMF Source/Utility/TurbInflow Source/Utility/PltFileManager
 PPdirs += Source/Utility/Diagnostics Source/Utility/BlackBoxFunction
 PPdirs += Source/Utility/TurbForcing
 PPdirs += Source/Utility/Utilities
-PPdirs += Source $(ChemDir) Source/Reactions Source/Eos Source/Transport
+PPdirs += Source Source/Reactions Source/Eos Source/Transport
+
+ifeq ($(USE_CUSTOM_CHEMISTRY), TRUE)
+  Bpack += $(Chemistry_Model)/Make.package
+  Blocs += $(Chemistry_Model)
+else
+  PPdirs += Mechanisms/$(Chemistry_Model)
+endif
+
 Bpack += $(foreach dir, $(PPdirs), $(PELE_PHYSICS_HOME)/$(dir)/Make.package)
 Blocs += $(foreach dir, $(PPdirs), $(PELE_PHYSICS_HOME)/$(dir))
+
 include $(PELE_PHYSICS_HOME)/ThirdParty/Make.ThirdParty
 
 # Spray


### PR DESCRIPTION
Currently, users specify a `Chemistry_Model` from those found in `PelePhysics/Mechanism`. This PR gives the user the option to activate `USE_CUSTOM_CHEMISTRY = TRUE`, in which case `Chemistry_Model` is interpreted as a path to an arbitrary location. The goal is to make it easier for users to use nonstandard chemistry models more easily without having to make modifications to the PelePhysics submodule.