### PR TITLE
Updates for both CMake and GNUMake to report git hashes for all repos

### DIFF
--- a/CMake/BuildPelePhysicsLib.cmake
+++ b/CMake/BuildPelePhysicsLib.cmake
@@ -2,6 +2,8 @@ function(build_pele_physics_lib pele_physics_lib_name)
   if (NOT (TARGET ${pele_physics_lib_name}))
     add_library(${pele_physics_lib_name} OBJECT)
 
+    target_compile_definitions(${pele_physics_lib_name} PUBLIC PELE_USE_CMAKE)
+
     set(PELE_PHYSICS_SRC_DIR "${CMAKE_SOURCE_DIR}/Submodules/PelePhysics")
     set(PELE_PHYSICS_TRANSPORT_DIR "${PELE_PHYSICS_SRC_DIR}/Source/Transport")
     set(PELE_PHYSICS_EOS_DIR "${PELE_PHYSICS_SRC_DIR}/Source/Eos")

--- a/CMake/PeleGitHashes.H.in
+++ b/CMake/PeleGitHashes.H.in
@@ -1,0 +1,13 @@
+#ifndef PELE_GIT_HASHES_H
+#define PELE_GIT_HASHES_H
+
+#include <string>
+
+namespace PeleBuildInfo {
+  inline const std::string PeleLMeX_git_hash   = "@PELELMEX_GIT_HASH@";
+  inline const std::string AMReX_git_hash       = "@AMREX_GIT_HASH@";
+  inline const std::string PelePhysics_git_hash = "@PELEPHYSICS_GIT_HASH@";
+  inline const std::string AMReXHydro_git_hash  = "@AMREX_HYDRO_GIT_HASH@";
+}
+
+#endif

--- a/CMake/PeleGitHashes.H.in
+++ b/CMake/PeleGitHashes.H.in
@@ -4,10 +4,11 @@
 #include <string>
 
 namespace PeleBuildInfo {
-  inline const std::string PeleLMeX_git_hash   = "@PELELMEX_GIT_HASH@";
+  inline const std::string PeleLMeX_git_hash    = "@PELELMEX_GIT_HASH@";
   inline const std::string AMReX_git_hash       = "@AMREX_GIT_HASH@";
   inline const std::string PelePhysics_git_hash = "@PELEPHYSICS_GIT_HASH@";
   inline const std::string AMReXHydro_git_hash  = "@AMREX_HYDRO_GIT_HASH@";
+  inline const std::string SUNDIALS_git_hash    = "@SUNDIALS_GIT_HASH@";
 }
 
 #endif

--- a/CMake/SetGitHashInfo.cmake
+++ b/CMake/SetGitHashInfo.cmake
@@ -24,17 +24,20 @@ set(PELELMEX_DIR "${CMAKE_SOURCE_DIR}")
 set(AMREX_DIR "${CMAKE_SOURCE_DIR}/Submodules/PelePhysics/Submodules/amrex")
 set(PELEPHYSICS_DIR "${CMAKE_SOURCE_DIR}/Submodules/PelePhysics")
 set(AMREX_HYDRO_DIR "${CMAKE_SOURCE_DIR}/Submodules/AMReX-Hydro")
+set(SUNDIALS_DIR "${CMAKE_SOURCE_DIR}/Submodules/PelePhysics/Submodules/sundials")
 
 # --- Get hashes ---
 get_git_hash("${PELELMEX_DIR}" PELELMEX_GIT_HASH)
 get_git_hash("${AMREX_DIR}" AMREX_GIT_HASH)
 get_git_hash("${PELEPHYSICS_DIR}" PELEPHYSICS_GIT_HASH)
 get_git_hash("${AMREX_HYDRO_DIR}" AMREX_HYDRO_GIT_HASH)
+get_git_hash("${SUNDIALS_DIR}" SUNDIALS_GIT_HASH)
 
 message(STATUS "PeleLMeX    git hash: ${PELELMEX_GIT_HASH}")
 message(STATUS "AMReX       git hash: ${AMREX_GIT_HASH}")
 message(STATUS "PelePhysics git hash: ${PELEPHYSICS_GIT_HASH}")
 message(STATUS "AMReX-Hydro git hash: ${AMREX_HYDRO_GIT_HASH}")
