### PR TITLE
decrease verbosity level needed to display regrid stats

### DIFF
--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -54,8 +54,12 @@ PeleLM::Advance(const int is_initIter)
   //----------------------------------------------------------------
 
   if (m_verbose != 0) {
+    int ncells = 0;
+    for (int lev = 0; lev <= finest_level; ++lev) {
+      ncells += m_extSource[lev]->boxArray().numPts();
+    }
     amrex::Print() << " STEP [" << m_nstep << "] - Time: " << m_cur_time
-                   << ", dt " << m_dt << "\n";
+                   << ", dt " << m_dt << ", Ncells " << ncells << "\n";
   }
 
   checkMemory("Adv. start");

--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -54,7 +54,7 @@ PeleLM::Advance(const int is_initIter)
   //----------------------------------------------------------------
 
   if (m_verbose != 0) {
-    int ncells = 0;
+    amrex::Long ncells = 0;
     for (int lev = 0; lev <= finest_level; ++lev) {
       ncells += m_extSource[lev]->boxArray().numPts();
     }

--- a/Source/PeleLMeX_Init.cpp
+++ b/Source/PeleLMeX_Init.cpp
@@ -31,7 +31,7 @@ PeleLM::MakeNewLevelFromScratch(
 
   if (m_verbose > 0) {
     amrex::Print() << " Making new level " << lev << " from scratch \n";
-    if (m_verbose > 2 && lev > 0) {
+    if (m_verbose > 1 && lev > 0) {
       auto const dx = geom[lev].CellSizeArray();
       const amrex::Real vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
       amrex::Print() << " with " << ba.numPts() << " cells," << ba.size()

--- a/Source/PeleLMeX_Regrid.cpp
+++ b/Source/PeleLMeX_Regrid.cpp
@@ -316,7 +316,7 @@ PeleLM::MakeNewLevelFromCoarse(
 
   if (m_verbose > 0) {
     amrex::Print() << " Making new level " << lev << " from coarse\n";
-    if (m_verbose > 2) {
+    if (m_verbose > 1) {
       auto const dx = geom[lev].CellSizeArray();
       amrex::Real vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
       amrex::Print() << " with " << ba.numPts() << " cells, " << ba.size()
@@ -432,7 +432,7 @@ PeleLM::RemakeLevel(
 
   if (m_verbose > 0) {
     amrex::Print() << " Remaking level " << lev << "\n";
-    if (m_verbose > 2) {
+    if (m_verbose > 1) {
       auto const dx = geom[lev].CellSizeArray();
       amrex::Real vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
       amrex::Print() << " with " << ba.numPts() << " cells," << ba.size()


### PR DESCRIPTION
Display grid sizes when regridding for verbosity 2 instead of verbosity 3.

Display total number of cells at each timestep.