### PR TITLE
add capability option for single output prefix across all output types

### DIFF
--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -112,6 +112,7 @@ IO parameters
 ::
 
     #--------------------------IO CONTROL--------------------------
+    peleLM.base_output_prefix = outdir/    # [OPT, DEF=""] Prefix applied across all output types (plt, chk, diagnostics, temporals)
     amr.plot_int         = 20              # [OPT, DEF=-1] Frequency (as step #) for writing plot file
     amr.plot_overwrite   = false           # [OPT, DEF=false] Overwrite plot files with same name if present
     amr.plot_init_state  = false           # [OPT, DEF=false] Create a plot file during initialization before the initial projections

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1953,7 +1953,7 @@ public:
   std::string pltfileSource{"LM"};
   std::string m_plot_file{"plt"};
   std::string m_check_file{"chk"};
-  std::string m_base_output_pref{""};
+  std::string m_base_output_pref;
   int m_derivePlotVarCount = 0;
   amrex::Vector<std::string> m_derivePlotVars;
   int m_plotChemDiag = 0;

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1953,6 +1953,7 @@ public:
   std::string pltfileSource{"LM"};
   std::string m_plot_file{"plt"};
   std::string m_check_file{"chk"};
+  std::string m_base_output_pref{""};
   int m_derivePlotVarCount = 0;
   amrex::Vector<std::string> m_derivePlotVars;
   int m_plotChemDiag = 0;

--- a/Source/PeleLMeX_Diagnostics.cpp
+++ b/Source/PeleLMeX_Diagnostics.cpp
@@ -19,7 +19,7 @@ PeleLM::createDiagnostics()
     std::string diag_type;
     ppd.get("type", diag_type);
     m_diagnostics[n] = DiagBase::create(diag_type);
-    m_diagnostics[n]->init(diag_prefix, diags[n]);
+    m_diagnostics[n]->init(diag_prefix, m_base_output_pref + diags[n]);
     m_diagnostics[n]->addVars(m_diagVars);
   }
 

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -694,6 +694,7 @@ PeleLM::readParameters()
   if (m_do_temporals != 0) {
     pp.query("temporal_int", m_temp_int);
     pp.query("temporal_dir", m_temporal_dir);
+    m_temporal_dir = m_base_output_pref + m_temporal_dir;
     pp.query("do_extremas", m_do_extremas);
     pp.query("do_mass_balance", m_do_massBalance);
     pp.query("do_species_balance", m_do_speciesBalance);
@@ -880,9 +881,15 @@ PeleLM::readIOParameters()
 {
   BL_PROFILE_VAR("PeleLMeX::readIOParameters()", readIOParameters);
 
+  {
+    amrex::ParmParse pp("peleLM");
+    pp.query("base_output_prefix", m_base_output_pref);
+  }
+
   amrex::ParmParse pp("amr");
 
   pp.query("check_file", m_check_file);
+  m_check_file = m_base_output_pref + m_check_file;
   pp.query("check_int", m_check_int);
   pp.query("check_overwrite", m_check_overwrite);
   pp.query("check_per", m_check_per);
@@ -890,6 +897,7 @@ PeleLM::readIOParameters()
   pp.query("initDataPlt", m_restart_pltfile);
   pp.query("initDataPltSource", pltfileSource);
   pp.query("plot_file", m_plot_file);
+  m_plot_file = m_base_output_pref + m_plot_file;
   pp.query("plot_int", m_plot_int);
   pp.query("plot_overwrite", m_plot_overwrite);
   pp.query("plot_init_state", m_plot_init_state);


### PR DESCRIPTION
New usability feature: enable a common prefix across all output types (checkpoints, plot files, diagnostics, and temporals) with the `peleLM.base_output_prefix` option. As with standard output specification, this prefix may be a path (end in/contain `/`) which will be created if needed. To avoid changes in PelePhysics, this prefix is not used for diagnostics where the `.file` input option is used to give the diagnostic a custom output location. 