### PR TITLE
deltaT iters: recompute RhoH before starting

### DIFF
--- a/Source/PeleLMeX_Diffusion.cpp
+++ b/Source/PeleLMeX_Diffusion.cpp
@@ -1,3 +1,4 @@
+
 #include <PeleLMeX.H>
 #include <PeleLMeX_Utils.H>
 #include <PeleLMeX_K.H>
@@ -1501,6 +1502,27 @@ PeleLM::differentialDiffusionUpdate(
         GetVecOfPtrs(diffData->Dhat), NUM_SPECIES, GetVecOfArrOfPtrs(fluxes),
         NUM_SPECIES, 2, 1, -1.0);
     }
+
+    //------------------------------------------------------------------------
+    // Recompute RhoH (before deltaT iters: we've updated species at the new
+    // state already, we should modify enthalpy to reflect this update before
+    // the iterative procedure to update enthalpy due to T diffusion)
+
+    auto const* leosparm = eos_parms.device_parm();
+    for (int lev = 0; lev <= finest_level; ++lev) {
+      auto* ldata_p = getLevelDataPtr(lev, AmrNewTime);
+      auto const& sma = ldata_p->state.arrays();
+      amrex::ParallelFor(
+        ldata_p->state, [sma, leosparm] AMREX_GPU_DEVICE(
+                          int box_no, int i, int j, int k) noexcept {
+          getRHmixGivenTY(
+            i, j, k, amrex::Array4<amrex::Real const>(sma[box_no], DENSITY),
+            amrex::Array4<amrex::Real const>(sma[box_no], FIRSTSPEC),
+            amrex::Array4<amrex::Real const>(sma[box_no], TEMP),
+            amrex::Array4<amrex::Real>(sma[box_no], RHOH), leosparm);
+        });
+    }
+    amrex::Gpu::streamSynchronize();
 
     //------------------------------------------------------------------------
     // delta(T) iterations


### PR DESCRIPTION
In the diffusion update, we first implicitly update species diffusion, then update temperature diffusion using a linearly implicit iterative approach where the update is done in terms of temperature rather than enthalpy, and iterated until the enthalpy of the updated system converges. In the past, we've observed that the residual in this iterative solve increases on the first step before decreasing and converging (usually).

The reason for this odd behavior is that the mixture enthalpy of the new state is not updated after species are diffused and updated to the new state. Because of the chemical enthalpy of species, this diffusion affects the mixture enthalpy. If we neglect it, we start out with an inconsistent enthalpy state for the deltaT iteration process, which gets corrected when enthalpy is recomputed after the first iteration (leading to the jump is residual on the second iteration). By updating the mixture enthalpy before the iteration process starts, we start out with a consistent value, and the iterations converge monotonically. Enthalpy is updated after each iteration anyway and this does not affect the value that the enthalpy converges to.

As a result of these modifications, deltaT iterations converge typically in one less iteration, avoiding one MLMG solve, which has a mild performance benefit.

It is not yet known whether this adjustment will solve the occasional issue where convergence stalls with the LiDryer mechanism, but I expect that is a separate issue and will not be affected.

Demonstration of improved convergence for the FlameSheet case with DRM19 run for 200 timesteps with 2 SDC iterations:
<img width="1280" height="960" alt="FlameSheet-DRM19-SDCiter 1" src="https://github.com/user-attachments/assets/02ada5bb-09ec-452f-ad3b-ae408aac5fa4" />
<img width="1280" height="960" alt="FlameSheet-DRM19-SDCiter 2" src="https://github.com/user-attachments/assets/38ce0a70-9029-4eeb-b349-14ea552b77e1" />

Demonstration for a jet in crossflow H2 flame with LiDryer run for 200 timesteps with 1 SDC iteration:
<img width="1280" height="960" alt="JICFflame-LiDryer-SDCiter 1" src="https://github.com/user-attachments/assets/a36ea4ad-532e-4131-916b-a38a50ca5068" />