+message(STATUS "SUNDIALS    git hash: ${SUNDIALS_GIT_HASH}")
 
 # --- Generate the header ---
 configure_file(

--- a/CMake/SetGitHashInfo.cmake
+++ b/CMake/SetGitHashInfo.cmake
@@ -1,0 +1,44 @@
+# Extract git hashes from each submodule at configure time
+# and generate a header that PeleLMeX C++ code can use directly.
+
+find_package(Git QUIET)
+
+function(get_git_hash _dir _output_var)
+  if(GIT_FOUND AND EXISTS "${_dir}")
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} describe --always --dirty --long
+      WORKING_DIRECTORY "${_dir}"
+      OUTPUT_VARIABLE _hash
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+    )
+  endif()
+  if(NOT _hash)
+    set(_hash "unknown")
+  endif()
+  set(${_output_var} "${_hash}" PARENT_SCOPE)
+endfunction()
+
+# --- Paths to each repository ---
+set(PELELMEX_DIR "${CMAKE_SOURCE_DIR}")
+set(AMREX_DIR "${CMAKE_SOURCE_DIR}/Submodules/PelePhysics/Submodules/amrex")
+set(PELEPHYSICS_DIR "${CMAKE_SOURCE_DIR}/Submodules/PelePhysics")
+set(AMREX_HYDRO_DIR "${CMAKE_SOURCE_DIR}/Submodules/AMReX-Hydro")
+
+# --- Get hashes ---
+get_git_hash("${PELELMEX_DIR}" PELELMEX_GIT_HASH)
+get_git_hash("${AMREX_DIR}" AMREX_GIT_HASH)
+get_git_hash("${PELEPHYSICS_DIR}" PELEPHYSICS_GIT_HASH)
+get_git_hash("${AMREX_HYDRO_DIR}" AMREX_HYDRO_GIT_HASH)
+
+message(STATUS "PeleLMeX    git hash: ${PELELMEX_GIT_HASH}")
+message(STATUS "AMReX       git hash: ${AMREX_GIT_HASH}")
+message(STATUS "PelePhysics git hash: ${PELEPHYSICS_GIT_HASH}")
+message(STATUS "AMReX-Hydro git hash: ${AMREX_HYDRO_GIT_HASH}")
+
+# --- Generate the header ---
+configure_file(
+  "${CMAKE_SOURCE_DIR}/CMake/PeleGitHashes.H.in"
+  "${CMAKE_BINARY_DIR}/PeleGitHashes.H"
+  @ONLY
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,9 @@ init_code_checks()
 
 include(SetRpath)
 
+########################### Git Hash Info ##################################
+include(SetGitHashInfo)
+
 add_subdirectory(Exec)
 add_subdirectory(Tests)
 add_subdirectory(${CMAKE_SOURCE_DIR}/Submodules/PelePhysics/Testing/Exec/Radiation)

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -1,9 +1,13 @@
-#include <PeleLMeX.H>
+#include <string>
 #include <AMReX_ParmParse.H>
+#include <AMReX_buildInfo.H>
+#include <PeleLMeX.H>
 #include <PeleLMeX_DeriveFunc.H>
 #include <PeleLMeX_BPatch.H>
-#include "PelePhysics.H"
-#include "PeleGitHashes.H"
+#include <PelePhysics.H>
+#ifdef PELE_USE_CMAKE
+#include <PeleGitHashes.H>
+#endif
 
 #ifdef PELE_USE_PLASMA
 #include "PeleLMeX_EOS_Extension.H"
@@ -50,11 +54,22 @@ PeleLM::Setup()
       &&amrex::almostEqual(dx[1], dx[2], 10)));
   }
   // Print build info to screen
