### PR TITLE
Initialize dt when restarting from plt

### DIFF
--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -913,8 +913,8 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
       m_prev_dt = m_fixed_dt;
     } else {
       // Use large value so CFL calculation isn't artificially constrained
-      m_dt = AMREX_REAL_MAX;
-      m_prev_dt = AMREX_REAL_MAX;
+      m_dt = m_max_dt;
+      m_prev_dt = m_max_dt;
     }
   }
 

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -905,6 +905,17 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   if (m_do_reset_time == 0) {
     m_cur_time = pltData.getTime();
     m_nstep = pltData.getNsteps();
+
+    // Plotfiles don't contain dt/prev_dt values, but we need to initialize
+    // them to avoid negative dt calculation
+    if (m_fixed_dt > 0.0) {
+      m_dt = m_fixed_dt;
+      m_prev_dt = m_fixed_dt;
+    } else {
+      // Use large value so CFL calculation isn't artificially constrained
+      m_dt = 1.0e200;
+      m_prev_dt = 1.0e200;
+    }
   }
 
   // Find required data in pltfile

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -913,8 +913,8 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
       m_prev_dt = m_fixed_dt;
     } else {
       // Use large value so CFL calculation isn't artificially constrained
-      m_dt = 1.0e200;
-      m_prev_dt = 1.0e200;
+      m_dt = AMREX_REAL_MAX;
+      m_prev_dt = AMREX_REAL_MAX;
     }
   }
 


### PR DESCRIPTION
This fixes an error when restarting from plt files with `peleLM.initDataPlt_reset_time = 0`. `m_dt` and `m_prev_dt` were not being initialized causing the following error:
~~~
Estimated dt -1.1 is below allowed dt_min 1e-12: the simulation will stop !
~~~

This PR sets `m_dt` and `m_prev_dt` based on the fixed time step in the input file. If `amr.cfl` is specified by the user, `m_dt` and `m_prev_dt` are set to large values which are then updated during the CFL calculation.