### PR TITLE
Spray data issue on HIP

### DIFF
--- a/Source/PeleLMeX.cpp
+++ b/Source/PeleLMeX.cpp
@@ -32,8 +32,7 @@ PeleLM::~PeleLM()
   m_initial_ba.clear();
   m_regrid_ba.clear();
 #ifdef PELE_USE_SPRAY
-  // SprayParticleContainer::SprayCleanUp();
-  // SprayPC.reset();
+  SprayParticleContainer::SprayCleanUp();
   SprayPC.reset();
   GhostPC.reset();
   VirtPC.reset();

--- a/Source/PeleLMeX.cpp
+++ b/Source/PeleLMeX.cpp
@@ -32,8 +32,11 @@ PeleLM::~PeleLM()
   m_initial_ba.clear();
   m_regrid_ba.clear();
 #ifdef PELE_USE_SPRAY
-  SprayParticleContainer::SprayCleanUp();
-  SprayPC.reset();
+  //SprayParticleContainer::SprayCleanUp();
+  //SprayPC.reset();
+  SprayPC.reset(); 
+  GhostPC.reset();
+  VirtPC.reset();
 #endif
 #ifdef PELE_USE_SOOT
   cleanupSootModel();

--- a/Source/PeleLMeX.cpp
+++ b/Source/PeleLMeX.cpp
@@ -32,9 +32,9 @@ PeleLM::~PeleLM()
   m_initial_ba.clear();
   m_regrid_ba.clear();
 #ifdef PELE_USE_SPRAY
-  //SprayParticleContainer::SprayCleanUp();
-  //SprayPC.reset();
-  SprayPC.reset(); 
+  // SprayParticleContainer::SprayCleanUp();
+  // SprayPC.reset();
+  SprayPC.reset();
   GhostPC.reset();
   VirtPC.reset();
 #endif


### PR DESCRIPTION
Problem: I get the following warning after PeleLMeX run is complete (signalled by AMReX finalize call)
```pure virtual method called```
```terminate called without an active exception```
Dependency: Should be used with PelePhysics PR#650
Issue: For some reason, on HIP, the spray particle containers are called by process exit handlers after AMreX finalize call, which results in double freeing and hence the error message
Solution: Enforcing all spray particle containers are destroyed before the AMReX finalize call