-  amrex::Print() << "\n ================= Build infos =================\n";
-  amrex::Print() << " PeleLMeX    git hash: " << PeleBuildInfo::PeleLMeX_git_hash << "\n";
-  amrex::Print() << " AMReX       git hash: " << PeleBuildInfo::AMReX_git_hash << "\n";
-  amrex::Print() << " PelePhysics git hash: " << PeleBuildInfo::PelePhysics_git_hash << "\n";
-  amrex::Print() << " AMReX-Hydro git hash: " << PeleBuildInfo::AMReXHydro_git_hash << "\n";
+#ifdef PELE_USE_CMAKE
+  const std::string githash1 = PeleBuildInfo::PeleLMeX_git_hash;
+  const std::string githash2 = PeleBuildInfo::AMReX_git_hash;
+  const std::string githash3 = PeleBuildInfo::PelePhysics_git_hash;
+  const std::string githash4 = PeleBuildInfo::AMReXHydro_git_hash;
+#else
+  const std::string githash1 = amrex::buildInfoGetGitHash(1);
+  const std::string githash2 = amrex::buildInfoGetGitHash(2);
+  const std::string githash3 = amrex::buildInfoGetGitHash(3);
+  const std::string githash4 = amrex::buildInfoGetGitHash(4);
+#endif
+  amrex::Print() << "\n ================ Version Info =================\n";
+  amrex::Print() << " PeleLMeX    git hash: " << githash1 << "\n";
+  amrex::Print() << " AMReX       git hash: " << githash2 << "\n";
+  amrex::Print() << " PelePhysics git hash: " << githash3 << "\n";
+  amrex::Print() << " AMReX-Hydro git hash: " << githash4 << "\n";
   amrex::Print() << " ===============================================\n";
 
 #ifdef PELE_USE_SOOT

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -3,7 +3,7 @@
 #include <PeleLMeX_DeriveFunc.H>
 #include <PeleLMeX_BPatch.H>
 #include "PelePhysics.H"
-#include <AMReX_buildInfo.H>
+#include "PeleGitHashes.H"
 
 #ifdef PELE_USE_PLASMA
 #include "PeleLMeX_EOS_Extension.H"
@@ -50,15 +50,11 @@ PeleLM::Setup()
       &&amrex::almostEqual(dx[1], dx[2], 10)));
   }
   // Print build info to screen
-  const char* githash1 = amrex::buildInfoGetGitHash(1);
-  const char* githash2 = amrex::buildInfoGetGitHash(2);
-  const char* githash3 = amrex::buildInfoGetGitHash(3);
-  const char* githash4 = amrex::buildInfoGetGitHash(4);
   amrex::Print() << "\n ================= Build infos =================\n";
-  amrex::Print() << " PeleLMeX    git hash: " << githash1 << "\n";
-  amrex::Print() << " AMReX       git hash: " << githash2 << "\n";
-  amrex::Print() << " PelePhysics git hash: " << githash3 << "\n";
-  amrex::Print() << " AMReX-Hydro git hash: " << githash4 << "\n";
+  amrex::Print() << " PeleLMeX    git hash: " << PeleBuildInfo::PeleLMeX_git_hash << "\n";
+  amrex::Print() << " AMReX       git hash: " << PeleBuildInfo::AMReX_git_hash << "\n";
+  amrex::Print() << " PelePhysics git hash: " << PeleBuildInfo::PelePhysics_git_hash << "\n";
+  amrex::Print() << " AMReX-Hydro git hash: " << PeleBuildInfo::AMReXHydro_git_hash << "\n";
   amrex::Print() << " ===============================================\n";
 
 #ifdef PELE_USE_SOOT

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -55,21 +55,25 @@ PeleLM::Setup()
   }
   // Print build info to screen
 #ifdef PELE_USE_CMAKE
-  const std::string githash1 = PeleBuildInfo::PeleLMeX_git_hash;
-  const std::string githash2 = PeleBuildInfo::AMReX_git_hash;
-  const std::string githash3 = PeleBuildInfo::PelePhysics_git_hash;
-  const std::string githash4 = PeleBuildInfo::AMReXHydro_git_hash;
+  const std::string pele_hash = PeleBuildInfo::PeleLMeX_git_hash;
+  const std::string amrex_hash = PeleBuildInfo::AMReX_git_hash;
+  const std::string pelephysics_hash = PeleBuildInfo::PelePhysics_git_hash;
+  const std::string amrex_hydro_hash = PeleBuildInfo::AMReXHydro_git_hash;
+  const std::string sundials_hash = PeleBuildInfo::SUNDIALS_git_hash;
 #else
-  const std::string githash1 = amrex::buildInfoGetGitHash(1);
-  const std::string githash2 = amrex::buildInfoGetGitHash(2);
-  const std::string githash3 = amrex::buildInfoGetGitHash(3);
-  const std::string githash4 = amrex::buildInfoGetGitHash(4);
+  const std::string pele_hash = amrex::buildInfoGetGitHash(1);
+  const std::string amrex_hash = amrex::buildInfoGetGitHash(2);
+  const std::string pelephysics_hash = amrex::buildInfoGetGitHash(3);
+  const std::string amrex_hydro_hash = amrex::buildInfoGetGitHash(4);
+  const std::string sundials_hash = amrex::buildInfoGetGitHash(5);
 #endif
+
   amrex::Print() << "\n ================ Version Info =================\n";
