### PR TITLE
Fix turb conv distance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,9 @@ jobs:
             reference_comparison: ON
           - os: ubuntu-24.04
             #Note mpich on ubuntu-24.04 does not run mpiexec correctly so we are using openmpi
-            install_deps: sudo apt-get install -y libopenmpi-dev openmpi-bin
+            install_deps:
+              sudo apt-get update
+              sudo apt-get install -y libopenmpi-dev openmpi-bin
             comp: gnu
             procs: $(nproc)
             ccache_cache: ~/.cache/ccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,11 +140,18 @@ jobs:
           if [ "${RUNNER_OS}" != "macOS" ]; then
             ${{github.workspace}}/Submodules/PelePhysics/Submodules/amrex/.github/workflows/dependencies/ubuntu_free_disk_space.sh
           fi
-      - name: Dependencies
+      - name: Dependencies (Ubuntu)
+        if: runner.os == 'Linux'
         run: |
-          # Install MPI
-          ${{matrix.install_deps}}
-          # Install Python packages
+          sudo apt-get update
+          sudo apt-get install -y libopenmpi-dev openmpi-bin
+          python -m pip install --upgrade pip
+          pip install pynose numpy pandas
+
+      - name: Dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install open-mpi automake ccache
           python -m pip install --upgrade pip
           pip install pynose numpy pandas
       - name: Install Ccache

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1984,6 +1984,10 @@ public:
   amrex::Vector<amrex::Real> m_ctrl_time_pts;
   amrex::Vector<amrex::Real> m_ctrl_velo_pts;
   amrex::Vector<amrex::Real> m_ctrl_cntl_pts;
+  // Time-integrated controlled inlet velocity (physical convected distance).
+  // Used to march through the turbulent-inflow data consistently with the
+  // controller. Reconstructed from AC history on restart.
+  amrex::Real m_turb_conv_dist{0.0};
 
   // PMF parameters
   pele::physics::PeleParams<pele::physics::PMF::PmfData::DataContainer>

--- a/Source/PeleLMeX_BC.cpp
+++ b/Source/PeleLMeX_BC.cpp
@@ -1222,6 +1222,18 @@ PeleLM::fillTurbInflow(
     amrex::Gpu::copy(
       amrex::Gpu::deviceToHost, probparmDD, probparmDD + 1, probparmDH);
 
+    // When active control drives the inlet velocity, march through the turb
+    // data using the time-integrated controlled velocity (convected distance)
+    // instead of turb_conv_vel * time. This keeps the marcher consistent with
+    // the time-varying mean inflow and avoids the position jumps that would
+    // arise from rescaling turb_conv_vel against absolute time.
+    if (m_ctrl_active != 0) {
+      const amrex::Real dtl = a_time - m_ctrl_tBase;
+      const amrex::Real conv_dist =
+        m_turb_conv_dist + m_ctrl_V_in * dtl + 0.5 * m_ctrl_dV * dtl * dtl;
+      turb_inflow.set_convected_distance(conv_dist);
+    }
+
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif

--- a/Source/PeleLMeX_FlowController.cpp
+++ b/Source/PeleLMeX_FlowController.cpp
@@ -184,6 +184,12 @@ PeleLM::activeControl(const int is_restart)
   m_ctrl_V_in_old = m_ctrl_V_in;
   if (m_dt > 0.0) {
     m_ctrl_V_in += m_dt * m_ctrl_dV;
+    // Accumulate the convected distance (integral of V_in dt) for consistent
+    // turbulent-inflow marching. Only on forward steps; on restart the value
+    // is reconstructed from AC history in loadActiveControlHistory().
+    if (is_restart == 0) {
+      m_turb_conv_dist += 0.5 * (m_ctrl_V_in_old + m_ctrl_V_in) * m_dt;
+    }
   }
 
   amrex::Real slocal = 0.5 * (m_ctrl_V_in_old + m_ctrl_V_in) -
@@ -431,11 +437,29 @@ PeleLM::loadActiveControlHistory()
     }
     std::fstream ACfile(m_ctrl_AChistory.c_str(), std::fstream::in);
     if (ACfile.is_open()) {
+      // Reconstruct the convected distance (integral of V_in dt) up to the
+      // restart step by trapezoidal quadrature of the (time, V_in) columns, so
+      // turbulent-inflow marching resumes smoothly. Assumes the history is
+      // contiguous up to m_nstep; since the turbfile is periodic in the
+      // convection direction, a small offset would be harmless anyway.
+      m_turb_conv_dist = 0.0;
+      bool have_prev = false;
+      amrex::Real prev_time = 0.0;
+      amrex::Real prev_vel = 0.0;
       while (ACfile.good()) {
         int step_io;
         amrex::Real time_io, vel_io, slocal_io, dV_io, s_est_io, coft_old_io;
         ACfile >> step_io >> time_io >> vel_io >> slocal_io >> dV_io >>
           s_est_io >> coft_old_io;
+        if (step_io <= m_nstep) {
+          if (have_prev && (time_io >= prev_time)) {
+            m_turb_conv_dist +=
+              0.5 * (prev_vel + vel_io) * (time_io - prev_time);
+          }
+          prev_time = time_io;
+          prev_vel = vel_io;
+          have_prev = true;
+        }
         if (
           ((m_nstep - step_io) >= 0) &&
           ((m_nstep - step_io) <=


### PR DESCRIPTION
March through the turbulent-inflow data at the *time-integrated* controlled inlet velocity (∫ V_in dt) instead of `turb_conv_vel * time`, so the turbulence marcher stays consistent with the controller-driven mean inflow and introduces no position jumps when `ctrl_V_in` is adjusted.