### PR TITLE
Minor fix so the postAdvance function works on GPU

### DIFF
--- a/Docs/sphinx/manual/Troubleshooting.rst
+++ b/Docs/sphinx/manual/Troubleshooting.rst
@@ -208,7 +208,7 @@ initial solution is most likely erroneous.
 
 In the case of the second message, the system was integrated up to 2.459e-6 s, but CVODE was not able
 to proceed any further as its internal step size dropped to a small value. This could indicates that your
-CFL condition is too loose and the chemical stifness can't be properly handled by
+CFL condition is too loose and the chemical stiffness can't be properly handled by
 CVODE. You can consider reduce your CFL number:
 
 ::

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![AMReX Badge](https://img.shields.io/static/v1?label=%22powered%20by%22&message=%22AMReX%22&color=%22blue%22)](https://amrex-codes.github.io/amrex/)
 [![Exascale Computing Project](https://img.shields.io/badge/supported%20by-ECP-blue)](https://www.exascaleproject.org/research-project/combustion-pele/)
-[![Language: C++17](https://img.shields.io/badge/language-C%2B%2B17-blue)](https://isocpp.org/)
+[![Language: C++20](https://img.shields.io/badge/language-C%2B%2B20-blue)](https://isocpp.org/)
 [![Citing](https://joss.theoj.org/papers/10.21105/joss.05450/status.svg)](https://joss.theoj.org/papers/10.21105/joss.05450)
 [![Archive](https://zenodo.org/badge/DOI/10.5281/zenodo.10056232.svg)](https://doi.org/10.5281/zenodo.10056232)
 

--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -282,7 +282,7 @@ PeleLM::Advance(const int is_initIter)
     geom_vec[lev] = &(geom[lev]);
   }
   ProblemSpecificFunctions::postAdvance(
-    m_cur_time + m_dt, m_dt, finest_level, state_mf, geom_vec, *prob_parm_d);
+    m_cur_time + m_dt, m_dt, finest_level, state_mf, geom_vec, *prob_parm);
 
   BL_PROFILE_VAR_STOP(PLM_POSTADV);
 }

--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -282,7 +282,8 @@ PeleLM::Advance(const int is_initIter)
     geom_vec[lev] = &(geom[lev]);
   }
   ProblemSpecificFunctions::postAdvance(
-    m_cur_time + m_dt, m_dt, finest_level, state_mf, geom_vec, *prob_parm, prob_parm_d);
+    m_cur_time + m_dt, m_dt, finest_level, state_mf, geom_vec, *prob_parm,
+    prob_parm_d);
 
   BL_PROFILE_VAR_STOP(PLM_POSTADV);
 }

--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -282,7 +282,7 @@ PeleLM::Advance(const int is_initIter)
     geom_vec[lev] = &(geom[lev]);
   }
   ProblemSpecificFunctions::postAdvance(
-    m_cur_time + m_dt, m_dt, finest_level, state_mf, geom_vec, prob_parm_d);
+    m_cur_time + m_dt, m_dt, finest_level, state_mf, geom_vec, *prob_parm_d);
 
   BL_PROFILE_VAR_STOP(PLM_POSTADV);
 }

--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -282,7 +282,7 @@ PeleLM::Advance(const int is_initIter)
     geom_vec[lev] = &(geom[lev]);
   }
   ProblemSpecificFunctions::postAdvance(
-    m_cur_time + m_dt, m_dt, finest_level, state_mf, geom_vec, *prob_parm);
+    m_cur_time + m_dt, m_dt, finest_level, state_mf, geom_vec, *prob_parm, prob_parm_d);
 
   BL_PROFILE_VAR_STOP(PLM_POSTADV);
 }

--- a/Source/PeleLMeX_Forces.cpp
+++ b/Source/PeleLMeX_Forces.cpp
@@ -403,7 +403,7 @@ PeleLM::getExternalSources(
       auto& ext_src = m_extSource[lev];
       ProblemSpecificFunctions::modify_ext_sources(
         getTime(lev, a_timestamp_old), m_dt, ldata_p_old->state,
-        ldata_p_new->state, ext_src, geom[lev].data(), prob_parm_d);
+        ldata_p_new->state, ext_src, geom[lev].data(), *prob_parm_d);
     }
   }
 }

