### PR TITLE
fix variable swap in divu dt estimate

### DIFF
--- a/Exec/RegTests/FlameSheet/flamesheet-drm19-3d.inp
+++ b/Exec/RegTests/FlameSheet/flamesheet-drm19-3d.inp
@@ -35,6 +35,7 @@ peleLM.incompressible = 0
 peleLM.use_wbar = 1
 peleLM.sdc_iterMax = 2
 peleLM.floor_species = 0
+peleLM.divu_dt_method = 2
 
 peleLM.do_temporals = 1
 peleLM.do_mass_balance = 1

--- a/Source/PeleLMeX_Timestep.cpp
+++ b/Source/PeleLMeX_Timestep.cpp
@@ -198,7 +198,7 @@ PeleLM::estDivUDt(const TimeStamp a_time)
       std::unique_ptr<amrex::MultiFab> velo = std::make_unique<amrex::MultiFab>(
         ldata_p->state, amrex::make_alias, VELX, AMREX_SPACEDIM);
       amrex::Real divu_dt = amrex::ReduceMin(
-        *density, ldata_p->divu, *velo, 0,
+        *density, *velo, ldata_p->divu, 0,
         [dtfac, rhoMin, dxinv] AMREX_GPU_HOST_DEVICE(
           amrex::Box const& bx, amrex::Array4<amrex::Real const> const& rho,
           amrex::Array4<amrex::Real const> const& vel,


### PR DESCRIPTION
Closes #642

We don't have any tests that use the divu_dt method in question, but if used in debug mode it currently results in an OOB error. 

This PR fixes the variable swap and sets a test to use the method.