### PR TITLE
Bpatch feature extension to include manifold variables

### DIFF
--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1039,7 +1039,9 @@ public:
   void massBalance();
   void speciesBalance();
   void speciesBalancePatch();
-  void initBPatches(const amrex::Geometry& a_geom);
+  void initBPatches(const amrex::Geometry& a_geom,pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type>* eosparms_h,
+		    const pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type>*
+		      eosparms_d);
 
   void rhoHBalance();
   void initTemporals(const PeleLM::TimeStamp a_time = AmrOldTime);

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1039,9 +1039,12 @@ public:
   void massBalance();
   void speciesBalance();
   void speciesBalancePatch();
-  void initBPatches(const amrex::Geometry& a_geom,pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type>* eosparms_h,
-		    const pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type>*
-		      eosparms_d);
+  void initBPatches(
+    const amrex::Geometry& a_geom,
+    pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type>*
+      eosparms_h,
+    const pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type>*
+      eosparms_d);
 
   void rhoHBalance();
   void initTemporals(const PeleLM::TimeStamp a_time = AmrOldTime);

--- a/Source/PeleLMeX_BPatch.H
+++ b/Source/PeleLMeX_BPatch.H
@@ -13,7 +13,13 @@ public:
   BPatch() = default;
   ~BPatch() = default;
 
-  BPatch(const std::string& patch_name, const amrex::Geometry& geom);
+  BPatch(
+    const std::string& patch_name,
+    const amrex::Geometry& geom,
+    pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type>*
+      eosparms_h,
+    const pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type>*
+      eosparms_d);
 
   struct BpatchDataContainer
   {

--- a/Source/PeleLMeX_BPatch.cpp
+++ b/Source/PeleLMeX_BPatch.cpp
@@ -263,6 +263,7 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
 
   // Now we collected all the species for which we need to find flux. Now let us
   // check if all the species in tmp_species_only exist in the mechanism
+
   for (const auto& s : tmp_species_only) {
     auto it = std::find(names.begin(), names.end(), s);
     if (it == names.end()) {

--- a/Source/PeleLMeX_BPatch.cpp
+++ b/Source/PeleLMeX_BPatch.cpp
@@ -13,7 +13,12 @@ Trim_First_Last_Whitespace(const std::string& species_name)
   return species_name.substr(start, end - start + 1);
 }
 
-BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
+BPatch::BPatch(
+  const std::string& patch_name,
+  const amrex::Geometry& geom,
+  pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type>* eosparms_h,
+  const pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type>* /*
+    eosparms_d*/)
   : m_patchname(std::move(patch_name))
 {
 
@@ -168,7 +173,8 @@ BPatch::BPatch(const std::string& patch_name, const amrex::Geometry& geom)
 
   amrex::Vector<std::string> tmp_species_only;
   amrex::Vector<std::string> names;
-  pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(names);
+  pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
+    names, eosparms_h);
 
   // Check if there are unpaired open or closing braces in group definitions.
   for (const auto& s : speciesList) {

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -182,7 +182,7 @@ PeleLM::Setup()
 
   // Boundary Patch Setup
   if (m_do_patch_mfr != 0) {
-    initBPatches(Geom(0));
+    initBPatches(Geom(0), &eos_parms.host_parm(), eos_parms.device_parm());
   }
 
   // Initialize Level Hierarchy data

--- a/Source/PeleLMeX_Temporals.cpp
+++ b/Source/PeleLMeX_Temporals.cpp
@@ -544,7 +544,11 @@ PeleLM::addRhoYFluxes(
 }
 
 void
-PeleLM::initBPatches(const amrex::Geometry& a_geom)
+PeleLM::initBPatches(
+  const amrex::Geometry& a_geom,
+  pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type>* eosparms_h,
+  const pele::physics::eos::EosParm<pele::physics::PhysicsType::eos_type>*
+    eosparms_d)
 {
   std::string pele_prefix = "peleLM.bpatch";
   amrex::ParmParse pp(pele_prefix);
@@ -559,7 +563,8 @@ PeleLM::initBPatches(const amrex::Geometry& a_geom)
   }
   for (int n = 0; n < num_bPatches; ++n) {
     pp.get("patchnames", bpatch_name[n], n);
-    m_bPatches[n] = std::make_unique<BPatch>(bpatch_name[n], a_geom);
+    m_bPatches[n] =
+      std::make_unique<BPatch>(bpatch_name[n], a_geom, eosparms_h, eosparms_d);
     if (m_verbose > 0) {
       amrex::Print() << " Initializing boundary patch: " << bpatch_name[n]
                      << "\n";


### PR DESCRIPTION
Problem: The current boundary patch feature does not work for manifold variables. 
Solution: Mostly involved extending speciesNames call to include manifold EoS. initBPatches function was also modified to pass eosparm variables.