### PR TITLE
Add postAdvance ProblemSpecificFunction after PeleLMeX::Advance()

### DIFF
--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -54,8 +54,12 @@ PeleLM::Advance(const int is_initIter)
   //----------------------------------------------------------------
 
   if (m_verbose != 0) {
+    amrex::Long ncells = 0;
+    for (int lev = 0; lev <= finest_level; ++lev) {
+      ncells += m_extSource[lev]->boxArray().numPts();
+    }
     amrex::Print() << " STEP [" << m_nstep << "] - Time: " << m_cur_time
-                   << ", dt " << m_dt << "\n";
+                   << ", dt " << m_dt << ", Ncells " << ncells << "\n";
   }
 
   checkMemory("Adv. start");

--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -54,12 +54,8 @@ PeleLM::Advance(const int is_initIter)
   //----------------------------------------------------------------
 
   if (m_verbose != 0) {
-    amrex::Long ncells = 0;
-    for (int lev = 0; lev <= finest_level; ++lev) {
-      ncells += m_extSource[lev]->boxArray().numPts();
-    }
     amrex::Print() << " STEP [" << m_nstep << "] - Time: " << m_cur_time
-                   << ", dt " << m_dt << ", Ncells " << ncells << "\n";
+                   << ", dt " << m_dt << "\n";
   }
 
   checkMemory("Adv. start");
@@ -268,6 +264,23 @@ PeleLM::Advance(const int is_initIter)
       run_time, amrex::ParallelDescriptor::IOProcessorNumber());
     amrex::Print() << " >> PeleLMeX::Advance() --> Time: " << run_time << "\n";
   }
+
+  //----------------------------------------------------------------
+  // Post advance steps ProblemSpecificFunctions
+  BL_PROFILE_VAR("ProblemSpecificFunctions::postAdvance()", PLM_POSTADV);
+
+  // Collect state MultiFabs and geometries for all levels
+  amrex::Vector<amrex::MultiFab*> state_mf(finest_level + 1);
+  amrex::Vector<const amrex::Geometry*> geom_vec(finest_level + 1);
+  for (int lev = 0; lev <= finest_level; ++lev) {
+    auto* ldata_p = getLevelDataPtr(lev, AmrNewTime);
+    state_mf[lev] = &(ldata_p->state);
+    geom_vec[lev] = &(geom[lev]);
+  }
+  ProblemSpecificFunctions::postAdvance(
+    m_cur_time + m_dt, m_dt, finest_level, state_mf, geom_vec, prob_parm_d);
+    
+  BL_PROFILE_VAR_STOP(PLM_POSTADV);
 }
 
 void

--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -283,7 +283,7 @@ PeleLM::Advance(const int is_initIter)
   }
   ProblemSpecificFunctions::postAdvance(
     m_cur_time + m_dt, m_dt, finest_level, state_mf, geom_vec, prob_parm_d);
-    
+
   BL_PROFILE_VAR_STOP(PLM_POSTADV);
 }
 

--- a/Source/PeleLMeX_ProblemSpecificFunctions.H
+++ b/Source/PeleLMeX_ProblemSpecificFunctions.H
@@ -240,6 +240,33 @@ struct DefaultProblemSpecificFunctions
       "ProblemSpecificFunctions in pelelmex_prob.H");
   }
 
+  /**
+   * \brief Perform problem-specific operations after advance
+   *
+   * \param time              current time after advance.
+   * \param dt                time-step size used in advance.
+   * \param finest_level      finest AMR level.
+   * \param state             vector of state multifabs for all levels.
+   * \param geom              vector of geometry objects for all levels.
+   * \param prob_parm         problem specific parameters.
+   */
+  static void postAdvance(
+    amrex::Real /*time*/,
+    amrex::Real /*dt*/,
+    int /*finest_level*/,
+    const amrex::Vector<amrex::MultiFab*>& /*state*/,
+    const amrex::Vector<const amrex::Geometry*>& /*geom*/,
+    const ProbParmDefault* /*prob_parm_d*/)
+  {
+    /** Notes:
+     *   1. This function is called once after each time advance
+     *   2. Receives state data for all AMR levels
+     *   3. Any post-advance operations must be performend on each level
+     *   4. The default implementation does nothing
+     *   5. Specific problem implementations can override this function
+     */
+  }
+
 }; // namespace DefaultProblemSpecificFunctions
 
 #endif


### PR DESCRIPTION
This allows users to add ProblemSpecificFunctions, most likely diagnostics, after PeleLMeX::Advance().