-  amrex::Print() << " PeleLMeX    git hash: " << githash1 << "\n";
-  amrex::Print() << " AMReX       git hash: " << githash2 << "\n";
-  amrex::Print() << " PelePhysics git hash: " << githash3 << "\n";
-  amrex::Print() << " AMReX-Hydro git hash: " << githash4 << "\n";
+  amrex::Print() << " PeleLMeX    git hash: " << pele_hash << "\n";
+  amrex::Print() << " AMReX       git hash: " << amrex_hash << "\n";
+  amrex::Print() << " PelePhysics git hash: " << pelephysics_hash << "\n";
+  amrex::Print() << " AMReX-Hydro git hash: " << amrex_hydro_hash << "\n";
+  amrex::Print() << " SUNDIALS    git hash: " << sundials_hash << "\n";
   amrex::Print() << " ===============================================\n";
 
 #ifdef PELE_USE_SOOT

--- a/Source/PeleLMeX_Utils.cpp
+++ b/Source/PeleLMeX_Utils.cpp
@@ -48,28 +48,33 @@ writeBuildInfo()
   std::cout << "\n";
 
 #ifdef PELE_USE_CMAKE
-  const std::string githash1 = PeleBuildInfo::PeleLMeX_git_hash;
-  const std::string githash2 = PeleBuildInfo::AMReX_git_hash;
-  const std::string githash3 = PeleBuildInfo::PelePhysics_git_hash;
-  const std::string githash4 = PeleBuildInfo::AMReXHydro_git_hash;
+  const std::string pele_hash = PeleBuildInfo::PeleLMeX_git_hash;
+  const std::string amrex_hash = PeleBuildInfo::AMReX_git_hash;
+  const std::string pelephysics_hash = PeleBuildInfo::PelePhysics_git_hash;
+  const std::string amrex_hydro_hash = PeleBuildInfo::AMReXHydro_git_hash;
+  const std::string sundials_hash = PeleBuildInfo::SUNDIALS_git_hash;
 #else
-  const std::string githash1 = amrex::buildInfoGetGitHash(1);
-  const std::string githash2 = amrex::buildInfoGetGitHash(2);
-  const std::string githash3 = amrex::buildInfoGetGitHash(3);
-  const std::string githash4 = amrex::buildInfoGetGitHash(4);
+  const std::string pele_hash = amrex::buildInfoGetGitHash(1);
+  const std::string amrex_hash = amrex::buildInfoGetGitHash(2);
+  const std::string pelephysics_hash = amrex::buildInfoGetGitHash(3);
+  const std::string amrex_hydro_hash = amrex::buildInfoGetGitHash(4);
+  const std::string sundials_hash = amrex::buildInfoGetGitHash(5);
 #endif
 
