### PR TITLE
git ignore .visit files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ chk*
 plt*
 grdlog
 temporals
+*.visit
 
 # OSX files
 .DS_Store
@@ -22,4 +23,3 @@ temporals
 .project
 Exec/**/*.cproject
 Exec/**/*.project
-


### PR DESCRIPTION
Not generated by solver, but often used when visualizing with visit.