### PR TITLE
Updated temporals to include integrated heatrelease in manifold based combustion simulations

### DIFF
--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -703,9 +703,12 @@ to activate `temporal` diagnostics performing these reductions at given interval
 
 The `do_temporal` flag will trigger the creation of a `temporals` folder in your run directory and the following entries
 will be appended to an ASCII `temporals/tempState` file: step, time, dt, kin. energy integral, enstrophy integral, mean pressure
-, fuel consumption rate integral, heat release rate integral. Additionally, if the `do_temporal` flag is activated, one can
-turn on state extremas (stored in `temporals/tempExtremas` as min/max for each state entry), mass balance (stored in
-`temporals/tempMass`) computing the total mass, dMdt and advective mass fluxes across the domain boundaries as well as the error in
+, fuel consumption rate integral, heat release rate integral. Please note that for simulations using finite-rate chemistry, the 
+heat-release rate integral is computed from the species reaction rates and enthalpies (:math:`-\sum_n h_n \dot\omega_n`). For the 
+manifold EOS, it is instead obtained by integrating the tabulated `HRR` variable looked up from the manifold table, which therefore 
+requires the table to include an `HRR` column (volumetric heat release rate, in the table's units). If the table has no `HRR` column 
+the reported integral is zero. Additionally, if the `do_temporal` flag is activated, one can turn on state extremas 
+(stored in `temporals/tempExtremas` as min/max for each state entry), mass balance (stored in `temporals/tempMass`) computing the total mass, dMdt and advective mass fluxes across the domain boundaries as well as the error in
 the balance (dMdt - sum of fluxes), and species balance (stored in `temporals/tempSpec`) computing each species total mass, dM_Ydt,
 advective \& diffusive fluxes across the domain boundaries, consumption rate integral and the error (dMdt - sum of fluxes - reaction).
 Users can also monitor species advective fluxes through specific regions of the domain boundaries (called as boundary patches).

--- a/Source/PeleLMeX_Reactions.cpp
+++ b/Source/PeleLMeX_Reactions.cpp
@@ -482,12 +482,36 @@ void
 PeleLM::getHeatRelease(const int a_lev, amrex::MultiFab* a_HR)
 {
   auto* ldataNew_p = getLevelDataPtr(a_lev, AmrNewTime);
-  auto* ldataR_p = getLevelDataReactPtr(a_lev);
 
   auto const* leosparm = eos_parms.device_parm();
-  auto const& react_ma = ldataR_p->I_R.const_arrays();
   auto const& state_n_ma = ldataNew_p->state.const_arrays();
+
+#ifdef USE_MANIFOLD_EOS
+
+  auto const& HRR_ma = a_HR->arrays();
+  auto table_idx = get_var_index(
+    "HRR", &eos_parms.host_only_parm().manfunc_par->host_parm(), false);
+  const int hrr_idx = table_idx;
+
+  amrex::ParallelFor(
+    *a_HR, [state_n_ma, leosparm, HRR_ma, hrr_idx] AMREX_GPU_DEVICE(
+             int box_no, int i, int j, int k) noexcept {
+      auto eos = pele::physics::PhysicsType::eos(leosparm);
+      amrex::Real rho, rhoinv,
+        mani_vars_prim[NUM_SPECIES]; // not the conserved (\rho.Y) but just Y
+      amrex::Array4<amrex::Real const> mani_var_cons(
+        state_n_ma[box_no], FIRSTSPEC);
+      eos.RY2RRinvY(
+        mani_var_cons.cellData(i, j, k), rho, rhoinv, mani_vars_prim);
+      amrex::Real mani_hrr = 0.0; // Get the manifold hrr
+      if (hrr_idx >= 0)
+        eos.Y2GenericManifoldData(mani_vars_prim, &hrr_idx, &mani_hrr, 1);
+      HRR_ma[box_no](i, j, k) = mani_hrr;
+    });
+#else
   amrex::MultiFab Enth(grids[a_lev], dmap[a_lev], NUM_SPECIES, 0);
+  auto* ldataR_p = getLevelDataReactPtr(a_lev);
+  auto const& react_ma = ldataR_p->I_R.const_arrays();
   auto const& enth_ma = Enth.arrays();
   auto const& HRR_ma = a_HR->arrays();
   amrex::ParallelFor(
@@ -501,5 +525,7 @@ PeleLM::getHeatRelease(const int a_lev, amrex::MultiFab* a_HR)
           enth_ma[box_no](i, j, k, n) * react_ma[box_no](i, j, k, n);
       }
     });
+#endif
+
   amrex::Gpu::streamSynchronize();
 }

--- a/Source/PeleLMeX_Temporals.cpp
+++ b/Source/PeleLMeX_Temporals.cpp
@@ -725,6 +725,15 @@ PeleLM::writeTemporals()
   // Combustion
   amrex::Real fuelConsumptionInt = 0.0;
   amrex::Real heatReleaseRateInt = 0.0;
+
+#ifdef USE_MANIFOLD_EOS
+  if (!(m_chem_integrator == "ReactorNull")) {
+    for (int lev = 0; lev <= finest_level; ++lev) {
+      getHeatRelease(lev, kinEnergy[lev].get()); // Reuse kinEnergy container
+    }
+    heatReleaseRateInt = MFSum(GetVecOfConstPtrs(kinEnergy), 0);
+  }
+#else
   if (fuelID >= 0 && !(m_chem_integrator == "ReactorNull")) {
     fuelConsumptionInt = MFSum(GetVecOfConstPtrs(getIRVect()), fuelID);
     for (int lev = 0; lev <= finest_level; ++lev) {
@@ -732,6 +741,7 @@ PeleLM::writeTemporals()
     }
     heatReleaseRateInt = MFSum(GetVecOfConstPtrs(kinEnergy), 0);
   }
+#endif
 
   tmpStateFile << m_nstep << "," << m_cur_time << "," << m_dt // Time
                << "," << kinenergy_int                        // Kinetic energy


### PR DESCRIPTION
Issue: tempExtremas report integrated heat release in species transport models but not for manifold models
Feature added: 'getHeatRelease' function modified to read the heat release rate from the manifold table and integrate it throughout the whole domain. 
Dependency: The chem table needs the heat release as a manifold variable under the name: 'HRR'. If not found, heat release uses its default value 0