-  if (!githash1.empty()) {
-    std::cout << "PeleLMeX     git hash: " << githash1 << "\n";
+  if (!pele_hash.empty()) {
+    std::cout << "PeleLMeX     git hash: " << pele_hash << "\n";
   }
-  if (!githash2.empty()) {
-    std::cout << "AMReX        git hash: " << githash2 << "\n";
+  if (!amrex_hash.empty()) {
+    std::cout << "AMReX        git hash: " << amrex_hash << "\n";
   }
-  if (!githash3.empty()) {
-    std::cout << "PelePhysics  git hash: " << githash3 << "\n";
+  if (!pelephysics_hash.empty()) {
+    std::cout << "PelePhysics  git hash: " << pelephysics_hash << "\n";
   }
-  if (!githash4.empty()) {
-    std::cout << "AMReX-Hydro  git hash: " << githash4 << "\n";
+  if (!amrex_hydro_hash.empty()) {
+    std::cout << "AMReX-Hydro  git hash: " << amrex_hydro_hash << "\n";
+  }
+  if (!sundials_hash.empty()) {
+    std::cout << "SUNDIALS     git hash: " << sundials_hash << "\n";
   }
 
   const std::string buildgithash = amrex::buildInfoGetBuildGitHash();

--- a/Source/PeleLMeX_Utils.cpp
+++ b/Source/PeleLMeX_Utils.cpp
@@ -1,11 +1,13 @@
 #include <AMReX_buildInfo.H>
-#include "PeleGitHashes.H"
 #include <PeleLMeX.H>
 #include <PeleLMeX_K.H>
 #include <hydro_utils.H>
 #include <memory>
 #ifdef PELE_USE_PLASMA
 #include <PeleLMeX_EF_Constants.H>
+#endif
+#ifdef PELE_USE_CMAKE
+#include "PeleGitHashes.H"
 #endif
 
 void
@@ -45,10 +47,36 @@ writeBuildInfo()
 
   std::cout << "\n";
 
-  std::cout << "PeleLMeX     git describe: " << PeleBuildInfo::PeleLMeX_git_hash << "\n";
-  std::cout << "AMReX        git describe: " << PeleBuildInfo::AMReX_git_hash << "\n";
-  std::cout << "PelePhysics  git describe: " << PeleBuildInfo::PelePhysics_git_hash << "\n";
-  std::cout << "AMReX-Hydro  git describe: " << PeleBuildInfo::AMReXHydro_git_hash << "\n";
+#ifdef PELE_USE_CMAKE
+  const std::string githash1 = PeleBuildInfo::PeleLMeX_git_hash;
+  const std::string githash2 = PeleBuildInfo::AMReX_git_hash;
+  const std::string githash3 = PeleBuildInfo::PelePhysics_git_hash;
+  const std::string githash4 = PeleBuildInfo::AMReXHydro_git_hash;
+#else
+  const std::string githash1 = amrex::buildInfoGetGitHash(1);
+  const std::string githash2 = amrex::buildInfoGetGitHash(2);
+  const std::string githash3 = amrex::buildInfoGetGitHash(3);
+  const std::string githash4 = amrex::buildInfoGetGitHash(4);
+#endif
+
+  if (!githash1.empty()) {
+    std::cout << "PeleLMeX     git hash: " << githash1 << "\n";
+  }
+  if (!githash2.empty()) {
+    std::cout << "AMReX        git hash: " << githash2 << "\n";
+  }
+  if (!githash3.empty()) {
+    std::cout << "PelePhysics  git hash: " << githash3 << "\n";
+  }
+  if (!githash4.empty()) {
+    std::cout << "AMReX-Hydro  git hash: " << githash4 << "\n";
+  }
+
+  const std::string buildgithash = amrex::buildInfoGetBuildGitHash();
+  const std::string buildgitname = amrex::buildInfoGetBuildGitName();
+  if (!buildgithash.empty()) {
+    std::cout << buildgitname << " git hash: " << buildgithash << "\n";
+  }
 
   std::cout << "\n\n";
 }

--- a/Source/PeleLMeX_Utils.cpp
+++ b/Source/PeleLMeX_Utils.cpp
@@ -1,4 +1,5 @@
 #include <AMReX_buildInfo.H>
+#include "PeleGitHashes.H"
 #include <PeleLMeX.H>
 #include <PeleLMeX_K.H>
 #include <hydro_utils.H>
@@ -44,25 +45,10 @@ writeBuildInfo()
 
   std::cout << "\n";
 
-  const char* githash1 = amrex::buildInfoGetGitHash(1);
-  const char* githash2 = amrex::buildInfoGetGitHash(2);
-  const char* githash3 = amrex::buildInfoGetGitHash(3);
-
-  if (strlen(githash1) > 0) {
-    std::cout << "PeleLMeX     git describe: " << githash1 << "\n";
-  }
-  if (strlen(githash2) > 0) {
-    std::cout << "AMReX        git describe: " << githash2 << "\n";
-  }
-  if (strlen(githash3) > 0) {
-    std::cout << "PelePhysics  git describe: " << githash3 << "\n";
-  }
-
-  const char* buildgithash = amrex::buildInfoGetBuildGitHash();
-  const char* buildgitname = amrex::buildInfoGetBuildGitName();
-  if (strlen(buildgithash) > 0) {
-    std::cout << buildgitname << " git describe: " << buildgithash << "\n";
-  }
+  std::cout << "PeleLMeX     git describe: " << PeleBuildInfo::PeleLMeX_git_hash << "\n";
+  std::cout << "AMReX        git describe: " << PeleBuildInfo::AMReX_git_hash << "\n";
+  std::cout << "PelePhysics  git describe: " << PeleBuildInfo::PelePhysics_git_hash << "\n";
+  std::cout << "AMReX-Hydro  git describe: " << PeleBuildInfo::AMReXHydro_git_hash << "\n";
 
   std::cout << "\n\n";
 }


### PR DESCRIPTION
I noticed when using CMake that PelePhysics and AMReX-Hydro git hashes are not reported due to limited capability in AMReX's CMake. This allows for both CMake and GNUMake to report the git hashes for all the repos.