### PR TITLE
Remove h > 0.0 constrain for flow controller

### DIFF
--- a/Source/PeleLMeX_FlowController.cpp
+++ b/Source/PeleLMeX_FlowController.cpp
@@ -20,7 +20,7 @@ PeleLM::initActiveControl()
   pp.query("temperature", m_ctrl_temperature);
   pp.query("tau", m_ctrl_tauControl);
   pp.query("v", m_ctrl_verbose);
-  pp.query("height", m_ctrl_h);
+  pp.get("height", m_ctrl_h);
   pp.query("changeMax", m_ctrl_changeMax);
   pp.query("velMax", m_ctrl_velMax);
   pp.query("pseudo_gravity", m_ctrl_pseudoGravity);
@@ -38,10 +38,6 @@ PeleLM::initActiveControl()
 
   if ((m_ctrl_active != 0) && (m_ctrl_tauControl <= 0.0)) {
     amrex::Error("active_control.tau MUST be set when using active_control");
-  }
-
-  if (m_ctrl_h <= 0.0) {
-    amrex::Error("active_control.height MUST be set when using active_control");
   }
 
   if (m_ctrl_flameDir > 2) {


### PR DESCRIPTION
## Problem

The current implementation of the flow controller uses  `m_ctrl_h <= 0.0` to check if the option `height`. This was probably done to provide a more descriptive error message to the user. However, this also blocks setting `m_ctrl_h` to a negative value, e.g., in a system where the lower boundary has a negative coordinate. 

## Fix

- Use `pp.get()` instead of `pp.query()` to ensure `height` is provided in the inputs
- Remove the check if-clause

## Test

Tested with the TripleFlame reg test:

1. TripleFlame case with active control runs normally
2. TripleFlame case with active control but no `active_control.height` fails with `ParmParse::getval ParmParse::getval(): active_control.height not found in database`
3. TripleFlame case runs normally with active control and 

```
geometry.prob_lo  = 0.0 -0.02 0.0
geometry.prob_hi  = 0.02 0.02 0.0
active_control.height = 0.0
```