--- a/Source/PeleLMeX_Forces.cpp
+++ b/Source/PeleLMeX_Forces.cpp
@@ -403,7 +403,7 @@ PeleLM::getExternalSources(
       auto& ext_src = m_extSource[lev];
       ProblemSpecificFunctions::modify_ext_sources(
         getTime(lev, a_timestamp_old), m_dt, ldata_p_old->state,
-        ldata_p_new->state, ext_src, geom[lev].data(), *prob_parm_d);
+        ldata_p_new->state, ext_src, geom[lev].data(), prob_parm_d);
     }
   }
 }

--- a/Source/PeleLMeX_ProblemSpecificFunctions.H
+++ b/Source/PeleLMeX_ProblemSpecificFunctions.H
@@ -207,7 +207,7 @@ struct DefaultProblemSpecificFunctions
     const amrex::MultiFab& /*state_new*/,
     std::unique_ptr<amrex::MultiFab>& /*ext_src*/,
     const amrex::GeometryData& /*geomdata*/,
-    const ProbParmDefault& /*prob_parm_d*/)
+    const ProbParmDefault* /*prob_parm_d*/)
   {
     /** Notes:
      *   1. ext_src contains sources from velocity forcing coming in.
@@ -256,7 +256,7 @@ struct DefaultProblemSpecificFunctions
     int /*finest_level*/,
     const amrex::Vector<amrex::MultiFab*>& /*state*/,
     const amrex::Vector<const amrex::Geometry*>& /*geom*/,
-    const ProbParmDefault& /*prob_parm_d*/)
+    const ProbParmDefault& /*prob_parm*/)
   {
     /** Notes:
      *   1. This function is called once after each time advance

--- a/Source/PeleLMeX_ProblemSpecificFunctions.H
+++ b/Source/PeleLMeX_ProblemSpecificFunctions.H
@@ -207,7 +207,7 @@ struct DefaultProblemSpecificFunctions
     const amrex::MultiFab& /*state_new*/,
     std::unique_ptr<amrex::MultiFab>& /*ext_src*/,
     const amrex::GeometryData& /*geomdata*/,
-    const ProbParmDefault* /*prob_parm_d*/)
+    const ProbParmDefault& /*prob_parm_d*/)
   {
     /** Notes:
      *   1. ext_src contains sources from velocity forcing coming in.
@@ -256,7 +256,7 @@ struct DefaultProblemSpecificFunctions
     int /*finest_level*/,
     const amrex::Vector<amrex::MultiFab*>& /*state*/,
     const amrex::Vector<const amrex::Geometry*>& /*geom*/,
-    const ProbParmDefault* /*prob_parm_d*/)
+    const ProbParmDefault& /*prob_parm_d*/)
   {
     /** Notes:
      *   1. This function is called once after each time advance

--- a/Source/PeleLMeX_ProblemSpecificFunctions.H
+++ b/Source/PeleLMeX_ProblemSpecificFunctions.H
@@ -248,7 +248,8 @@ struct DefaultProblemSpecificFunctions
    * \param finest_level      finest AMR level.
    * \param state             vector of state multifabs for all levels.
    * \param geom              vector of geometry objects for all levels.
-   * \param prob_parm         problem specific parameters.
+   * \param prob_parm         host copy of problem specific parameters.
+   * \param prob_parm_d       device copy of problem specific parameters.
    */
   static void postAdvance(
     amrex::Real /*time*/,
@@ -256,14 +257,17 @@ struct DefaultProblemSpecificFunctions
     int /*finest_level*/,
     const amrex::Vector<amrex::MultiFab*>& /*state*/,
     const amrex::Vector<const amrex::Geometry*>& /*geom*/,
-    const ProbParmDefault& /*prob_parm*/)
+    const ProbParmDefault& /*prob_parm*/,
+    const ProbParmDefault* /*prob_parm_d*/)
   {
     /** Notes:
      *   1. This function is called once after each time advance
      *   2. Receives state data for all AMR levels
-     *   3. Any post-advance operations must be performend on each level
-     *   4. The default implementation does nothing
-     *   5. Specific problem implementations can override this function
+     *   3. prob_parm is the host copy, useful for CPU-side logic and checks
+     *   4. prob_parm_d is the device copy, useful for GPU kernel launches
+     *   5. Any post-advance operations must be performend on each level
+     *   6. The default implementation does nothing
+     *   7. Specific problem implementations can override this function
      */
   }
 


### PR DESCRIPTION
This updates how prob_parm is passed to the `postAdvance` function in the ProblemSpecificFunctions for compatibility with CPU and  GPU. 